### PR TITLE
Use debian experimental repo to install capnproto 0.8.0

### DIFF
--- a/.github/workflows/last-commit-release.yml
+++ b/.github/workflows/last-commit-release.yml
@@ -9,8 +9,9 @@ jobs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
           sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
-          sudo apt -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true update
-          sudo apt-get -o APT::Get::AllowUnauthenticated=true -y install opencc inkscape capnproto
+          sudo apt update
+          sudo apt-get -t experimental -y install capnproto
+          sudo apt-get -y install opencc inkscape
 
       - name: Checkout last commit
         uses: actions/checkout@v2

--- a/.github/workflows/last-commit-release.yml
+++ b/.github/workflows/last-commit-release.yml
@@ -12,13 +12,9 @@ jobs:
 
       - name: Install dependency
         run: |
-          curl -O https://capnproto.org/capnproto-c++-0.8.0.tar.gz
-          tar zxf capnproto-c++-0.8.0.tar.gz
-          cd capnproto-c++-0.8.0
-          ./configure
-          make -j4 check
-          sudo make install
-          sudo apt-get -y install opencc inkscape
+          sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
+          sudo apt update
+          sudo apt-get -y install opencc inkscape capnproto
 
       - name: Set up adoptJDK 8
         uses: actions/setup-java@v2

--- a/.github/workflows/last-commit-release.yml
+++ b/.github/workflows/last-commit-release.yml
@@ -4,12 +4,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout last commit
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
       - name: Install dependency
         run: |
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
@@ -17,6 +11,12 @@ jobs:
           sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
           sudo apt -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true update
           sudo apt-get -o APT::Get::AllowUnauthenticated=true -y install opencc inkscape capnproto
+
+      - name: Checkout last commit
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
 
       - name: Set up adoptJDK 8
         uses: actions/setup-java@v2

--- a/.github/workflows/last-commit-release.yml
+++ b/.github/workflows/last-commit-release.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Install dependency
         run: |
           sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
-          sudo apt update
-          sudo apt-get -y install opencc inkscape capnproto
+          sudo apt -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true update
+          sudo apt-get -o APT::Get::AllowUnauthenticated=true -y install opencc inkscape capnproto
 
       - name: Set up adoptJDK 8
         uses: actions/setup-java@v2

--- a/.github/workflows/last-commit-release.yml
+++ b/.github/workflows/last-commit-release.yml
@@ -10,7 +10,7 @@ jobs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
           sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
           sudo apt update
-          sudo apt-get -t experimental -y install capnproto=0.8.0
+          sudo apt-get -t experimental -y install capnproto=0.8.0-1
           sudo apt-get -y install opencc inkscape
 
       - name: Checkout last commit

--- a/.github/workflows/last-commit-release.yml
+++ b/.github/workflows/last-commit-release.yml
@@ -10,7 +10,7 @@ jobs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
           sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
           sudo apt update
-          sudo apt-get -t experimental -y install capnproto
+          sudo apt-get -t experimental -y install capnproto=0.8.0
           sudo apt-get -y install opencc inkscape
 
       - name: Checkout last commit

--- a/.github/workflows/last-commit-release.yml
+++ b/.github/workflows/last-commit-release.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Install dependency
         run: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
           sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
           sudo apt -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true update
           sudo apt-get -o APT::Get::AllowUnauthenticated=true -y install opencc inkscape capnproto

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -4,21 +4,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependency
+        run: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
+          sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
+          sudo apt update
+          sudo apt-get -t experimental -y install capnproto=0.8.0-1
+
       - name: Checkout last commit
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: 'recursive'
-
-      - name: Install dependency
-        run: |
-          curl -O https://capnproto.org/capnproto-c++-0.8.0.tar.gz
-          tar zxf capnproto-c++-0.8.0.tar.gz
-          cd capnproto-c++-0.8.0
-          ./configure
-          make -j4 check
-          sudo make install
-
+      
       - name: Set up adoptJDK 8
         uses: actions/setup-java@v2
         with:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,5 +56,5 @@ android {
 }
 
 dependencies {
-    implementation 'org.ocpsoft.prettytime:prettytime:4.0.1.Final'
+    implementation 'org.ocpsoft.prettytime:prettytime:5.0.1.Final'
 }


### PR DESCRIPTION
We don't need to install capnproto by building source now, to save ci time about 8 minutes.