### PR TITLE
Add clipboard function

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -878,8 +878,8 @@ preset_keyboards:
       - {click: z, long_click: '`', swipe_down: '[]{Left}', key_back_color: bh3, key_text_color: th3}
       - {click: x, long_click: cut, swipe_down: '{}{Left}', key_back_color: bh3, key_text_color: th3}
       - {click: c, long_click: copy, swipe_down: ' ', key_back_color: bh3, key_text_color: th3}
-      - {click: v, long_click: paste, swipe_down: "\\", key_back_color: bh3, key_text_color: th3}
-      - {click: b, long_click: ";", key_back_color: bh3, key_text_color: th3}
+      - {click: v, long_click: paste_clip, swipe_down: paste, key_back_color: bh3, key_text_color: th3}
+      - {click: b, long_click: ";", swipe_down: "\\", key_back_color: bh3, key_text_color: th3}
       - {click: n, long_click: ":", key_back_color: bh3, key_text_color: th3}
       - {click: m, long_click: '?', swipe_down: "|", key_back_color: bh3, key_text_color: th3}
       - {click: BackSpace, width: 15, key_back_color: bbs, key_text_color: tbs}
@@ -927,8 +927,8 @@ preset_keyboards:
       - {click: z, long_click: '`', swipe_down: '[]{Left}', key_back_color: bh3, key_text_color: th3}
       - {click: x, long_click: cut, swipe_down: '{}{Left}', key_back_color: bh3, key_text_color: th3}
       - {click: c, long_click: copy, swipe_down: ' ', key_back_color: bh3, key_text_color: th3}
-      - {click: v, long_click: paste, swipe_down: "\\", key_back_color: bh3, key_text_color: th3}
-      - {click: b, long_click: ";", key_back_color: bh3, key_text_color: th3}
+      - {click: v, long_click: paste_clip, swipe_down: paste, key_back_color: bh3, key_text_color: th3}
+      - {click: b, long_click: ";", swipe_down: "\\", key_back_color: bh3, key_text_color: th3}
       - {click: n, long_click: ":", key_back_color: bh3, key_text_color: th3}
       - {click: m, long_click: '?', swipe_down: "|", key_back_color: bh3, key_text_color: th3}
       - {click: BackSpace, width: 15, key_back_color: bbs, key_text_color: tbs}
@@ -967,7 +967,7 @@ preset_keyboards:
       - {click: '*', long_click: '±', key_back_color: bgn, key_text_color: tgn}
       - {click: 7, long_click: select_all}
       - {click: 8, long_click: copy}
-      - {click: 9, long_click: paste}
+      - {click: 9, long_click: paste_clip, swipe_down: paste}
       - {click: BackSpace, key_back_color: bbs, key_text_color: tbs}
 
       - {click: Keyboard_default, long_click: ':', key_back_color: bgn, key_text_color: 'tgn'}
@@ -3773,6 +3773,7 @@ preset_keys:
   cut: {label: 剪切, functional: false, send: Control+x}
   copy: {label: 复制, functional: false, send: Control+c}
   paste: {label: 粘贴, functional: false, send: Control+v}
+  paste_clip: {label: 剪贴板, send: function, command: clipboard}
   paste_text: {label: 貼上文本, send: Control+Shift+Alt+v} #>=Android 6.0
   share_text: {label: 分享文本, send: Control+Alt+s} #>=Android 6.0
   redo: {label: 重做, functional: false, send: Control+y} #>=Android 6.0

--- a/app/src/main/java/com/osfans/trime/Function.java
+++ b/app/src/main/java/com/osfans/trime/Function.java
@@ -21,6 +21,8 @@ package com.osfans.trime;
 import android.annotation.TargetApi;
 import android.app.SearchManager;
 import android.content.ComponentName;
+import android.content.ClipboardManager;
+import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -160,6 +162,17 @@ class Function {
     return s;
   }
 
+  private static String getClipboard(Context context) {
+    ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+    ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
+    CharSequence pasteData = item.getText();
+    if (pasteData != null) {
+      return pasteData.toString();
+    } else {
+      return "";
+    }
+  }
+
   public static String handle(Context context, String command, String option) {
     String s = null;
     if (command == null) return s;
@@ -172,6 +185,9 @@ class Function {
         break;
       case "broadcast":
         context.sendBroadcast(new Intent(option)); //廣播
+        break;
+      case "clipboard":
+        s = getClipboard(context);
         break;
       default:
         startIntent(context, command, option); //其他intent

--- a/app/src/main/java/com/osfans/trime/Function.java
+++ b/app/src/main/java/com/osfans/trime/Function.java
@@ -164,7 +164,14 @@ class Function {
 
   private static String getClipboard(Context context) {
     ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
-    ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
+    ClipData primaryClip = clipboard.getPrimaryClip();
+    if (primaryClip == null) {
+      return "";
+    }
+    ClipData.Item item = primaryClip.getItemAt(0);
+    if (item == null) {
+      return "";
+    }
     CharSequence pasteData = item.getText();
     if (pasteData != null) {
       return pasteData.toString();


### PR DESCRIPTION
简单实现了一个 clipboard 的功能，以实现阻止应用滥用剪贴板的同时不影响用户主动粘贴文本：https://github.com/osfans/trime/issues/406

用法：
```
paste_clip: {label: 剪贴板, send: function, command: clipboard}
```

使用此功能需要授予 `同文输入法` “读取剪贴板” 权限，不需要授予目标应用 “读取剪贴板” 权限。
