### PR TITLE
chore: add sponsor for trime

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# add alipay QR code for sponsor
+custom: https://raw.githubusercontent.com/osfans/trime/develop/osfans_alipay.png


### PR DESCRIPTION
You can enable sponsor in repository setting follow this instruction
https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository