### PR TITLE
Fix: charset_filter doesn't work after librime 1.6.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,6 @@
 [submodule "app/src/main/jni/capnproto"]
 	path = app/src/main/jni/capnproto
 	url = https://github.com/lotem/capnproto.git
+[submodule "app/src/main/jni/librime-charcode"]
+	path = app/src/main/jni/librime-charcode
+	url = https://github.com/rime/librime-charcode

--- a/app/src/main/jni/CMakeLists.txt
+++ b/app/src/main/jni/CMakeLists.txt
@@ -429,6 +429,11 @@ set(rime_extra_modules "${rime_extra_modules},Q(grammar)")
 file(GLOB_RECURSE rime_plugin_sources librime-octagram/src/*.cc)
 set(rime_plugins_sources ${rime_plugins_sources} ${rime_plugin_sources})
 
+## librime-charcode
+set(rime_extra_modules "${rime_extra_modules},Q(charcode)")
+file(GLOB_RECURSE rime_plugin_sources librime-charcode/src/*.cc)
+set(rime_plugins_sources ${rime_plugins_sources} ${rime_plugin_sources})
+
 # rime proto
 capnp_generate_cpp(
   CAPNP_SRCS


### PR DESCRIPTION
BREAKING CHANGE from https://github.com/rime/librime/commit/00af291382f0b1e5d51001e3e14fb412fb9a3dd7 