### PR TITLE
[WIP] Clean code and fix deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 bin/
 gen/
 obj/
+app/.cxx/*
 
 # Eclipse Generate files
 .classpath      
@@ -44,3 +45,6 @@ libs/*
 
 # Android Studio
 .idea/*
+
+# VS Code
+.vscode/*

--- a/app/src/main/java/com/osfans/trime/Candidate.java
+++ b/app/src/main/java/com/osfans/trime/Candidate.java
@@ -57,8 +57,8 @@ public class Candidate extends View {
 
   private Rect candidateRect[] = new Rect[MAX_CANDIDATE_COUNT + 2];
 
-  public void reset() {
-    Config config = Config.get();
+  public void reset(Context context) {
+    Config config = Config.get(context);
     candidateHighlight = new PaintDrawable(config.getColor("hilited_candidate_back_color"));
     ((PaintDrawable) candidateHighlight).setCornerRadius(config.getFloat("layout/round_corner"));
     candidateSeparator = new PaintDrawable(config.getColor("candidate_separator_color"));
@@ -109,7 +109,7 @@ public class Candidate extends View {
     paintComment.setAntiAlias(true);
     paintComment.setStrokeWidth(0);
 
-    reset();
+    reset(context);
 
     setWillNotDraw(false);
   }

--- a/app/src/main/java/com/osfans/trime/ColorDialog.java
+++ b/app/src/main/java/com/osfans/trime/ColorDialog.java
@@ -29,16 +29,16 @@ class ColorDialog {
   private int checkedColor;
   private AlertDialog dialog;
 
-  private void selectColor() {
+  private void selectColor(Context context) {
     if (checkedColor < 0 || checkedColor >= colorKeys.length) return;
     String color = colorKeys[checkedColor];
-    Config config = Config.get();
+    Config config = Config.get(context);
     config.setColor(color);
     Trime trime = Trime.getService();
     if (trime != null) trime.initKeyboard(); //實時生效
   }
 
-  public ColorDialog(Context context) {
+  public ColorDialog(final Context context) {
     Config config = Config.get(context);
     String colorScheme = config.getColorScheme();
     colorKeys = config.getColorKeys();
@@ -56,7 +56,7 @@ class ColorDialog {
                 new DialogInterface.OnClickListener() {
                   @Override
                   public void onClick(DialogInterface di, int id) {
-                    selectColor();
+                    selectColor(context);
                   }
                 })
             .setSingleChoiceItems(

--- a/app/src/main/java/com/osfans/trime/Composition.java
+++ b/app/src/main/java/com/osfans/trime/Composition.java
@@ -148,7 +148,7 @@ public class Composition extends TextView {
 
   public Composition(Context context, AttributeSet attrs) {
     super(context, attrs);
-    reset();
+    reset(context);
   }
 
   @Override
@@ -192,8 +192,8 @@ public class Composition extends TextView {
     show_comment = value;
   }
 
-  public void reset() {
-    Config config = Config.get();
+  public void reset(Context context) {
+    Config config = Config.get(context);
     components = (List<Map<String, Object>>) config.getValue("window");
     if (config.hasKey("layout/max_entries")) max_entries = config.getInt("layout/max_entries");
     candidate_use_cursor = config.getBoolean("candidate_use_cursor");

--- a/app/src/main/java/com/osfans/trime/Config.java
+++ b/app/src/main/java/com/osfans/trime/Config.java
@@ -139,7 +139,7 @@ public class Config {
   }
 
   public static boolean deployOpencc() {
-    String dataDir = get().getResDataDir("opencc");
+    String dataDir = self.getResDataDir("opencc");
     File d = new File(dataDir);
     if (d.exists()) {
       FilenameFilter txtFilter =
@@ -337,6 +337,10 @@ public class Config {
   }
 
   public static Config get() {
+    if (self == null) {
+      Trime trime = Trime.getService();
+      self = new Config(trime);
+    }
     return self;
   }
 

--- a/app/src/main/java/com/osfans/trime/Config.java
+++ b/app/src/main/java/com/osfans/trime/Config.java
@@ -101,12 +101,12 @@ public class Config {
     boolean isOverwrite = Function.isDiffVer(context);
     String defaultFile = "trime.yaml";
     if (isOverwrite) {
-      copyFileOrDir(context, "", true);
+      copyFileOrDir(context, RIME, true);
     } else if (isExist) {
-      String path = new File("", defaultFile).getPath();
+      String path = new File(RIME, defaultFile).getPath();
       copyFileOrDir(context, path, false);
     } else {
-      copyFileOrDir(context, "", false);
+      copyFileOrDir(context, RIME, false);
     }
     while (!new File(getSharedDataDir(), defaultFile).exists()) {
       SystemClock.sleep(3000);
@@ -175,8 +175,10 @@ public class Config {
     try {
       assets = assetManager.list(path);
       if (assets.length == 0) {
-        copyFile(context, path, overwrite);
+        // Files
+        copyFile(context, path, overwrite); 
       } else {
+        // Dirs
         File dir = new File(getSharedDataDir(), path);
         if (!dir.exists()) dir.mkdir();
         for (int i = 0; i < assets.length; ++i) {
@@ -261,7 +263,8 @@ public class Config {
 
   public void reset() {
     schema_id = Rime.getSchemaId();
-    mStyle = (Map<String, Object>) Rime.schema_get_value(schema_id, "style");
+    if (schema_id != null)
+      mStyle = (Map<String, Object>) Rime.schema_get_value(schema_id, "style");
   }
 
   private Object _getValue(String k1, String k2) {

--- a/app/src/main/java/com/osfans/trime/Function.java
+++ b/app/src/main/java/com/osfans/trime/Function.java
@@ -189,19 +189,19 @@ class Function {
     System.exit(0); //清理內存
   }
 
-  public static void deploy() {
+  public static void deploy(Context context) {
     Rime.destroy();
-    Rime.get(true);
+    Rime.get(context, true);
     //Trime trime = Trime.getService();
     //if (trime != null) trime.invalidate();
   }
 
-  public static void sync() {
-    Rime.syncUserData();
+  public static void sync(Context context) {
+    Rime.syncUserData(context);
   }
 
   public static void syncBackground(Context ctx){
-    boolean success = Rime.syncUserData();
+    boolean success = Rime.syncUserData(ctx);
     getPref(ctx).edit() //记录同步时间和状态
             .putLong("last_sync_time",new Date().getTime())
             .putBoolean("last_sync_status",success)

--- a/app/src/main/java/com/osfans/trime/IntentReceiver.java
+++ b/app/src/main/java/com/osfans/trime/IntentReceiver.java
@@ -42,11 +42,11 @@ public class IntentReceiver extends BroadcastReceiver {
 
     switch (command) {
       case COMMAND_DEPLOY:
-        Function.deploy();
+        Function.deploy(ctx);
         System.exit(0);
         break;
       case COMMAND_SYNC:
-        Function.sync();
+        Function.sync(ctx);
         break;
       case Intent.ACTION_SHUTDOWN:
         Rime.destroy();

--- a/app/src/main/java/com/osfans/trime/Key.java
+++ b/app/src/main/java/com/osfans/trime/Key.java
@@ -17,6 +17,7 @@
  */
 package com.osfans.trime;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
@@ -106,7 +107,7 @@ public class Key {
    * @param parent 按鍵所在的{@link Keyboard 鍵盤}
    * @param mk 從YAML中解析得到的Map
    */
-  public Key(Keyboard parent, Map<String, Object> mk) {
+  public Key(Context context, Keyboard parent, Map<String, Object> mk) {
     this(parent);
     String s;
     for (int i = 0; i < EVENT_NUM; i++) {
@@ -136,12 +137,12 @@ public class Key {
     if (isShift()) mKeyboard.setmShiftKey(this);
     key_text_size = Config.getPixel(mk, "key_text_size");
     symbol_text_size = Config.getPixel(mk, "symbol_text_size");
-    key_text_color = Config.getColor(mk, "key_text_color");
-    hilited_key_text_color = Config.getColor(mk, "hilited_key_text_color");
-    key_back_color = Config.getColorDrawable(mk, "key_back_color");
-    hilited_key_back_color = Config.getColorDrawable(mk, "hilited_key_back_color");
-    key_symbol_color = Config.getColor(mk, "key_symbol_color");
-    hilited_key_symbol_color = Config.getColor(mk, "hilited_key_symbol_color");
+    key_text_color = Config.getColor(context, mk, "key_text_color");
+    hilited_key_text_color = Config.getColor(context, mk, "hilited_key_text_color");
+    key_back_color = Config.getColorDrawable(context, mk, "key_back_color");
+    hilited_key_back_color = Config.getColorDrawable(context, mk, "hilited_key_back_color");
+    key_symbol_color = Config.getColor(context, mk, "key_symbol_color");
+    hilited_key_symbol_color = Config.getColor(context, mk, "hilited_key_symbol_color");
     round_corner = Config.getFloat(mk, "round_corner");
   }
 

--- a/app/src/main/java/com/osfans/trime/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/Keyboard.java
@@ -93,7 +93,7 @@ public class Keyboard {
     int mDisplayHeight = dm.heightPixels;
     //Log.v(TAG, "keyboard's display metrics:" + dm);
 
-    Config config = Config.get();
+    Config config = Config.get(context);
     mDefaultHorizontalGap = config.getPixel("horizontal_gap");
     mDefaultVerticalGap = config.getPixel("vertical_gap");
     mDefaultWidth = (int) (mDisplayWidth * config.getDouble("key_width") / 100);
@@ -157,7 +157,7 @@ public class Keyboard {
 
   public Keyboard(Context context, String name) {
     this(context);
-    Map<String, Object> m = Config.get().getKeyboard(name);
+    Map<String, Object> m = Config.get(context).getKeyboard(name);
     mLabelTransform = Config.getString(m, "label_transform", "none");
     mAsciiMode = Config.getInt(m, "ascii_mode", 1);
     if (mAsciiMode == 0) mAsciiKeyboard = Config.getString(m, "ascii_keyboard");
@@ -175,7 +175,7 @@ public class Keyboard {
     if (m.containsKey("vertical_gap")) mDefaultVerticalGap = Config.getPixel(m, "vertical_gap");
     if (m.containsKey("round_corner")) mRoundCorner = Config.getFloat(m, "round_corner");
     if (m.containsKey("keyboard_back_color")) {
-      Drawable background = Config.getColorDrawable(m, "keyboard_back_color");
+      Drawable background = Config.getColorDrawable(context, m, "keyboard_back_color");
       if (background != null) mBackground = background;
     }
     int x = mDefaultHorizontalGap / 2;
@@ -222,7 +222,7 @@ public class Keyboard {
         continue; //縮進
       }
 
-      final Key key = new Key(this, mk);
+      final Key key = new Key(context, this, mk);
       key.setKey_text_offset_x(Config.getPixel(mk, "key_text_offset_x", key_text_offset_x));
       key.setKey_text_offset_y(Config.getPixel(mk, "key_text_offset_y", key_text_offset_y));
       key.setKey_symbol_offset_x(Config.getPixel(mk, "key_symbol_offset_x", key_symbol_offset_x));

--- a/app/src/main/java/com/osfans/trime/KeyboardSwitch.java
+++ b/app/src/main/java/com/osfans/trime/KeyboardSwitch.java
@@ -36,11 +36,11 @@ class KeyboardSwitch {
     currentId = -1;
     lastId = 0;
     lastLockId = 0;
-    reset();
+    reset(context);
   }
 
-  public void reset() {
-    mKeyboardNames = Config.get().getKeyboardNames();
+  public void reset(Context context) {
+    mKeyboardNames = Config.get(context).getKeyboardNames();
     int n = mKeyboardNames.size();
     mKeyboards = new Keyboard[n];
     for (int i = 0; i < n; i++) {
@@ -92,7 +92,7 @@ class KeyboardSwitch {
     }
 
     currentDisplayWidth = displayWidth;
-    reset();
+    reset(context);
   }
 
   public Keyboard getCurrentKeyboard() {

--- a/app/src/main/java/com/osfans/trime/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/KeyboardView.java
@@ -270,8 +270,8 @@ public class KeyboardView extends View implements View.OnClickListener {
     mShowHint = value;
   }
 
-  public void reset() {
-    Config config = Config.get();
+  public void reset(Context context) {
+    Config config = Config.get(context);
     key_symbol_color = config.getColor("key_symbol_color");
     hilited_key_symbol_color = config.getColor("hilited_key_symbol_color");
     mShadowColor = config.getColor("shadow_color");
@@ -360,7 +360,7 @@ public class KeyboardView extends View implements View.OnClickListener {
     mPaintSymbol = new Paint();
     mPaintSymbol.setAntiAlias(true);
     mPaintSymbol.setTextAlign(Align.CENTER);
-    reset();
+    reset(context);
 
     mPreviewPopup = new PopupWindow(context);
     mPreviewPopup.setContentView(mPreviewText);

--- a/app/src/main/java/com/osfans/trime/Pref.java
+++ b/app/src/main/java/com/osfans/trime/Pref.java
@@ -278,14 +278,15 @@ public class Pref extends PreferenceActivity
     }
   }
 
-  private void deployOpencc() {
-    boolean b = Config.get().deployOpencc();
+  private void deployOpencc(Context context) {
+    boolean b = Config.get(context).deployOpencc(context);
   }
 
   @Override
   public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
     boolean b;
     String key = preference.getKey();
+    final Pref self = this;
     switch (key) {
       case "pref_enable": //啓用
         if (!isEnabled()) startActivity(new Intent(Settings.ACTION_INPUT_METHOD_SETTINGS));
@@ -294,19 +295,19 @@ public class Pref extends PreferenceActivity
         ((InputMethodManager) getSystemService(INPUT_METHOD_SERVICE)).showInputMethodPicker();
         return true;
       case "pref_themes": //主題
-        new ThemeDlg(this);
+        new ThemeDlg(self);
         return true;
       case "pref_colors": //配色
-        new ColorDialog(this).show();
+        new ColorDialog(self).show();
         return true;
       case "pref_schemas": //方案
-        new SchemaDialog(this);
+        new SchemaDialog(self);
         return true;
       case "pref_maintenance": //維護
         Function.check();
         return true;
       case "pref_deploy_opencc": //部署OpenCC
-        deployOpencc();
+        deployOpencc(self);
         return true;
       case "pref_deploy": //部署
         mProgressDialog.setMessage(getString(R.string.deploy_progress));
@@ -316,7 +317,7 @@ public class Pref extends PreferenceActivity
                   @Override
                   public void run() {
                     try {
-                      Function.deploy();
+                      Function.deploy(self);
                     } catch (Exception ex) {
                       Log.e(TAG, "Deploy Exception" + ex);
                     } finally {
@@ -335,7 +336,7 @@ public class Pref extends PreferenceActivity
                   @Override
                   public void run() {
                     try {
-                      Function.sync();
+                      Function.sync(self);
                     } catch (Exception ex) {
                       Log.e(TAG, "Sync Exception" + ex);
                     } finally {
@@ -348,17 +349,17 @@ public class Pref extends PreferenceActivity
         return true;
       case "pref_input":
       case "pref_sync_bg": //后台同步
-        setBackgroundSyncSummary(this);
+        setBackgroundSyncSummary(self);
         return true;
       case "pref_reset": //回廠
-        new ResetDialog(this).show();
+        new ResetDialog(self).show();
         return true;
       case "pref_licensing": //許可協議
         showLicenseDialog();
         return true;
       case "pref_ui": //色調
         finish();
-        Function.showPrefDialog(this);
+        Function.showPrefDialog(self);
         return true;
     }
     return false;

--- a/app/src/main/java/com/osfans/trime/ResetDialog.java
+++ b/app/src/main/java/com/osfans/trime/ResetDialog.java
@@ -41,7 +41,7 @@ class ResetDialog {
     int n = items.length;
     for (int i = 0; i < n; i++) {
       if (checked[i]) {
-        ret = Config.get(context).copyFileOrDir(context, items[i], true);
+        ret = Config.get(context).copyFileOrDir(context, "rime" + "/" + items[i], true);
       }
     }
     Toast.makeText(

--- a/app/src/main/java/com/osfans/trime/Rime.java
+++ b/app/src/main/java/com/osfans/trime/Rime.java
@@ -18,6 +18,7 @@
 
 package com.osfans.trime;
 
+import android.content.Context;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -266,8 +267,8 @@ public class Rime {
     return mContext.commit_text_preview;
   }
 
-  private Rime(boolean full_check) {
-    init(full_check);
+  public Rime(Context context, boolean full_check) {
+    init(context, full_check);
     self = this;
   }
 
@@ -283,10 +284,13 @@ public class Rime {
     return get_status(mStatus);
   }
 
-  private static void init(boolean full_check) {
+  private static void init(Context context, boolean full_check) {
     mOnMessage = false;
-    Trime trime = Trime.getService();
-    initialize(Config.get(trime).getSharedDataDir(), Config.get(trime).getUserDataDir());
+
+    // Initialize librime APIs
+    setup(Config.get(context).getSharedDataDir(), Config.get(context).getUserDataDir());
+    initialize(Config.get(context).getSharedDataDir(), Config.get(context).getUserDataDir());
+    
     check(full_check);
     set_notification_handler();
     if (!find_session()) {
@@ -471,16 +475,16 @@ public class Rime {
     return selectSchema(target);
   }
 
-  public static Rime get(boolean full_check) {
+  public static Rime get(Context context, boolean full_check) {
     if (self == null) {
-      if (full_check) Config.deployOpencc();
-      self = new Rime(full_check);
+      if (full_check) Config.deployOpencc(context);
+      self = new Rime(context, full_check);
     }
     return self;
   }
 
-  public static Rime get() {
-    return get(false);
+  public static Rime get(Context context) {
+    return get(context, false);
   }
 
   public static String RimeGetInput() {
@@ -533,13 +537,16 @@ public class Rime {
 
   public static void check(boolean full_check) {
     start_maintenance(full_check);
-    if (is_maintenance_mode()) join_maintenance_thread();
-  }
+    // if (start_maintenance(full_check) && is_maintenance_mode())
+    // {
+    //   join_maintenance_thread();
+    // }
+}
 
-  public static boolean syncUserData() {
+  public static boolean syncUserData(Context context) {
     boolean b = sync_user_data();
     destroy();
-    get(true);
+    get(context, true);
     return b;
   }
 

--- a/app/src/main/java/com/osfans/trime/Rime.java
+++ b/app/src/main/java/com/osfans/trime/Rime.java
@@ -524,7 +524,8 @@ public class Rime {
 
   public static String openccConvert(String line, String name) {
     if (name != null && name.length() > 0) {
-      File f = new File(Config.get().getResDataDir("opencc"), name);
+      Trime trime = Trime.getService();
+      File f = new File(Config.get(trime).getResDataDir("opencc"), name);
       if (f.exists()) return opencc_convert(line, f.getAbsolutePath());
     }
     return line;

--- a/app/src/main/java/com/osfans/trime/Rime.java
+++ b/app/src/main/java/com/osfans/trime/Rime.java
@@ -473,7 +473,7 @@ public class Rime {
 
   public static Rime get(boolean full_check) {
     if (self == null) {
-      if (full_check) Config.get().deployOpencc();
+      if (full_check) Config.deployOpencc();
       self = new Rime(full_check);
     }
     return self;
@@ -539,7 +539,7 @@ public class Rime {
   public static boolean syncUserData() {
     boolean b = sync_user_data();
     destroy();
-    get();
+    get(true);
     return b;
   }
 

--- a/app/src/main/java/com/osfans/trime/SchemaDialog.java
+++ b/app/src/main/java/com/osfans/trime/SchemaDialog.java
@@ -53,7 +53,7 @@ class SchemaDialog extends AsyncTask {
     }
   }
 
-  private void selectSchema() {
+  private void selectSchema(Context context) {
     List<String> checkedIds = new ArrayList<String>();
     int i = 0;
     for (boolean b : checkedSchemaItems) {
@@ -65,7 +65,7 @@ class SchemaDialog extends AsyncTask {
       String[] schema_id_list = new String[n];
       checkedIds.toArray(schema_id_list);
       Rime.select_schemas(schema_id_list);
-      Function.deploy();
+      Function.deploy(context);
     }
   }
 
@@ -156,7 +156,7 @@ class SchemaDialog extends AsyncTask {
                         @Override
                         public void run() {
                           try {
-                            selectSchema();
+                            selectSchema(mContext);
                           } catch (Exception ex) {
                             Log.e(TAG, "Select Schema" + ex);
                           } finally {

--- a/app/src/main/java/com/osfans/trime/ThemeDlg.java
+++ b/app/src/main/java/com/osfans/trime/ThemeDlg.java
@@ -41,7 +41,7 @@ class ThemeDlg extends AsyncTask {
 
   private void selectTheme() {
     String theme = keys[checked].replace(".yaml", "");
-    Config config = Config.get();
+    Config config = Config.get(mContext);
     config.setTheme(theme);
   }
 
@@ -68,7 +68,7 @@ class ThemeDlg extends AsyncTask {
     mToken = token;
     Config config = Config.get(context);
     String theme = config.getTheme() + ".yaml";
-    keys = Config.getThemeKeys(true);
+    keys = Config.getThemeKeys(context, true);
     if (keys == null) return;
     Arrays.sort(keys);
     checked = Arrays.binarySearch(keys, theme);

--- a/app/src/main/java/com/osfans/trime/Trime.java
+++ b/app/src/main/java/com/osfans/trime/Trime.java
@@ -333,7 +333,7 @@ public class Trime extends InputMethodService
   }
 
   public void invalidate() {
-    Rime.get();
+    Rime.get(this);
     if (mConfig != null) mConfig.destroy();
     mConfig = new Config(this);
     reset();
@@ -369,7 +369,7 @@ public class Trime extends InputMethodService
   public void resetKeyboard() {
     if (mKeyboardView != null) {
       mKeyboardView.setShowHint(!Rime.getOption("_hide_key_hint"));
-      mKeyboardView.reset(); //實體鍵盤無軟鍵盤
+      mKeyboardView.reset(this); //實體鍵盤無軟鍵盤
     }
   }
 
@@ -378,10 +378,10 @@ public class Trime extends InputMethodService
       loadBackground();
       setShowComment(!Rime.getOption("_hide_comment"));
       mCandidate.setVisibility(!Rime.getOption("_hide_candidate") ? View.VISIBLE : View.GONE);
-      mCandidate.reset();
+      mCandidate.reset(this);
       mShowWindow = mConfig.getShowWindow();
       mComposition.setVisibility(mShowWindow ? View.VISIBLE : View.GONE);
-      mComposition.reset();
+      mComposition.reset(this);
     }
   }
 
@@ -389,7 +389,7 @@ public class Trime extends InputMethodService
   private void reset() {
     mConfig.reset();
     loadConfig();
-    if (mKeyboardSwitch != null) mKeyboardSwitch.reset();
+    if (mKeyboardSwitch != null) mKeyboardSwitch.reset(this);
     resetCandidate();
     hideComposition();
     resetKeyboard();
@@ -562,7 +562,7 @@ public class Trime extends InputMethodService
         if (canCompose) break;
         return;
     }
-    Rime.get();
+    Rime.get(this);
     if (reset_ascii_mode) mAsciiMode = false;
     // Select a keyboard based on the input type of the editing field.
     mKeyboardSwitch.init(getMaxWidth()); //橫豎屏切換時重置鍵盤


### PR DESCRIPTION
- [x] Fix #334 
- [x] Try **not** to avoid `context` to maintain state. Fixes some complicated crashes and avoid undiscovered bugs.
- [x] `setup()` before calling APIs (AFAIK it should only take place in init phase, however the data model and JNI are harder to understand than I expected.
- [ ] Fix schema_get_value JNI.
````
3-23 22:30:00.257 20124 20285 F om.osfans.trim: runtime.cc:630]   native: #12 pc 00000000001a6d50  /data/app/com.osfans.trime-vhi_C3DjoS2fZ_APkPjKmQ==/lib/arm64/librime.so (rime::Deployer::Run()+172)
03-23 22:30:00.258 20124 20285 F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 20285 (Thread-3), pid 20124 (om.osfans.trime)
03-23 22:30:00.528 20288 20288 F DEBUG   : pid: 20124, tid: 20285, name: Thread-3  >>> com.osfans.trime <<<
03-23 22:30:00.536 20288 20288 F DEBUG   :       #06 pc 00000000000071bc  /data/app/com.osfans.trime-vhi_C3DjoS2fZ_APkPjKmQ==/lib/arm64/librime_jni.so (on_message(void*, unsigned long, char const*, char const*)+68) (BuildId: 4e5c5681def4d54a8d629b97ba254c9880a80344)
03-23 22:30:00.536 20288 20288 F DEBUG   :       #07 pc 0000000000255edc  /data/app/com.osfans.trime-vhi_C3DjoS2fZ_APkPjKmQ==/lib/arm64/librime.so (rime::Service::Notify(unsigned long, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+140) (BuildId: 29195cd89ea0d5f7154837740d587fc350bbe90b)
03-23 22:30:00.536 20288 20288 F DEBUG   :       #08 pc 00000000001aa43c  /data/app/com.osfans.trime-vhi_C3DjoS2fZ_APkPjKmQ==/lib/arm64/librime.so (_ZNK5boost8signals26detail20slot_call_iterator_tINS1_21variadic_slot_invokerINS1_9void_typeEJRKNSt6__ndk112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEESD_EEENS5_15__list_iteratorINS_10shared_ptrINS1_15connection_bodyINS5_4pairINS1_15slot_meta_groupENS_8optionalIiEEEENS0_4slotIFvSD_SD_ENS_8functionISO_EEEENS0_5mutexEEEEEPvEEST_E11dereferenceEv+88) (BuildId: 29195cd89ea0d5f7154837740d587fc350bbe90b)
03-23 22:30:00.536 20288 20288 F DEBUG   :       #09 pc 00000000001a99e4  /data/app/com.osfans.trime-vhi_C3DjoS2fZ_APkPjKmQ==/lib/arm64/librime.so (boost::signals2::detail::signal_impl<void (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&), boost::signals2::optional_last_value<void>, int, std::__ndk1::less<int>, boost::function<boost::signals2::optional_last_value>, boost::function<boost::signals2::optional_last_value><void (boost::signals2::connection const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)>, boost::signals2::mutex>::operator()(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+536) (BuildId: 29195cd89ea0d5f7154837740d587fc350bbe90b)
03-23 22:30:00.536 20288 20288 F DEBUG   :       #10 pc 00000000001a6d50  /data/app/com.osfans.trime-vhi_C3DjoS2fZ_APkPjKmQ==/lib/arm64/librime.so (rime::Deployer::Run()+172) (BuildId: 29195cd89ea0d5f7154837740d587fc350bbe90b)
03-23 22:30:00.536 20288 20288 F DEBUG   :       #11 pc 00000000001ab544  /data/app/com.osfans.trime-vhi_C3DjoS2fZ_APkPjKmQ==/lib/arm64/librime.so (BuildId: 29195cd89ea0d5f7154837740d587fc350bbe90b)
03-23 22:30:00.537 20288 20288 F DEBUG   :       #12 pc 00000000001ab5f8  /data/app/com.osfans.trime-vhi_C3DjoS2fZ_APkPjKmQ==/lib/arm64/librime.so (BuildId: 29195cd89ea0d5f7154837740d587fc350bbe90b)
03-23 22:30:00.967  1468 20291 W ActivityTaskManager:   Force finishing activity com.osfans.trime/.Pref
03-23 22:30:01.023  1468  1989 W InputDispatcher: channel '80c8137 com.osfans.trime/com.osfans.trime.Pref (server)' ~ Consumer closed input channel or an error occurred.  events=0x9
03-23 22:30:01.023  1468  1989 E InputDispatcher: channel '80c8137 com.osfans.trime/com.osfans.trime.Pref (server)' ~ Channel is unrecoverably broken and will be disposed!
03-23 22:30:01.030  1468  1989 W InputDispatcher: channel '213134e com.osfans.trime/com.osfans.trime.Pref (server)' ~ Consumer closed input channel or an error occurred.  events=0x9
03-23 22:30:01.030  1468  1989 E InputDispatcher: channel '213134e com.osfans.trime/com.osfans.trime.Pref (server)' ~ Channel is unrecoverably broken and will be disposed!
03-23 22:30:01.032  1468  4725 I ActivityManager: Process com.osfans.trime (pid 20124) has died: vis+99 TOP 
03-23 22:30:01.033  1468  2443 I WindowManager: WIN DEATH: Window{213134e u0 com.osfans.trime/com.osfans.trime.Pref}
03-23 22:30:01.033  1468  2443 W InputDispatcher: Attempted to unregister already unregistered input channel '213134e com.osfans.trime/com.osfans.trime.Pref (server)'
````