### PR TITLE
[Settings Enhancement] Rewrite `Pref` with AppCompatActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,10 @@ android {
         }
     }
 
+    buildFeatures {
+        viewBinding = true
+    }
+
     externalNativeBuild {
         cmake {
             path "src/main/jni/CMakeLists.txt"
@@ -59,6 +63,7 @@ android {
 dependencies {
     implementation 'org.ocpsoft.prettytime:prettytime:5.0.1.Final'
     implementation "androidx.core:core-ktx:1.3.2"
+    implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'org.ocpsoft.prettytime:prettytime:5.0.1.Final'
     implementation "androidx.core:core-ktx:1.3.2"
     implementation "androidx.appcompat:appcompat:1.3.0"
+    implementation "androidx.preference:preference-ktx:1.1.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation "androidx.core:core-ktx:1.3.2"
     implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "androidx.preference:preference-ktx:1.1.1"
+    implementation "androidx.fragment:fragment-ktx:1.2.4"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,5 +57,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name=".settings.HelpActivity"
+            android:label="@string/pref_help" />
+
+        <activity android:name=".settings.AboutActivity"
+            android:label="@string/pref_about" />
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,8 @@
     <application android:label="@string/ime_name"
                  android:icon="@drawable/icon"
                  android:requestLegacyExternalStorage="true"
-                 android:allowBackup="false" >
+                 android:allowBackup="false"
+                 android:theme="@style/PreferenceTheme">
 
         <service android:name="Trime" android:label="@string/ime_name"
                 android:permission="android.permission.BIND_INPUT_METHOD">
@@ -40,8 +41,16 @@
             </intent-filter>
             <meta-data android:name="android.view.im" android:resource="@xml/method" />
         </service>
-
+        <!--
         <activity android:name="Pref" android:label="@string/ime_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity> -->
+
+        <activity android:name=".settings.PrefMainActivity" android:label="@string/ime_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/assets/licensing.html
+++ b/app/src/main/assets/licensing.html
@@ -42,7 +42,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see https://www.gnu.org/licenses/.
 </pre>
 </td></tr></table>
 </body>

--- a/app/src/main/java/com/osfans/trime/settings/AboutActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/AboutActivity.kt
@@ -1,12 +1,17 @@
 package com.osfans.trime.settings
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
+import android.webkit.WebView
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.osfans.trime.R
+import com.osfans.trime.Rime
 import com.osfans.trime.databinding.AboutActivityBinding
 
 class AboutActivity: AppCompatActivity() {
@@ -65,6 +70,50 @@ class AboutActivity: AppCompatActivity() {
     class AboutFragment: PreferenceFragmentCompat() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.about_preference, rootKey)
+            val changelogPreference: Preference? = findPreference("pref_changelog")
+            if (changelogPreference != null) {
+                setVersion(changelogPreference, Rime.get_trime_version())
+            }
+            val librimeVerPreference: Preference? = findPreference("pref_librime_ver")
+            if (librimeVerPreference != null) {
+                setVersion(librimeVerPreference, Rime.get_librime_version())
+            }
+            val openccVerPreference: Preference? = findPreference("pref_opencc_ver")
+            if (openccVerPreference != null) {
+                setVersion(openccVerPreference, Rime.get_opencc_version())
+            }
+        }
+
+        override fun onPreferenceTreeClick(preference: Preference?): Boolean {
+            return when(preference?.key) {
+                "pref_licensing" -> {
+                    val webView = WebView(requireContext())
+                    webView.loadUrl("file:///android_asset/licensing.html")
+                    AlertDialog.Builder(requireContext())
+                        .setTitle(R.string.pref_licensing)
+                        .setView(webView)
+                        .setPositiveButton(android.R.string.ok, null)
+                        .show()
+                    true
+                }
+                else -> super.onPreferenceTreeClick(preference)
+            }
+        }
+
+        private fun getCommit(versionCode: String): String {
+            return if (versionCode.contains("-g")) {
+                versionCode.replace("^(.*-g)([0-9a-f]+)(.*)$".toRegex(), "$2")
+            } else {
+                versionCode.replace("^([^-]*)(-.*)$".toRegex(), "$1")
+            }
+        }
+
+        private fun setVersion(pref: Preference, versionCode: String) {
+            val commit = getCommit(versionCode)
+            pref.summary = versionCode
+            val intent = pref.intent
+            intent.data = Uri.withAppendedPath(intent.data, "commits/$commit")
+            pref.intent = intent
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/AboutActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/AboutActivity.kt
@@ -1,0 +1,70 @@
+package com.osfans.trime.settings
+
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.R
+import com.osfans.trime.databinding.AboutActivityBinding
+
+class AboutActivity: AppCompatActivity() {
+    lateinit var binding: AboutActivityBinding
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = AboutActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+
+        if (savedInstanceState == null) {
+            loadFragment(AboutFragment())
+        } else {
+            title = savedInstanceState.getCharSequence(FRAGMENT_TAG)
+        }
+        supportFragmentManager.addOnBackStackChangedListener {
+            if (supportFragmentManager.backStackEntryCount == 0) {
+                setTitle(R.string.pref_about)
+            }
+        }
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putCharSequence(FRAGMENT_TAG, title)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        if (supportFragmentManager.popBackStackImmediate()) {
+            return true
+        }
+        return super.onSupportNavigateUp()
+    }
+
+    private fun loadFragment(fragment: Fragment) {
+        supportFragmentManager
+            .beginTransaction()
+            .replace(binding.about.id, fragment, FRAGMENT_TAG)
+            .commit()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressed()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    class AboutFragment: PreferenceFragmentCompat() {
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.about_preference, rootKey)
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/settings/HelpActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/HelpActivity.kt
@@ -1,0 +1,70 @@
+package com.osfans.trime.settings
+
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.R
+import com.osfans.trime.databinding.HelpActivityBinding
+
+class HelpActivity: AppCompatActivity() {
+    lateinit var binding: HelpActivityBinding
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = HelpActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+
+        if (savedInstanceState == null) {
+            loadFragment(HelpFragment())
+        } else {
+            title = savedInstanceState.getCharSequence(FRAGMENT_TAG)
+        }
+        supportFragmentManager.addOnBackStackChangedListener {
+            if (supportFragmentManager.backStackEntryCount == 0) {
+                setTitle(R.string.pref_help)
+            }
+        }
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putCharSequence(FRAGMENT_TAG, title)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        if (supportFragmentManager.popBackStackImmediate()) {
+            return true
+        }
+        return super.onSupportNavigateUp()
+    }
+
+    private fun loadFragment(fragment: Fragment) {
+        supportFragmentManager
+            .beginTransaction()
+            .replace(binding.help.id, fragment, FRAGMENT_TAG)
+            .commit()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressed()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    class HelpFragment: PreferenceFragmentCompat() {
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.help_preference, rootKey)
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -129,9 +129,11 @@ class PrefMainActivity: AppCompatActivity(),
                 true
             }
             R.id.preference__menu_help -> {
+                startActivity(Intent(this, HelpActivity::class.java))
                 true
             }
             R.id.preference__menu_about -> {
+                startActivity(Intent(this, AboutActivity::class.java))
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -26,6 +26,7 @@ import androidx.preference.PreferenceManager
 import com.osfans.trime.Function
 import com.osfans.trime.R
 import com.osfans.trime.databinding.PrefActivityBinding
+import com.osfans.trime.settings.components.SchemaPickerDialog
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 import kotlin.system.exitProcess
@@ -214,6 +215,10 @@ class PrefMainActivity: AppCompatActivity(),
                 }
                 "pref_select" -> { //切換
                     (activity as PrefMainActivity).imeManager.showInputMethodPicker()
+                    true
+                }
+                "pref_schemas" -> {
+                    SchemaPickerDialog(requireContext()).show()
                     true
                 }
                 else -> super.onPreferenceTreeClick(preference)

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -3,6 +3,7 @@ package com.osfans.trime.settings
 import android.app.ProgressDialog
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
@@ -10,10 +11,12 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceManager
 import com.osfans.trime.Function
 import com.osfans.trime.R
 import com.osfans.trime.databinding.PrefActivityBinding
@@ -29,11 +32,20 @@ class PrefMainActivity: AppCompatActivity(),
     private val job = Job()
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Main + job
+    private val prefs get() = PreferenceManager.getDefaultSharedPreferences(this)
 
     lateinit var binding: PrefActivityBinding
     lateinit var imeManager: InputMethodManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        val mode = when (prefs.getString("pref__settings_theme", "auto")) {
+            "auto" -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            "light" -> AppCompatDelegate.MODE_NIGHT_NO
+            "dark" -> AppCompatDelegate.MODE_NIGHT_YES
+            else -> AppCompatDelegate.MODE_NIGHT_UNSPECIFIED
+        }
+        AppCompatDelegate.setDefaultNightMode(mode)
+
         super.onCreate(savedInstanceState)
         binding = PrefActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -1,0 +1,16 @@
+package com.osfans.trime.settings
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.osfans.trime.databinding.PrefActivityBinding
+
+class PrefMainActivity: AppCompatActivity() {
+
+    lateinit var binding: PrefActivityBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = PrefActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+}

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -44,13 +44,13 @@ class PrefMainActivity: AppCompatActivity(),
     lateinit var imeManager: InputMethodManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val mode = when (prefs.getString("pref__settings_theme", "auto")) {
+        val uiMode = when (prefs.getString("pref__settings_theme", "auto")) {
             "auto" -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
             "light" -> AppCompatDelegate.MODE_NIGHT_NO
             "dark" -> AppCompatDelegate.MODE_NIGHT_YES
             else -> AppCompatDelegate.MODE_NIGHT_UNSPECIFIED
         }
-        AppCompatDelegate.setDefaultNightMode(mode)
+        AppCompatDelegate.setDefaultNightMode(uiMode)
 
         super.onCreate(savedInstanceState)
         binding = PrefActivityBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -1,18 +1,37 @@
 package com.osfans.trime.settings
 
+import android.app.ProgressDialog
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
+import android.util.Log
+import android.view.Menu
+import android.view.MenuItem
+import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.Function
 import com.osfans.trime.R
 import com.osfans.trime.databinding.PrefActivityBinding
+import kotlinx.coroutines.*
+import kotlin.coroutines.CoroutineContext
+import kotlin.system.exitProcess
 
 internal const val FRAGMENT_TAG = "FRAGMENT_TAG"
 
-class PrefMainActivity: AppCompatActivity() {
+class PrefMainActivity: AppCompatActivity(),
+    PreferenceFragmentCompat.OnPreferenceStartFragmentCallback,
+    CoroutineScope {
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main + job
 
     lateinit var binding: PrefActivityBinding
+    lateinit var imeManager: InputMethodManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,6 +40,8 @@ class PrefMainActivity: AppCompatActivity() {
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
+
+        imeManager = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
 
         if (savedInstanceState == null) {
             loadFragment(PrefFragment())
@@ -48,6 +69,28 @@ class PrefMainActivity: AppCompatActivity() {
         return super.onSupportNavigateUp()
     }
 
+    override fun onPreferenceStartFragment(
+        caller: PreferenceFragmentCompat,
+        pref: Preference
+    ): Boolean {
+        // Instantiate the new Fragment
+        val args = pref.extras
+        val fragment = supportFragmentManager.fragmentFactory.instantiate(
+            classLoader,
+            pref.fragment
+        ).apply {
+            arguments = args
+            setTargetFragment(caller, 0)
+        }
+        // Replace the existing Fragment with the new Fragment
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.preference, fragment)
+            .addToBackStack(null)
+            .commit()
+        title = pref.title
+        return true
+    }
+
     private fun loadFragment(fragment: Fragment) {
         supportFragmentManager
             .beginTransaction()
@@ -55,9 +98,102 @@ class PrefMainActivity: AppCompatActivity() {
             .commit()
     }
 
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.preference_main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressed()
+                true
+            }
+            R.id.preference__menu_deploy -> {
+                val progressDialog = ProgressDialog(this).apply {
+                    setMessage(getString(R.string.deploy_progress))
+                    show()
+                }
+                launch {
+                    Runnable {
+                        try {
+                            Function.deploy(this@PrefMainActivity)
+                        } catch (ex: Exception) {
+                            Log.e(FRAGMENT_TAG, "Deploy Exception: $ex")
+                        } finally {
+                            progressDialog.dismiss()
+                            exitProcess(0)
+                        }
+                    }.run()
+                }
+                true
+            }
+            R.id.preference__menu_help -> {
+                true
+            }
+            R.id.preference__menu_about -> {
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
     class PrefFragment : PreferenceFragmentCompat() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.prefs, rootKey)
+            if (checkIfImeIsEnabled(requireContext())) {
+                findPreference<Preference>("pref_enable")?.isVisible = false
+            }
+            if (checkIfImeIsSelected(requireContext())) {
+                findPreference<Preference>("pref_select")?.isVisible = false
+            }
+        }
+
+        override fun onPreferenceTreeClick(preference: Preference?): Boolean {
+            return when (preference?.key) {
+                "pref_enable" -> { //啓用
+                    val intent = Intent()
+                    intent.action = Settings.ACTION_INPUT_METHOD_SETTINGS
+                    intent.addCategory(Intent.CATEGORY_DEFAULT)
+                    startActivity(intent)
+                    true
+                }
+                "pref_select" -> { //切換
+                    (activity as PrefMainActivity).imeManager.showInputMethodPicker()
+                    true
+                }
+                else -> super.onPreferenceTreeClick(preference)
+            }
+        }
+
+        override fun onResume() { // 如果同文已被启用/选用，则隐藏设置项
+            super.onResume()
+            if (checkIfImeIsEnabled(requireContext())) {
+                findPreference<Preference>("pref_enable")?.isVisible = false
+            }
+            if (checkIfImeIsSelected(requireContext())) {
+                findPreference<Preference>("pref_select")?.isVisible = false
+            }
+        }
+    }
+
+    companion object {
+        private const val IME_ID: String = "com.osfans.trime/.Trime"
+
+        fun checkIfImeIsEnabled(context: Context): Boolean {
+            val activeImeIds = Settings.Secure.getString(
+                context.contentResolver,
+                Settings.Secure.ENABLED_INPUT_METHODS
+            ) ?: "(none)"
+            return activeImeIds.split(":").contains(IME_ID)
+        }
+
+        fun checkIfImeIsSelected(context: Context): Boolean {
+            val selectedImeIds = Settings.Secure.getString(
+                context.contentResolver,
+                Settings.Secure.DEFAULT_INPUT_METHOD
+            ) ?: "(none)"
+            return selectedImeIds == IME_ID
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceFragmentCompat
 import com.osfans.trime.R
 import com.osfans.trime.databinding.PrefActivityBinding
 
@@ -20,12 +21,43 @@ class PrefMainActivity: AppCompatActivity() {
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
+
+        if (savedInstanceState == null) {
+            loadFragment(PrefFragment())
+        } else {
+            title = savedInstanceState.getCharSequence(FRAGMENT_TAG)
+        }
+        supportFragmentManager.addOnBackStackChangedListener {
+            if (supportFragmentManager.backStackEntryCount == 0) {
+                setTitle(R.string.ime_name)
+            }
+        }
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
-    
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putCharSequence(FRAGMENT_TAG, title)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        if (supportFragmentManager.popBackStackImmediate()) {
+            return true
+        }
+        return super.onSupportNavigateUp()
+    }
+
     private fun loadFragment(fragment: Fragment) {
         supportFragmentManager
             .beginTransaction()
             .replace(binding.preference.id, fragment, FRAGMENT_TAG)
             .commit()
+    }
+
+    class PrefFragment : PreferenceFragmentCompat() {
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.prefs, rootKey)
+        }
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -1,15 +1,21 @@
 package com.osfans.trime.settings
 
+import android.Manifest
+import android.annotation.TargetApi
 import android.app.ProgressDialog
 import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.inputmethod.InputMethodManager
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
@@ -67,6 +73,7 @@ class PrefMainActivity: AppCompatActivity(),
         }
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        requestPermission()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -149,6 +156,39 @@ class PrefMainActivity: AppCompatActivity(),
                 true
             }
             else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    @TargetApi(VERSION_CODES.M)
+    private fun requestPermission() {
+        if (checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestPermissions(
+                arrayOf(
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_EXTERNAL_STORAGE
+                ),
+                0
+            )
+        }
+        if (VERSION.SDK_INT >= VERSION_CODES.P) { //僅Android P需要此權限在最上層顯示懸浮窗、對話框
+            if (!Settings.canDrawOverlays(this)) { // 事先说明需要权限的理由
+                AlertDialog.Builder(this).apply {
+                    setTitle(R.string.pref__draw_overlays_tip_title)
+                    setCancelable(true)
+                    setMessage(R.string.pref__draw_overlays_tip_message)
+                    setPositiveButton(android.R.string.ok) { _, _ ->
+                        val intent = Intent(
+                            Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                            Uri.parse("package:$packageName")
+                        )
+                        //startActivityForResult(intent, OVERLAY_PERMISSION_REQ_CODE);
+                        startActivity(intent)
+                    }
+                    setNegativeButton(android.R.string.cancel, null)
+                }.create().show()
+            }
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -2,7 +2,12 @@ package com.osfans.trime.settings
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import com.osfans.trime.R
 import com.osfans.trime.databinding.PrefActivityBinding
+
+internal const val FRAGMENT_TAG = "FRAGMENT_TAG"
 
 class PrefMainActivity: AppCompatActivity() {
 
@@ -12,5 +17,15 @@ class PrefMainActivity: AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = PrefActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+    }
+    
+    private fun loadFragment(fragment: Fragment) {
+        supportFragmentManager
+            .beginTransaction()
+            .replace(binding.preference.id, fragment, FRAGMENT_TAG)
+            .commit()
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/components/SeekBarPreference.java
+++ b/app/src/main/java/com/osfans/trime/settings/components/SeekBarPreference.java
@@ -16,19 +16,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.osfans.trime;
+package com.osfans.trime.settings.components;
 
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.preference.Preference;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import com.osfans.trime.R;
 
 /** @hide */
 public class SeekBarPreference extends Preference implements OnSeekBarChangeListener {
@@ -47,13 +51,25 @@ public class SeekBarPreference extends Preference implements OnSeekBarChangeList
   }
 
   public SeekBarPreference(Context context, AttributeSet attrs) {
-    this(context, attrs, android.R.attr.preferenceStyle);
+    this(context, attrs, R.attr.preferenceStyle);
   }
 
   public SeekBarPreference(Context context) {
     this(context, null);
   }
 
+  @Override
+  public void onBindViewHolder(PreferenceViewHolder holder) {
+    super.onBindViewHolder(holder);
+    SeekBar seekBar = (SeekBar) holder.findViewById(R.id.seekbar);
+    seekBar.setOnSeekBarChangeListener(this);
+    seekBar.setMax(mMax);
+    seekBar.setProgress(mProgress);
+    seekBar.setEnabled(isEnabled());
+    mValue = (TextView) holder.findViewById(R.id.value);
+    setValue();
+  }
+  /*
   @Override
   protected void onBindView(View view) {
     super.onBindView(view);
@@ -64,7 +80,7 @@ public class SeekBarPreference extends Preference implements OnSeekBarChangeList
     seekBar.setEnabled(isEnabled());
     mValue = (TextView) view.findViewById(R.id.value);
     setValue();
-  }
+  } */
 
   private CharSequence getValue(int progress) {
     String unit = "%";

--- a/app/src/main/java/com/osfans/trime/settings/fragments/AppearanceFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/AppearanceFragment.kt
@@ -1,0 +1,38 @@
+package com.osfans.trime.settings.fragments
+
+import android.os.Bundle
+import android.view.Menu
+import androidx.core.view.forEach
+import androidx.core.view.forEachIndexed
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.R
+import com.osfans.trime.settings.components.ColorPickerDialog
+import com.osfans.trime.settings.components.ThemePickerDialog
+
+class AppearanceFragment: PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.appearance_preference)
+
+        setHasOptionsMenu(true)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        menu.forEach { item -> item.isVisible = false}
+        super.onPrepareOptionsMenu(menu)
+    }
+
+    override fun onPreferenceTreeClick(preference: Preference?): Boolean {
+        return when (preference?.key) {
+            "pref_themes" -> {
+                ThemePickerDialog(requireContext()).show()
+                true
+            }
+            "pref_colors" -> {
+                ColorPickerDialog(requireContext()).show()
+                true
+            }
+            else -> super.onPreferenceTreeClick(preference)
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
@@ -4,6 +4,8 @@ import android.app.ProgressDialog
 import android.content.Context
 import android.os.Bundle
 import android.util.Log
+import android.view.Menu
+import androidx.core.view.forEach
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
@@ -30,14 +32,17 @@ class InputFragment: PreferenceFragmentCompat(), CoroutineScope {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.input_preference)
+
+        setHasOptionsMenu(true)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        menu.forEach { item -> item.isVisible = false}
+        super.onPrepareOptionsMenu(menu)
     }
 
     override fun onPreferenceTreeClick(preference: Preference?): Boolean {
         return when (preference?.key) {
-            "pref_schemas" -> {
-                SchemaPickerDialog(requireContext()).show()
-                true
-            }
             "pref_sync" -> {
                 @Suppress("DEPRECATION")
                 val progressDialog = ProgressDialog(context).apply {

--- a/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
@@ -1,11 +1,106 @@
 package com.osfans.trime.settings.fragments
 
+import android.app.ProgressDialog
+import android.content.Context
 import android.os.Bundle
+import android.util.Log
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceManager
+import androidx.preference.SwitchPreference
+import com.osfans.trime.Function
 import com.osfans.trime.R
+import com.osfans.trime.settings.components.ResetAssetsDialog
+import com.osfans.trime.settings.components.SchemaPickerDialog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.ocpsoft.prettytime.PrettyTime
+import java.util.*
+import kotlin.coroutines.CoroutineContext
+import kotlin.system.exitProcess
 
-class InputFragment: PreferenceFragmentCompat() {
+class InputFragment: PreferenceFragmentCompat(), CoroutineScope {
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main + job
+
+    private val prefs get() = PreferenceManager.getDefaultSharedPreferences(requireContext())
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.input_preference)
+    }
+
+    override fun onPreferenceTreeClick(preference: Preference?): Boolean {
+        return when (preference?.key) {
+            "pref_schemas" -> {
+                SchemaPickerDialog(requireContext()).show()
+                true
+            }
+            "pref_sync" -> {
+                val progressDialog = ProgressDialog(context).apply {
+                    setMessage(getString(R.string.sync_progress))
+                    show()
+                }
+                launch {
+                    Runnable {
+                        try {
+                            Function.sync(requireContext())
+                        } catch (ex: Exception) {
+                            Log.e("InputFragment", "Sync Exception: $ex")
+                        } finally {
+                            progressDialog.dismiss()
+                            exitProcess(0)
+                        }
+                    }.run()
+                }
+                true
+            }
+            "pref_sync_bg" -> {
+                setBackgroundSyncSummary(context)
+                true
+            }
+            "pref_reset" -> {
+                ResetAssetsDialog(requireContext()).show()
+                true
+            }
+            else -> super.onPreferenceTreeClick(preference)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setBackgroundSyncSummary(context)
+    }
+
+    private fun setBackgroundSyncSummary(context: Context?) {
+        val syncBgPref = findPreference<SwitchPreference>("pref_sync_bg")
+        if (context == null) {
+            if (syncBgPref?.isChecked == true) {
+                syncBgPref.setSummaryOn(R.string.pref_sync_bg_never)
+            } else {
+                syncBgPref?.setSummaryOff(R.string.pref_sync_bg_tip)
+            }
+        } else {
+            var summary: String
+            if (syncBgPref?.isChecked == true) {
+                val lastResult = prefs.getBoolean("last_sync_status", false)
+                val lastTime = prefs.getLong("last_sync_time", 0)
+                summary = if (lastResult) {
+                    context.getString(R.string.pref_sync_bg_success)
+                } else {
+                    context.getString(R.string.pref_sync_bg_failure)
+                }
+                summary = if (lastTime == 0L) {
+                    context.getString(R.string.pref_sync_bg_tip)
+                } else {
+                    summary.format(PrettyTime().format(Date(lastTime)))
+                }
+                syncBgPref.summaryOn = summary
+            } else {
+                syncBgPref?.setSummaryOff(R.string.pref_sync_bg_tip)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
@@ -39,6 +39,7 @@ class InputFragment: PreferenceFragmentCompat(), CoroutineScope {
                 true
             }
             "pref_sync" -> {
+                @Suppress("DEPRECATION")
                 val progressDialog = ProgressDialog(context).apply {
                     setMessage(getString(R.string.sync_progress))
                     show()

--- a/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
@@ -1,0 +1,11 @@
+package com.osfans.trime.settings.fragments
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.R
+
+class InputFragment: PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.input_preference)
+    }
+}

--- a/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
@@ -2,6 +2,8 @@ package com.osfans.trime.settings.fragments
 
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.view.Menu
+import androidx.core.view.forEach
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.osfans.trime.R
@@ -14,20 +16,13 @@ class KeyboardFragment: PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.keyboard_preference)
+
+        setHasOptionsMenu(true)
     }
 
-    override fun onPreferenceTreeClick(preference: Preference?): Boolean {
-        return when (preference?.key) {
-            "pref_themes" -> {
-                ThemePickerDialog(requireContext()).show()
-                true
-            }
-            "pref_colors" -> {
-                ColorPickerDialog(requireContext()).show()
-                true
-            }
-            else -> super.onPreferenceTreeClick(preference)
-        }
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        menu.forEach { item -> item.isVisible = false}
+        super.onPrepareOptionsMenu(menu)
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {

--- a/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
@@ -1,0 +1,11 @@
+package com.osfans.trime.settings.fragments
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.R
+
+class KeyboardFragment: PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.keyboard_preference)
+    }
+}

--- a/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
@@ -71,11 +71,11 @@ class KeyboardFragment: PreferenceFragmentCompat(),
 
     override fun onResume() {
         super.onResume()
-        preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+        preferenceScreen.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }
 
     override fun onPause() {
         super.onPause()
-        preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
+        preferenceScreen.sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
@@ -1,11 +1,81 @@
 package com.osfans.trime.settings.fragments
 
+import android.content.SharedPreferences
 import android.os.Bundle
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.osfans.trime.R
+import com.osfans.trime.Rime
+import com.osfans.trime.Trime
+import com.osfans.trime.settings.components.ColorPickerDialog
+import com.osfans.trime.settings.components.ThemePickerDialog
 
-class KeyboardFragment: PreferenceFragmentCompat() {
+class KeyboardFragment: PreferenceFragmentCompat(),
+    SharedPreferences.OnSharedPreferenceChangeListener {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.keyboard_preference)
+    }
+
+    override fun onPreferenceTreeClick(preference: Preference?): Boolean {
+        return when (preference?.key) {
+            "pref_themes" -> {
+                ThemePickerDialog(requireContext()).show()
+                true
+            }
+            "pref_colors" -> {
+                ColorPickerDialog(requireContext()).show()
+                true
+            }
+            else -> super.onPreferenceTreeClick(preference)
+        }
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        val trime = Trime.getService()
+        when (key) {
+            "key_sound" -> {
+                trime?.resetEffect()
+            }
+            "key_vibrate" -> {
+                trime?.resetEffect()
+            }
+            "key_sound_volume" -> {
+                trime?.let {
+                    it.resetEffect()
+                    it.soundEffect()
+                }
+            }
+            "key_vibrate_duration", "key_vibrate_amplitude" -> {
+                trime?.let {
+                    it.resetEffect()
+                    it.vibrateEffect()
+                }
+            }
+            "speak_key", "speak_commit" -> {
+                trime?.resetEffect()
+            }
+            "longpress_timeout", "repeat_interval", "show_preview" -> {
+                trime?.resetKeyboard()
+            }
+            "show_window" -> {
+                trime?.resetCandidate()
+            }
+            "inline_preedit", "soft_cursor" -> {
+                trime?.loadConfig()
+            }
+            "show_switches" -> {
+                sharedPreferences?.getBoolean(key, false)?.let { Rime.setShowSwitches(it) }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -1,11 +1,35 @@
 package com.osfans.trime.settings.fragments
 
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.preference.PreferenceFragmentCompat
 import com.osfans.trime.R
+import com.osfans.trime.Trime
 
-class OtherFragment: PreferenceFragmentCompat() {
+class OtherFragment: PreferenceFragmentCompat(),
+    SharedPreferences.OnSharedPreferenceChangeListener {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.other_preference)
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        val trime = Trime.getService()
+        when (key) {
+            "pref_notification_icon" -> {
+                if (sharedPreferences?.getBoolean(key, false) == true) {
+                    trime?.showStatusIcon(R.drawable.status)
+                } else { trime.hideStatusIcon() }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -1,0 +1,11 @@
+package com.osfans.trime.settings.fragments
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.R
+
+class OtherFragment: PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.other_preference)
+    }
+}

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -3,6 +3,8 @@ package com.osfans.trime.settings.fragments
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.view.Menu
+import androidx.core.view.forEach
 import androidx.preference.PreferenceFragmentCompat
 import com.osfans.trime.Pref
 import com.osfans.trime.R
@@ -13,6 +15,13 @@ class OtherFragment: PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.other_preference)
+
+        setHasOptionsMenu(true)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        menu.forEach { item -> item.isVisible = false}
+        super.onPrepareOptionsMenu(menu)
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -1,10 +1,13 @@
 package com.osfans.trime.settings.fragments
 
+import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.Pref
 import com.osfans.trime.R
 import com.osfans.trime.Trime
+import com.osfans.trime.settings.PrefMainActivity
 
 class OtherFragment: PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {
@@ -20,16 +23,22 @@ class OtherFragment: PreferenceFragmentCompat(),
                     trime?.showStatusIcon(R.drawable.status)
                 } else { trime.hideStatusIcon() }
             }
+            "pref__settings_theme" -> {
+                (activity as PrefMainActivity).finish()
+                val intent = Intent(context, PrefMainActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_HISTORY
+                requireContext().startActivity(intent)
+            }
         }
     }
 
     override fun onResume() {
         super.onResume()
-        preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+        preferenceScreen.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }
 
     override fun onPause() {
         super.onPause()
-        preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
+        preferenceScreen.sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
     }
 }

--- a/app/src/main/res/layout/about_activity.xml
+++ b/app/src/main/res/layout/about_activity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/toolbar" />
+
+    <FrameLayout
+        android:id="@+id/about"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/help_activity.xml
+++ b/app/src/main/res/layout/help_activity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/toolbar" />
+
+    <FrameLayout
+        android:id="@+id/help"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/pref_activity.xml
+++ b/app/src/main/res/layout/pref_activity.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/preference"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/app/src/main/res/layout/pref_activity.xml
+++ b/app/src/main/res/layout/pref_activity.xml
@@ -4,6 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include layout="@layout/toolbar" />
+
     <FrameLayout
         android:id="@+id/preference"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/preference_widget_seekbar.xml
+++ b/app/src/main/res/layout/preference_widget_seekbar.xml
@@ -34,7 +34,7 @@
 
     <SeekBar
         android:id="@+id/seekbar"
-        android:minWidth="180dp"
+        android:minWidth="100dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:focusable="false"

--- a/app/src/main/res/layout/preference_widget_seekbar.xml
+++ b/app/src/main/res/layout/preference_widget_seekbar.xml
@@ -34,7 +34,7 @@
 
     <SeekBar
         android:id="@+id/seekbar"
-        android:minWidth="100dip"
+        android:minWidth="180dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:focusable="false"

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:background="@color/colorPrimary"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />

--- a/app/src/main/res/menu/preference_main_menu.xml
+++ b/app/src/main/res/menu/preference_main_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/preference__menu_deploy"
+        android:title="@string/pref_deploy"
+        app:showAsAction="ifRoom" />
+    <item android:id="@+id/preference__menu_help"
+        android:title="@string/pref_help" />
+    <item android:id="@+id/preference__menu_about"
+        android:title="@string/pref_about" />
+</menu>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,7 +39,7 @@
     <string name="pref_credits">鸣谢</string>
     <string name="pref_pime">微软平台PRIME输入法</string>
     <string name="pref_privacy">隐私策略</string>
-    <string name="pref_input">输入</string>
+    <string name="pref_input">输入配置</string>
     <string name="pref_enable">启用</string>
     <string name="pref_enable_summary">启用同文输入法</string>
     <string name="pref_select">选取软键盘</string>
@@ -52,7 +52,7 @@
     <string name="pref_colors_summary">选取键盘配色</string>
     <string name="pref_reset">恢复默认设置</string>
     <string name="pref_reset_summary">使用默认设置覆盖共享文件夹下同名文件</string>
-    <string name="pref_keyboard">键盘</string>
+    <string name="pref_keyboard">偏好设置</string>
     <string name="key_sound">按键声音</string>
     <string name="key_sound_volume">按键音量</string>
     <string name="key_vibrate">按键时振动</string>
@@ -108,9 +108,9 @@
     <string name="pref_help__general_channel">常规渠道</string>
     <string name="pref_help__marketplace">应用市场</string>
     <string name="pref_help__user_community">用户社区</string>
-    <string name="pref_keyboard__appearance">外观</string>
-    <string name="pref_keyboard__function">功能</string>
-    <string name="pref_keyboard__effect">效果</string>
+    <string name="pref_keyboard__effect">按键效果</string>
     <string name="pref__draw_overlays_tip_title">显示在其他应用上方</string>
     <string name="pref__draw_overlays_tip_message">要正确显示候选栏，或从键盘开启各项菜单，您需要授予同文输入法“显示在其他应用上方”的权限。点击“确定”前往设置页，或“取消”以稍后手动设置。</string>
+    <string name="pref_keyboard_appearance">键盘外观</string>
+    <string name="pref_keyboard__function">视图</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -73,6 +73,11 @@
         <item>输入码</item>
         <item>无</item>
     </string-array>
+    <string-array name="settings_theme__entries" >
+        <item name="auto">系统默认</item>
+        <item name="light">亮色</item>
+        <item name="dark">暗色</item>
+    </string-array>
     <string name="soft_cursor">编码区使用插入符号(^)</string>
     <string name="pref_deploy">部署</string>
     <string name="pref_deploy_summary">修改设置后需要再次部署同文输入法平台</string>
@@ -100,4 +105,12 @@
     <string name="pref_sync_bg_failure">上次同步于 %s，失败</string>
     <string name="pref_sync_bg_never">后台同步未运行</string>
     <string name="pref_sync_bg_tip">点击以开启后台同步</string>
+    <string name="pref_help__general_channel">常规渠道</string>
+    <string name="pref_help__marketplace">应用市场</string>
+    <string name="pref_help__user_community">用户社区</string>
+    <string name="pref_keyboard__appearance">外观</string>
+    <string name="pref_keyboard__function">功能</string>
+    <string name="pref_keyboard__effect">效果</string>
+    <string name="pref__draw_overlays_tip_title">显示在其他应用上方</string>
+    <string name="pref__draw_overlays_tip_message">要正确显示候选栏，或从键盘开启各项菜单，您需要授予同文输入法“显示在其他应用上方”的权限。点击“确定”前往设置页，或“取消”以稍后手动设置。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -40,7 +40,7 @@
     <string name="pref_credits">鳴謝</string>
     <string name="pref_pime">Win10 PRIME輸入法平臺</string>
     <string name="pref_privacy">隱私權政策</string>
-    <string name="pref_input">輸入</string>
+    <string name="pref_input">輸入配置</string>
     <string name="pref_enable">啓用</string>
     <string name="pref_enable_summary">啓用同文輸入法平臺</string>
     <string name="pref_select">選取軟鍵盤</string>
@@ -53,7 +53,7 @@
     <string name="pref_colors_summary">選取想要的鍵盤配色</string>
     <string name="pref_reset">回廠</string>
     <string name="pref_reset_summary">使用預設設定覆蓋共享資料夾下同名檔案</string>
-    <string name="pref_keyboard">鍵盤</string>
+    <string name="pref_keyboard">偏好設定</string>
     <string name="key_sound">按鍵聲音</string>
     <string name="key_sound_volume">按鍵音量</string>
     <string name="key_vibrate">按鍵時振動</string>
@@ -109,9 +109,9 @@
     <string name="pref_help__general_channel">常規渠道</string>
     <string name="pref_help__marketplace">應用市場</string>
     <string name="pref_help__user_community">使用者社群</string>
-    <string name="pref_keyboard__appearance">外觀</string>
-    <string name="pref_keyboard__function">功能</string>
-    <string name="pref_keyboard__effect">效果</string>
+    <string name="pref_keyboard__function">檢視</string>
+    <string name="pref_keyboard__effect">按键效果</string>
     <string name="pref__draw_overlays_tip_title">顯示在其他應用上方</string>
     <string name="pref__draw_overlays_tip_message">要正確顯示候選欄，或從鍵盤開啟各項選單，您需要授予同文輸入法“顯示在其他應用上方”的許可權。點選“確定”前往設定頁，或“取消”以稍後手動設定。</string>
+    <string name="pref_keyboard_appearance">鍵盤外觀</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -74,6 +74,11 @@
         <item>輸入碼</item>
         <item>無</item>
     </string-array>
+    <string-array name="settings_theme__entries" >
+        <item name="auto">系統預設</item>
+        <item name="light">亮色</item>
+        <item name="dark">暗色</item>
+    </string-array>
     <string name="soft_cursor">編碼區使用插入符號(^)</string>
     <string name="pref_deploy">部署</string>
     <string name="pref_deploy_summary">修改設定後需要再次部署同文輸入法平臺</string>
@@ -101,4 +106,12 @@
     <string name="pref_sync_bg_failure">上次同步於 %s，失敗</string>
     <string name="pref_sync_bg_never">後台同步未運行</string>
     <string name="pref_sync_bg_tip">點擊以啟用後台同步</string>
+    <string name="pref_help__general_channel">常規渠道</string>
+    <string name="pref_help__marketplace">應用市場</string>
+    <string name="pref_help__user_community">使用者社群</string>
+    <string name="pref_keyboard__appearance">外觀</string>
+    <string name="pref_keyboard__function">功能</string>
+    <string name="pref_keyboard__effect">效果</string>
+    <string name="pref__draw_overlays_tip_title">顯示在其他應用上方</string>
+    <string name="pref__draw_overlays_tip_message">要正確顯示候選欄，或從鍵盤開啟各項選單，您需要授予同文輸入法“顯示在其他應用上方”的許可權。點選“確定”前往設定頁，或“取消”以稍後手動設定。</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- 本色彩方案取自 Rime 官网（https://rime.im） -->
+    <color name="colorPrimary">#3F4144</color> <!-- 浅主题色 -->
+    <color name="colorPrimaryDark">#37393D</color> <!-- 深主题色 -->
+    <color name="colorAccent">#009BD1</color>  <!-- 浅强调色 -->
+    <color name="colorAccentDark">#1976D2</color> <!-- 深强调色 -->
+    <color name="toolbarForegroundColor">#FFFFFF</color>  <!-- 工具栏前景色 -->
+</resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -33,7 +33,7 @@
     <string-array name="settings_theme__values">
         <item>auto</item>
         <item>light</item>
-        <item>default</item>
+        <item>dark</item>
     </string-array>
 
 

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -30,6 +30,12 @@
         <item>input</item>
         <item>none</item>
     </string-array>
+    <string-array name="pref__settings_theme__values">
+        <item>auto</item>
+        <item>light</item>
+        <item>default</item>
+    </string-array>
+
 
     <string name="default_shared_data_dir">/sdcard/rime</string>
     <string name="default_user_data_dir">/sdcard/rime</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -20,23 +20,23 @@
 -->
 
 <resources xmlns:xliff="urn:oasis:names:en:xliff:document:1.2">
-    <string name="pref_trime_qq_summary">811142286</string>
-    <string name="pref_trime_qq2_summary">458845988</string>
-    <string name="pref_rime_qq_summary">77608640</string>
-    <string name="pref_licensing_summary">GPLv3</string>
+    <string name="pref_trime_qq_summary" translatable="false">811142286</string>
+    <string name="pref_trime_qq2_summary" translatable="false">458845988</string>
+    <string name="pref_rime_qq_summary" translatable="false">77608640</string>
+    <string name="pref_licensing_summary" translatable="false">GPLv3</string>
     <string-array name="inline_values">
         <item>preview</item>
         <item>composition</item>
         <item>input</item>
         <item>none</item>
     </string-array>
-    <string-array name="pref__settings_theme__values">
+    <string-array name="settings_theme__values">
         <item>auto</item>
         <item>light</item>
         <item>default</item>
     </string-array>
 
 
-    <string name="default_shared_data_dir">/sdcard/rime</string>
-    <string name="default_user_data_dir">/sdcard/rime</string>
+    <string name="default_shared_data_dir" translatable="false">/sdcard/rime</string>
+    <string name="default_user_data_dir" translatable="false">/sdcard/rime</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,4 +101,10 @@
     <string name="pref_sync_bg_failure">Last background synchronized failed at %s</string>
     <string name="pref_sync_bg_never">Never synchronized background</string>
     <string name="pref_sync_bg_tip">Click to enable</string>
+    <string name="pref_help__general_channel">General Channel</string>
+    <string name="pref_help__marketplace">Marketplace</string>
+    <string name="pref_help__user_community">User Community</string>
+    <string name="pref_keyboard__appearance">Appearance</string>
+    <string name="pref_keyboard__function">Function</string>
+    <string name="pref_keyboard__effect">Effect</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,7 +76,7 @@
         <item>Input</item>
         <item>None</item>
     </string-array>
-    <string-array name="pref__settings_theme__entries" >
+    <string-array name="settings_theme__entries" >
         <item name="auto">System Default</item>
         <item name="light">Light</item>
         <item name="dark">Dark</item>
@@ -112,4 +112,6 @@
     <string name="pref_keyboard__appearance">Appearance</string>
     <string name="pref_keyboard__function">Function</string>
     <string name="pref_keyboard__effect">Effect</string>
+    <string name="pref__draw_overlays_tip_title">Display Over Other Apps</string>
+    <string name="pref__draw_overlays_tip_message">To display the candidate bar properly, or to open menus from the keyboard, you need to grant Trime permission to \"Display over other apps\". Click OK to go to the settings page, or cancel to set it manually later.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <string name="pref_credits">Credits</string>
     <string name="pref_pime">Win10 PRIME Platform</string>
     <string name="pref_privacy">Privacy Policy</string>
-    <string name="pref_input">Input</string>
+    <string name="pref_input">Input Setup</string>
     <string name="pref_enable">Enable</string>
     <string name="pref_enable_summary">Enable TRIME</string>
     <string name="pref_select">Change Keyboard</string>
@@ -55,7 +55,7 @@
     <string name="pref_colors_summary">Select Desired Color for Keyboard</string>
     <string name="pref_reset">Reset</string>
     <string name="pref_reset_summary">Use Default Settings to Replace the contents in shared directory</string>
-    <string name="pref_keyboard">Keyboard</string>
+    <string name="pref_keyboard">Preferences</string>
     <string name="key_sound">Sound on keypress</string>
     <string name="key_sound_volume">Volume on keypress</string>
     <string name="key_vibrate">Vibrate on keypress</string>
@@ -109,9 +109,9 @@
     <string name="pref_help__general_channel">General Channel</string>
     <string name="pref_help__marketplace">Marketplace</string>
     <string name="pref_help__user_community">User Community</string>
-    <string name="pref_keyboard__appearance">Appearance</string>
-    <string name="pref_keyboard__function">Function</string>
-    <string name="pref_keyboard__effect">Effect</string>
+    <string name="pref_keyboard__function">View</string>
+    <string name="pref_keyboard__effect">Keypress Effect</string>
     <string name="pref__draw_overlays_tip_title">Display Over Other Apps</string>
     <string name="pref__draw_overlays_tip_message">To display the candidate bar properly, or to open menus from the keyboard, you need to grant Trime permission to \"Display over other apps\". Click OK to go to the settings page, or cancel to set it manually later.</string>
+    <string name="pref_keyboard_appearance">Appearance</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,11 @@
         <item>Input</item>
         <item>None</item>
     </string-array>
+    <string-array name="pref__settings_theme__entries" >
+        <item name="auto">System Default</item>
+        <item name="light">Light</item>
+        <item name="dark">Dark</item>
+    </string-array>
     <string name="soft_cursor">Use soft cursor(^) in composition</string>
     <string name="pref_deploy">Deploy</string>
     <string name="pref_deploy_summary">Gotta Deploy after Modifying Settings </string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="PreferenceTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:colorAccent" tools:targetApi="lollipop">@color/colorAccent</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/theme.xml
+++ b/app/src/main/res/values/theme.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!--
     <style name="PreferenceTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:colorAccent" tools:targetApi="lollipop">@color/colorAccent</item>
-    </style> -->
+    </style>
 </resources>

--- a/app/src/main/res/xml/about_preference.xml
+++ b/app/src/main/res/xml/about_preference.xml
@@ -1,31 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <Preference android:key="pref_changelog" android:title="@string/pref_changelog">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Preference android:key="pref_changelog" android:title="@string/pref_changelog"
+        app:iconSpaceReserved="false">
         <intent android:action="android.intent.action.VIEW"
             android:data="https://github.com/osfans/trime" />
     </Preference>
-    <Preference android:key="pref_librime_ver" android:title="@string/pref_librime_ver">
+    <Preference android:key="pref_librime_ver" android:title="@string/pref_librime_ver"
+        app:iconSpaceReserved="false">
         <intent android:action="android.intent.action.VIEW"
             android:data="https://github.com/rime/librime" />
     </Preference>
-    <Preference android:key="pref_opencc_ver" android:title="@string/pref_opencc_ver">
+    <Preference android:key="pref_opencc_ver" android:title="@string/pref_opencc_ver"
+        app:iconSpaceReserved="false">
         <intent android:action="android.intent.action.VIEW"
             android:data="https://github.com/BYVoid/OpenCC" />
     </Preference>
-    <Preference android:key="pref_licensing" android:title="@string/pref_licensing" android:summary="@string/pref_licensing_summary"/>
-    <Preference android:key="pref_pravcy" android:title="@string/pref_privacy">
+    <Preference android:key="pref_licensing" android:title="@string/pref_licensing" android:summary="@string/pref_licensing_summary"
+        app:iconSpaceReserved="false"/>
+    <Preference android:key="pref_pravcy" android:title="@string/pref_privacy"
+        app:iconSpaceReserved="false">
         <intent android:action="android.intent.action.VIEW"
             android:data="https://github.com/osfans/trime/blob/develop/PRIVACY.md" />
     </Preference>
-    <Preference android:key="pref_pime" android:title="@string/pref_pime">
+    <Preference android:key="pref_pime" android:title="@string/pref_pime"
+        app:iconSpaceReserved="false">
         <intent android:action="android.intent.action.VIEW"
             android:data="https://github.com/osfans/PIME/releases" />
     </Preference>
-    <Preference android:key="pref_donate" android:title="@string/pref_donate" android:summary="@string/pref_donate_summary">
+    <Preference android:key="pref_donate" android:title="@string/pref_donate" android:summary="@string/pref_donate_summary"
+        app:iconSpaceReserved="false">
         <intent android:action="android.intent.action.VIEW"
             android:data="https://qr.alipay.com/tsx03439zwna78hloqtm6bc" />
     </Preference>
-    <Preference android:key="pref_credits" android:title="@string/pref_credits">
+    <Preference android:key="pref_credits" android:title="@string/pref_credits"
+        app:iconSpaceReserved="false">
         <intent android:action="android.intent.action.VIEW"
             android:data="https://github.com/osfans/trime/releases" />
     </Preference>

--- a/app/src/main/res/xml/about_preference.xml
+++ b/app/src/main/res/xml/about_preference.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <Preference android:key="pref_changelog" android:title="@string/pref_changelog">
+        <intent android:action="android.intent.action.VIEW"
+            android:data="https://github.com/osfans/trime" />
+    </Preference>
+    <Preference android:key="pref_librime_ver" android:title="@string/pref_librime_ver">
+        <intent android:action="android.intent.action.VIEW"
+            android:data="https://github.com/rime/librime" />
+    </Preference>
+    <Preference android:key="pref_opencc_ver" android:title="@string/pref_opencc_ver">
+        <intent android:action="android.intent.action.VIEW"
+            android:data="https://github.com/BYVoid/OpenCC" />
+    </Preference>
+    <Preference android:key="pref_licensing" android:title="@string/pref_licensing" android:summary="@string/pref_licensing_summary"/>
+    <Preference android:key="pref_pravcy" android:title="@string/pref_privacy">
+        <intent android:action="android.intent.action.VIEW"
+            android:data="https://github.com/osfans/trime/blob/develop/PRIVACY.md" />
+    </Preference>
+    <Preference android:key="pref_pime" android:title="@string/pref_pime">
+        <intent android:action="android.intent.action.VIEW"
+            android:data="https://github.com/osfans/PIME/releases" />
+    </Preference>
+    <Preference android:key="pref_donate" android:title="@string/pref_donate" android:summary="@string/pref_donate_summary">
+        <intent android:action="android.intent.action.VIEW"
+            android:data="https://qr.alipay.com/tsx03439zwna78hloqtm6bc" />
+    </Preference>
+    <Preference android:key="pref_credits" android:title="@string/pref_credits">
+        <intent android:action="android.intent.action.VIEW"
+            android:data="https://github.com/osfans/trime/releases" />
+    </Preference>
+</PreferenceScreen>

--- a/app/src/main/res/xml/appearance_preference.xml
+++ b/app/src/main/res/xml/appearance_preference.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Preference android:key="pref_themes"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_themes"
+        android:summary="@string/pref_themes_summary" />
+    <Preference android:key="pref_colors"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_colors"
+        android:summary="@string/pref_colors_summary" />
+</PreferenceScreen>

--- a/app/src/main/res/xml/help_preference.xml
+++ b/app/src/main/res/xml/help_preference.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:key="pref_help"
+    android:title="@string/pref_help">
+
+    <PreferenceCategory app:title="@string/pref_help__general_channel" app:key="pref_help__general_channel" >
+        <Preference android:key="pref_wiki" android:title="@string/pref_wiki">
+            <intent android:action="android.intent.action.VIEW"
+                android:data="https://github.com/osfans/trime/wiki/UserGuide" />
+        </Preference>
+        <Preference android:key="pref_issues" android:title="@string/pref_issues">
+            <intent android:action="android.intent.action.VIEW"
+                android:data="https://github.com/osfans/trime/issues" />
+        </Preference>
+    </PreferenceCategory>
+
+    <PreferenceCategory app:title="@string/pref_help__marketplace" app:key="pref_help__marketplace">
+        <Preference android:key="pref_market" android:title="@string/pref_market">
+            <intent android:action="android.intent.action.VIEW"
+                android:data="https://play.google.com/store/apps/details?id=com.osfans.trime" />
+        </Preference>
+        <Preference android:key="pref_coolmarket" android:title="@string/pref_coolmarket">
+            <intent android:action="android.intent.action.VIEW"
+                android:data="https://www.coolapk.com/apk/com.osfans.trime" />
+        </Preference>
+    </PreferenceCategory>
+
+    <PreferenceCategory app:title="@string/pref_help__user_community" app:key="pref_help__user_community" >
+        <Preference android:key="pref_trime_qq" android:title="@string/pref_trime_qq"
+            android:summary="@string/pref_trime_qq_summary">
+            <intent android:action="android.intent.action.VIEW"
+                android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3DzifdI0iaEYjATwYkvVzP1cjsUEWSa9Ha" />
+        </Preference>
+        <Preference android:key="pref_trime_qq2" android:title="@string/pref_trime_qq2"
+            android:summary="@string/pref_trime_qq2_summary">
+            <intent android:action="android.intent.action.VIEW"
+                android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3D46XegYX4TQW366gVRKAUhTgtFYmYw7G3" />
+        </Preference>
+        <Preference android:key="pref_rime_qq" android:title="@string/pref_rime_qq"
+            android:summary="@string/pref_rime_qq_summary">
+            <intent android:action="android.intent.action.VIEW"
+                android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3Dm505aYSeLZjOwWeMNAViWylZZDYqMrxV" />
+        </Preference>
+    </PreferenceCategory>
+
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/help_preference.xml
+++ b/app/src/main/res/xml/help_preference.xml
@@ -4,40 +4,56 @@
     android:key="pref_help"
     android:title="@string/pref_help">
 
-    <PreferenceCategory app:title="@string/pref_help__general_channel" app:key="pref_help__general_channel" >
-        <Preference android:key="pref_wiki" android:title="@string/pref_wiki">
+    <PreferenceCategory app:iconSpaceReserved="false"
+        app:title="@string/pref_help__general_channel"
+        app:key="pref_help__general_channel" >
+        <Preference android:key="pref_wiki" android:title="@string/pref_wiki"
+            app:iconSpaceReserved="false">
             <intent android:action="android.intent.action.VIEW"
                 android:data="https://github.com/osfans/trime/wiki/UserGuide" />
         </Preference>
-        <Preference android:key="pref_issues" android:title="@string/pref_issues">
+        <Preference android:key="pref_issues" android:title="@string/pref_issues"
+            app:iconSpaceReserved="false">
             <intent android:action="android.intent.action.VIEW"
                 android:data="https://github.com/osfans/trime/issues" />
         </Preference>
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/pref_help__marketplace" app:key="pref_help__marketplace">
-        <Preference android:key="pref_market" android:title="@string/pref_market">
+    <PreferenceCategory app:iconSpaceReserved="false"
+        app:title="@string/pref_help__marketplace"
+        app:key="pref_help__marketplace">
+        <Preference android:key="pref_market" android:title="@string/pref_market"
+            app:iconSpaceReserved="false">
             <intent android:action="android.intent.action.VIEW"
                 android:data="https://play.google.com/store/apps/details?id=com.osfans.trime" />
         </Preference>
-        <Preference android:key="pref_coolmarket" android:title="@string/pref_coolmarket">
+        <Preference android:key="pref_coolmarket" android:title="@string/pref_coolmarket"
+            app:iconSpaceReserved="false">
             <intent android:action="android.intent.action.VIEW"
                 android:data="https://www.coolapk.com/apk/com.osfans.trime" />
         </Preference>
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/pref_help__user_community" app:key="pref_help__user_community" >
-        <Preference android:key="pref_trime_qq" android:title="@string/pref_trime_qq"
+    <PreferenceCategory app:iconSpaceReserved="false"
+        app:title="@string/pref_help__user_community"
+        app:key="pref_help__user_community" >
+        <Preference android:key="pref_trime_qq"
+            app:iconSpaceReserved="false"
+            android:title="@string/pref_trime_qq"
             android:summary="@string/pref_trime_qq_summary">
             <intent android:action="android.intent.action.VIEW"
                 android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3DzifdI0iaEYjATwYkvVzP1cjsUEWSa9Ha" />
         </Preference>
-        <Preference android:key="pref_trime_qq2" android:title="@string/pref_trime_qq2"
+        <Preference android:key="pref_trime_qq2"
+            app:iconSpaceReserved="false"
+            android:title="@string/pref_trime_qq2"
             android:summary="@string/pref_trime_qq2_summary">
             <intent android:action="android.intent.action.VIEW"
                 android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3D46XegYX4TQW366gVRKAUhTgtFYmYw7G3" />
         </Preference>
-        <Preference android:key="pref_rime_qq" android:title="@string/pref_rime_qq"
+        <Preference android:key="pref_rime_qq"
+            app:iconSpaceReserved="false"
+            android:title="@string/pref_rime_qq"
             android:summary="@string/pref_rime_qq_summary">
             <intent android:action="android.intent.action.VIEW"
                 android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3Dm505aYSeLZjOwWeMNAViWylZZDYqMrxV" />

--- a/app/src/main/res/xml/input_preference.xml
+++ b/app/src/main/res/xml/input_preference.xml
@@ -16,11 +16,6 @@
         android:defaultValue="@string/default_user_data_dir"
         app:useSimpleSummaryProvider="true"/>
 
-    <Preference android:key="pref_schemas"
-        app:iconSpaceReserved="false"
-        android:title="@string/pref_schemas"
-        android:summary="@string/pref_schemas_summary"/>
-
     <Preference android:key="pref_sync"
         app:iconSpaceReserved="false"
         android:title="@string/pref_sync"

--- a/app/src/main/res/xml/input_preference.xml
+++ b/app/src/main/res/xml/input_preference.xml
@@ -1,10 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    android:key="pref_input" android:title="@string/pref_input">
-    <EditTextPreference android:key="shared_data_dir" android:title="@string/shared_data_dir" android:defaultValue="@string/default_shared_data_dir" />
-    <EditTextPreference android:key="user_data_dir" android:title="@string/user_data_dir" android:defaultValue="@string/default_user_data_dir"/>
-    <Preference android:key="pref_schemas" android:title="@string/pref_schemas" android:summary="@string/pref_schemas_summary"/>
-    <Preference android:key="pref_sync" android:title="@string/pref_sync" android:summary="@string/pref_sync_summary"/>
-    <SwitchPreference android:key="pref_sync_bg" android:title="@string/pref_sync_bg" android:summary="@string/pref_sync_bg_tip" android:persistent="true" />
-    <Preference android:key="pref_reset" android:title="@string/pref_reset" android:summary="@string/pref_reset_summary"/>
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:key="pref_input"
+    android:title="@string/pref_input">
+
+    <EditTextPreference android:key="shared_data_dir"
+        app:iconSpaceReserved="false"
+        android:title="@string/shared_data_dir"
+        android:defaultValue="@string/default_shared_data_dir"
+        app:useSimpleSummaryProvider="true"/>
+
+    <EditTextPreference android:key="user_data_dir"
+        app:iconSpaceReserved="false"
+        android:title="@string/user_data_dir"
+        android:defaultValue="@string/default_user_data_dir"
+        app:useSimpleSummaryProvider="true"/>
+
+    <Preference android:key="pref_schemas"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_schemas"
+        android:summary="@string/pref_schemas_summary"/>
+
+    <Preference android:key="pref_sync"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_sync"
+        android:summary="@string/pref_sync_summary"/>
+
+    <SwitchPreference android:key="pref_sync_bg"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_sync_bg"
+        android:summary="@string/pref_sync_bg_tip"
+        android:persistent="true" />
+
+    <Preference android:key="pref_reset"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_reset"
+        android:summary="@string/pref_reset_summary"/>
 </PreferenceScreen>

--- a/app/src/main/res/xml/input_preference.xml
+++ b/app/src/main/res/xml/input_preference.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:key="pref_input" android:title="@string/pref_input">
+    <EditTextPreference android:key="shared_data_dir" android:title="@string/shared_data_dir" android:defaultValue="@string/default_shared_data_dir" />
+    <EditTextPreference android:key="user_data_dir" android:title="@string/user_data_dir" android:defaultValue="@string/default_user_data_dir"/>
+    <Preference android:key="pref_schemas" android:title="@string/pref_schemas" android:summary="@string/pref_schemas_summary"/>
+    <Preference android:key="pref_sync" android:title="@string/pref_sync" android:summary="@string/pref_sync_summary"/>
+    <SwitchPreference android:key="pref_sync_bg" android:title="@string/pref_sync_bg" android:summary="@string/pref_sync_bg_tip" android:persistent="true" />
+    <Preference android:key="pref_reset" android:title="@string/pref_reset" android:summary="@string/pref_reset_summary"/>
+</PreferenceScreen>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:key="pref_keyboard" android:title="@string/pref_keyboard">
+    <Preference android:key="pref_themes" android:title="@string/pref_themes" android:summary="@string/pref_themes_summary"/>
+    <Preference android:key="pref_colors" android:title="@string/pref_colors" android:summary="@string/pref_colors_summary"/>
+    <ListPreference android:key="inline_preedit" android:title="@string/inline_preedit" android:entries="@array/inline_entries" android:entryValues="@array/inline_values" android:defaultValue="preview"/>
+    <SwitchPreference android:key="soft_cursor" android:title="@string/soft_cursor" android:defaultValue="true"/>
+    <SwitchPreference android:key="show_window" android:title="@string/show_window" android:defaultValue="true"/>
+    <SwitchPreference android:key="show_preview" android:title="@string/show_preview" android:defaultValue="false"/>
+    <SwitchPreference android:key="key_sound" android:title="@string/key_sound"/>
+    <SeekBarPreference
+        android:widgetLayout="@layout/preference_widget_seekbar"
+        android:key="key_sound_volume"
+        android:title="@string/key_sound_volume"
+        android:max="100"
+        android:defaultValue="100" />
+    <SwitchPreference android:key="key_vibrate" android:title="@string/key_vibrate"/>
+    <SeekBarPreference
+        android:widgetLayout="@layout/preference_widget_seekbar"
+        android:key="key_vibrate_duration"
+        android:title="@string/key_vibrate_duration"
+        android:max="100"
+        android:defaultValue="10" />
+    <SeekBarPreference
+        android:widgetLayout="@layout/preference_widget_seekbar"
+        android:key="key_vibrate_amplitude"
+        android:title="@string/key_vibrate_amplitude"
+        android:max="255"
+        android:defaultValue="0"/>
+    <!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
+    <SwitchPreference android:key="speak_key" android:title="@string/speak_key"/>
+    <SwitchPreference android:key="speak_commit" android:title="@string/speak_commit"/>
+    <SeekBarPreference
+        android:widgetLayout="@layout/preference_widget_seekbar"
+        android:key="longpress_timeout"
+        android:title="@string/longpress_timeout"
+        android:max="60"
+        android:defaultValue="20" />
+    <SeekBarPreference
+        android:widgetLayout="@layout/preference_widget_seekbar"
+        android:key="repeat_interval"
+        android:title="@string/repeat_interval"
+        android:max="9"
+        android:defaultValue="4" />
+    <SwitchPreference android:key="show_switches" android:title="@string/show_switches" android:defaultValue="true" />
+</PreferenceScreen>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -1,49 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    android:key="pref_keyboard" android:title="@string/pref_keyboard">
-    <Preference android:key="pref_themes" android:title="@string/pref_themes" android:summary="@string/pref_themes_summary"/>
-    <Preference android:key="pref_colors" android:title="@string/pref_colors" android:summary="@string/pref_colors_summary"/>
-    <ListPreference android:key="inline_preedit" android:title="@string/inline_preedit" android:entries="@array/inline_entries" android:entryValues="@array/inline_values" android:defaultValue="preview"/>
-    <SwitchPreference android:key="soft_cursor" android:title="@string/soft_cursor" android:defaultValue="true"/>
-    <SwitchPreference android:key="show_window" android:title="@string/show_window" android:defaultValue="true"/>
-    <SwitchPreference android:key="show_preview" android:title="@string/show_preview" android:defaultValue="false"/>
-    <SwitchPreference android:key="key_sound" android:title="@string/key_sound"/>
-    <SeekBarPreference
-        android:widgetLayout="@layout/preference_widget_seekbar"
-        android:key="key_sound_volume"
-        android:title="@string/key_sound_volume"
-        android:max="100"
-        android:defaultValue="100"
-        android:dependency="key_sound"/>
-    <SwitchPreference android:key="key_vibrate" android:title="@string/key_vibrate"/>
-    <SeekBarPreference
-        android:widgetLayout="@layout/preference_widget_seekbar"
-        android:key="key_vibrate_duration"
-        android:title="@string/key_vibrate_duration"
-        android:max="100"
-        android:defaultValue="10"
-        android:dependency="key_vibrate"/>
-    <SeekBarPreference
-        android:widgetLayout="@layout/preference_widget_seekbar"
-        android:key="key_vibrate_amplitude"
-        android:title="@string/key_vibrate_amplitude"
-        android:max="255"
-        android:defaultValue="0"
-        android:dependency="key_vibrate"/>
-    <!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
-    <SwitchPreference android:key="speak_key" android:title="@string/speak_key"/>
-    <SwitchPreference android:key="speak_commit" android:title="@string/speak_commit"/>
-    <SeekBarPreference
-        android:widgetLayout="@layout/preference_widget_seekbar"
-        android:key="longpress_timeout"
-        android:title="@string/longpress_timeout"
-        android:max="60"
-        android:defaultValue="20" />
-    <SeekBarPreference
-        android:widgetLayout="@layout/preference_widget_seekbar"
-        android:key="repeat_interval"
-        android:title="@string/repeat_interval"
-        android:max="9"
-        android:defaultValue="4" />
-    <SwitchPreference android:key="show_switches" android:title="@string/show_switches" android:defaultValue="true" />
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:key="pref_keyboard"
+    android:title="@string/pref_keyboard">
+    <PreferenceCategory app:title="@string/pref_keyboard__appearance" app:key="pref_keyboard__appearance" >
+        <Preference android:key="pref_themes"
+            android:title="@string/pref_themes"
+            android:summary="@string/pref_themes_summary"/>
+        <Preference android:key="pref_colors"
+            android:title="@string/pref_colors"
+            android:summary="@string/pref_colors_summary"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory app:title="@string/pref_keyboard__function" app:key="pref_keyboard__function" >
+        <ListPreference android:key="inline_preedit" android:title="@string/inline_preedit" android:entries="@array/inline_entries" android:entryValues="@array/inline_values" android:defaultValue="preview"/>
+        <SwitchPreference android:key="soft_cursor" android:title="@string/soft_cursor" android:defaultValue="true"/>
+        <SwitchPreference android:key="show_window" android:title="@string/show_window" android:defaultValue="true"/>
+        <SwitchPreference android:key="show_preview" android:title="@string/show_preview" android:defaultValue="false"/>
+        <SwitchPreference android:key="show_switches" android:title="@string/show_switches" android:defaultValue="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory app:title="@string/pref_keyboard__effect" app:key="pref_keyboard__effect" >
+        <SwitchPreference android:key="key_sound" android:title="@string/key_sound"/>
+        <SeekBarPreference
+            android:widgetLayout="@layout/preference_widget_seekbar"
+            android:key="key_sound_volume"
+            android:title="@string/key_sound_volume"
+            android:max="100"
+            android:defaultValue="100"
+            android:dependency="key_sound"/>
+        <SwitchPreference android:key="key_vibrate" android:title="@string/key_vibrate"/>
+        <SeekBarPreference
+            android:widgetLayout="@layout/preference_widget_seekbar"
+            android:key="key_vibrate_duration"
+            android:title="@string/key_vibrate_duration"
+            android:max="100"
+            android:defaultValue="10"
+            android:dependency="key_vibrate"/>
+        <SeekBarPreference
+            android:widgetLayout="@layout/preference_widget_seekbar"
+            android:key="key_vibrate_amplitude"
+            android:title="@string/key_vibrate_amplitude"
+            android:max="255"
+            android:defaultValue="0"
+            android:dependency="key_vibrate"/>
+        <!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
+        <SwitchPreference android:key="speak_key" android:title="@string/speak_key"/>
+        <SwitchPreference android:key="speak_commit" android:title="@string/speak_commit"/>
+        <SeekBarPreference
+            android:widgetLayout="@layout/preference_widget_seekbar"
+            android:key="longpress_timeout"
+            android:title="@string/longpress_timeout"
+            android:max="60"
+            android:defaultValue="20" />
+        <SeekBarPreference
+            android:widgetLayout="@layout/preference_widget_seekbar"
+            android:key="repeat_interval"
+            android:title="@string/repeat_interval"
+            android:max="9"
+            android:defaultValue="4" />
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -3,36 +3,67 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:key="pref_keyboard"
     android:title="@string/pref_keyboard">
-    <PreferenceCategory app:title="@string/pref_keyboard__appearance" app:key="pref_keyboard__appearance" >
+    <PreferenceCategory app:iconSpaceReserved="false"
+        app:title="@string/pref_keyboard__appearance"
+        app:key="pref_keyboard__appearance" >
         <Preference android:key="pref_themes"
+            app:iconSpaceReserved="false"
             android:title="@string/pref_themes"
             android:summary="@string/pref_themes_summary" />
         <Preference android:key="pref_colors"
+            app:iconSpaceReserved="false"
             android:title="@string/pref_colors"
             android:summary="@string/pref_colors_summary" />
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/pref_keyboard__function" app:key="pref_keyboard__function" >
-        <ListPreference android:key="inline_preedit" android:title="@string/inline_preedit" android:entries="@array/inline_entries" android:entryValues="@array/inline_values" android:defaultValue="preview"/>
-        <SwitchPreference android:key="soft_cursor" android:title="@string/soft_cursor" android:defaultValue="true"/>
-        <SwitchPreference android:key="show_window" android:title="@string/show_window" android:defaultValue="true"/>
-        <SwitchPreference android:key="show_preview" android:title="@string/show_preview" android:defaultValue="false"/>
-        <SwitchPreference android:key="show_switches" android:title="@string/show_switches" android:defaultValue="true" />
+    <PreferenceCategory app:iconSpaceReserved="false"
+        app:title="@string/pref_keyboard__function"
+        app:key="pref_keyboard__function" >
+        <ListPreference android:key="inline_preedit"
+            app:iconSpaceReserved="false"
+            android:title="@string/inline_preedit"
+            android:entries="@array/inline_entries"
+            android:entryValues="@array/inline_values"
+            android:defaultValue="preview"/>
+        <SwitchPreference android:key="soft_cursor"
+            app:iconSpaceReserved="false"
+            android:title="@string/soft_cursor"
+            android:defaultValue="true"/>
+        <SwitchPreference android:key="show_window"
+            app:iconSpaceReserved="false"
+            android:title="@string/show_window"
+            android:defaultValue="true"/>
+        <SwitchPreference android:key="show_preview"
+            app:iconSpaceReserved="false"
+            android:title="@string/show_preview"
+            android:defaultValue="false"/>
+        <SwitchPreference android:key="show_switches"
+            app:iconSpaceReserved="false"
+            android:title="@string/show_switches"
+            android:defaultValue="true" />
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/pref_keyboard__effect" app:key="pref_keyboard__effect" >
-        <SwitchPreference android:key="key_sound" android:title="@string/key_sound"/>
+    <PreferenceCategory app:iconSpaceReserved="false"
+        app:title="@string/pref_keyboard__effect"
+        app:key="pref_keyboard__effect" >
+        <SwitchPreference android:key="key_sound"
+            app:iconSpaceReserved="false"
+            android:title="@string/key_sound"/>
         <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="key_sound_volume"
+            app:iconSpaceReserved="false"
             android:title="@string/key_sound_volume"
             android:max="100"
             android:defaultValue="100"
             android:dependency="key_sound"/>
-        <SwitchPreference android:key="key_vibrate" android:title="@string/key_vibrate"/>
+        <SwitchPreference android:key="key_vibrate"
+            app:iconSpaceReserved="false"
+            android:title="@string/key_vibrate"/>
         <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="key_vibrate_duration"
+            app:iconSpaceReserved="false"
             android:title="@string/key_vibrate_duration"
             android:max="100"
             android:defaultValue="10"
@@ -40,22 +71,29 @@
         <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="key_vibrate_amplitude"
+            app:iconSpaceReserved="false"
             android:title="@string/key_vibrate_amplitude"
             android:max="255"
             android:defaultValue="0"
             android:dependency="key_vibrate"/>
         <!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
-        <SwitchPreference android:key="speak_key" android:title="@string/speak_key"/>
-        <SwitchPreference android:key="speak_commit" android:title="@string/speak_commit"/>
+        <SwitchPreference android:key="speak_key"
+            app:iconSpaceReserved="false"
+            android:title="@string/speak_key"/>
+        <SwitchPreference android:key="speak_commit"
+            app:iconSpaceReserved="false"
+            android:title="@string/speak_commit"/>
         <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="longpress_timeout"
+            app:iconSpaceReserved="false"
             android:title="@string/longpress_timeout"
             android:max="60"
             android:defaultValue="20" />
         <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="repeat_interval"
+            app:iconSpaceReserved="false"
             android:title="@string/repeat_interval"
             android:max="9"
             android:defaultValue="4" />

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -13,20 +13,23 @@
         android:key="key_sound_volume"
         android:title="@string/key_sound_volume"
         android:max="100"
-        android:defaultValue="100" />
+        android:defaultValue="100"
+        android:dependency="key_sound"/>
     <SwitchPreference android:key="key_vibrate" android:title="@string/key_vibrate"/>
     <SeekBarPreference
         android:widgetLayout="@layout/preference_widget_seekbar"
         android:key="key_vibrate_duration"
         android:title="@string/key_vibrate_duration"
         android:max="100"
-        android:defaultValue="10" />
+        android:defaultValue="10"
+        android:dependency="key_vibrate"/>
     <SeekBarPreference
         android:widgetLayout="@layout/preference_widget_seekbar"
         android:key="key_vibrate_amplitude"
         android:title="@string/key_vibrate_amplitude"
         android:max="255"
-        android:defaultValue="0"/>
+        android:defaultValue="0"
+        android:dependency="key_vibrate"/>
     <!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
     <SwitchPreference android:key="speak_key" android:title="@string/speak_key"/>
     <SwitchPreference android:key="speak_commit" android:title="@string/speak_commit"/>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -3,18 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:key="pref_keyboard"
     android:title="@string/pref_keyboard">
-    <PreferenceCategory app:iconSpaceReserved="false"
-        app:title="@string/pref_keyboard__appearance"
-        app:key="pref_keyboard__appearance" >
-        <Preference android:key="pref_themes"
-            app:iconSpaceReserved="false"
-            android:title="@string/pref_themes"
-            android:summary="@string/pref_themes_summary" />
-        <Preference android:key="pref_colors"
-            app:iconSpaceReserved="false"
-            android:title="@string/pref_colors"
-            android:summary="@string/pref_colors_summary" />
-    </PreferenceCategory>
 
     <PreferenceCategory app:iconSpaceReserved="false"
         app:title="@string/pref_keyboard__function"
@@ -24,7 +12,8 @@
             android:title="@string/inline_preedit"
             android:entries="@array/inline_entries"
             android:entryValues="@array/inline_values"
-            android:defaultValue="preview"/>
+            android:defaultValue="preview"
+            app:useSimpleSummaryProvider="true"/>
         <SwitchPreference android:key="soft_cursor"
             app:iconSpaceReserved="false"
             android:title="@string/soft_cursor"

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -6,10 +6,10 @@
     <PreferenceCategory app:title="@string/pref_keyboard__appearance" app:key="pref_keyboard__appearance" >
         <Preference android:key="pref_themes"
             android:title="@string/pref_themes"
-            android:summary="@string/pref_themes_summary"/>
+            android:summary="@string/pref_themes_summary" />
         <Preference android:key="pref_colors"
             android:title="@string/pref_colors"
-            android:summary="@string/pref_colors_summary"/>
+            android:summary="@string/pref_colors_summary" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/pref_keyboard__function" app:key="pref_keyboard__function" >
@@ -22,7 +22,7 @@
 
     <PreferenceCategory app:title="@string/pref_keyboard__effect" app:key="pref_keyboard__effect" >
         <SwitchPreference android:key="key_sound" android:title="@string/key_sound"/>
-        <SeekBarPreference
+        <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="key_sound_volume"
             android:title="@string/key_sound_volume"
@@ -30,14 +30,14 @@
             android:defaultValue="100"
             android:dependency="key_sound"/>
         <SwitchPreference android:key="key_vibrate" android:title="@string/key_vibrate"/>
-        <SeekBarPreference
+        <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="key_vibrate_duration"
             android:title="@string/key_vibrate_duration"
             android:max="100"
             android:defaultValue="10"
             android:dependency="key_vibrate"/>
-        <SeekBarPreference
+        <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="key_vibrate_amplitude"
             android:title="@string/key_vibrate_amplitude"
@@ -47,13 +47,13 @@
         <!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
         <SwitchPreference android:key="speak_key" android:title="@string/speak_key"/>
         <SwitchPreference android:key="speak_commit" android:title="@string/speak_commit"/>
-        <SeekBarPreference
+        <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="longpress_timeout"
             android:title="@string/longpress_timeout"
             android:max="60"
             android:defaultValue="20" />
-        <SeekBarPreference
+        <com.osfans.trime.settings.components.SeekBarPreference
             android:widgetLayout="@layout/preference_widget_seekbar"
             android:key="repeat_interval"
             android:title="@string/repeat_interval"

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -20,5 +20,5 @@
 -->
 
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
-        android:settingsActivity="com.osfans.trime.Pref"
+        android:settingsActivity="com.osfans.trime.settings.PrefMainActivity"
 />

--- a/app/src/main/res/xml/other_preference.xml
+++ b/app/src/main/res/xml/other_preference.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <SwitchPreference android:key="pref_notification_icon" android:title="@string/pref_notification_icon" />
+    <SwitchPreference android:key="pref_destroy_on_quit" android:title="@string/pref_destroy_on_quit" />
+</PreferenceScreen>

--- a/app/src/main/res/xml/other_preference.xml
+++ b/app/src/main/res/xml/other_preference.xml
@@ -3,8 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <ListPreference
         android:defaultValue="auto"
-        app:entries="@array/pref__settings_theme__entries"
-        app:entryValues="@array/pref__settings_theme__values"
+        app:entries="@array/settings_theme__entries"
+        app:entryValues="@array/settings_theme__values"
         app:key="pref__settings_theme"
         app:title="@string/pref_ui"
         app:useSimpleSummaryProvider="true" />

--- a/app/src/main/res/xml/other_preference.xml
+++ b/app/src/main/res/xml/other_preference.xml
@@ -3,12 +3,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <ListPreference
         android:defaultValue="auto"
+        app:iconSpaceReserved="false"
         app:entries="@array/settings_theme__entries"
         app:entryValues="@array/settings_theme__values"
         app:key="pref__settings_theme"
         app:title="@string/pref_ui"
         app:useSimpleSummaryProvider="true" />
 
-    <SwitchPreference android:key="pref_notification_icon" android:title="@string/pref_notification_icon" />
-    <SwitchPreference android:key="pref_destroy_on_quit" android:title="@string/pref_destroy_on_quit" />
+    <SwitchPreference android:key="pref_notification_icon"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_notification_icon" />
+    <SwitchPreference android:key="pref_destroy_on_quit"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_destroy_on_quit" />
 </PreferenceScreen>

--- a/app/src/main/res/xml/other_preference.xml
+++ b/app/src/main/res/xml/other_preference.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <ListPreference
+        android:defaultValue="auto"
+        app:entries="@array/pref__settings_theme__entries"
+        app:entryValues="@array/pref__settings_theme__values"
+        app:key="pref__settings_theme"
+        app:title="@string/pref_ui"
+        app:useSimpleSummaryProvider="true" />
+
     <SwitchPreference android:key="pref_notification_icon" android:title="@string/pref_notification_icon" />
     <SwitchPreference android:key="pref_destroy_on_quit" android:title="@string/pref_destroy_on_quit" />
 </PreferenceScreen>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -22,10 +22,10 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/ime_name">
 
-    <SwitchPreference android:key="pref_ui"
+    <!-- <SwitchPreference android:key="pref_ui"
         android:order="1"
         android:title="@string/pref_ui"
-        android:persistent="true" />
+        android:persistent="true" /> -->
 
     <Preference
         android:key="pref_enable"

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -26,67 +26,17 @@
     <Preference android:key="pref_enable" android:order="2" android:title="@string/pref_enable" android:summary="@string/pref_enable_summary"/>
     <Preference android:key="pref_select" android:order="3" android:title="@string/pref_select" android:summary="@string/pref_select_summary"/>
 
-    <PreferenceScreen android:key="pref_keyboard" android:order="4" android:title="@string/pref_keyboard">
-        <Preference android:key="pref_themes" android:title="@string/pref_themes" android:summary="@string/pref_themes_summary"/>
-        <Preference android:key="pref_colors" android:title="@string/pref_colors" android:summary="@string/pref_colors_summary"/>
-        <ListPreference android:key="inline_preedit" android:title="@string/inline_preedit" android:entries="@array/inline_entries" android:entryValues="@array/inline_values" android:defaultValue="preview"/>
-        <SwitchPreference android:key="soft_cursor" android:title="@string/soft_cursor" android:defaultValue="true"/>
-        <SwitchPreference android:key="show_window" android:title="@string/show_window" android:defaultValue="true"/>
-        <SwitchPreference android:key="show_preview" android:title="@string/show_preview" android:defaultValue="false"/>
-        <SwitchPreference android:key="key_sound" android:title="@string/key_sound"/>
-        <com.osfans.trime.SeekBarPreference
-            android:widgetLayout="@layout/preference_widget_seekbar"
-            android:key="key_sound_volume"
-            android:title="@string/key_sound_volume"
-            android:max="100"
-            android:defaultValue="100" />
-        <SwitchPreference android:key="key_vibrate" android:title="@string/key_vibrate"/>
-        <com.osfans.trime.SeekBarPreference
-            android:widgetLayout="@layout/preference_widget_seekbar"
-            android:key="key_vibrate_duration"
-            android:title="@string/key_vibrate_duration"
-            android:max="100"
-            android:defaultValue="10" />
-        <com.osfans.trime.SeekBarPreference
-            android:widgetLayout="@layout/preference_widget_seekbar"
-            android:key="key_vibrate_amplitude"
-            android:title="@string/key_vibrate_amplitude"
-            android:max="255"
-            android:defaultValue="0"/>
-<!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
-        <SwitchPreference android:key="speak_key" android:title="@string/speak_key"/>
-        <SwitchPreference android:key="speak_commit" android:title="@string/speak_commit"/>
-        <com.osfans.trime.SeekBarPreference
-            android:widgetLayout="@layout/preference_widget_seekbar"
-            android:key="longpress_timeout"
-            android:title="@string/longpress_timeout"
-            android:max="60"
-            android:defaultValue="20" />
-        <com.osfans.trime.SeekBarPreference
-            android:widgetLayout="@layout/preference_widget_seekbar"
-            android:key="repeat_interval"
-            android:title="@string/repeat_interval"
-            android:max="9"
-            android:defaultValue="4" />
-        <SwitchPreference android:key="show_switches" android:title="@string/show_switches" android:defaultValue="true" />
-    </PreferenceScreen>
+    <Preference android:key="pref_keyboard" android:order="4" android:title="@string/pref_keyboard"
+        android:fragment="com.osfans.trime.settings.fragments.KeyboardFragment"/>
 
-    <PreferenceScreen android:key="pref_input" android:order="8" android:title="@string/pref_input">
-        <EditTextPreference android:key="shared_data_dir" android:title="@string/shared_data_dir" android:defaultValue="@string/default_shared_data_dir" />
-        <EditTextPreference android:key="user_data_dir" android:title="@string/user_data_dir" android:defaultValue="@string/default_user_data_dir"/>
-        <Preference android:key="pref_schemas" android:title="@string/pref_schemas" android:summary="@string/pref_schemas_summary"/>
-        <Preference android:key="pref_sync" android:title="@string/pref_sync" android:summary="@string/pref_sync_summary"/>
-        <SwitchPreference android:key="pref_sync_bg" android:title="@string/pref_sync_bg" android:summary="@string/pref_sync_bg_tip" android:persistent="true" />
-        <Preference android:key="pref_reset" android:title="@string/pref_reset" android:summary="@string/pref_reset_summary"/>
-    </PreferenceScreen>
+    <Preference android:key="pref_input" android:order="8" android:title="@string/pref_input"
+        android:fragment="com.osfans.trime.settings.fragments.InputFragment"/>
 
     <Preference android:key="pref_deploy" android:order="16"
         android:title="@string/pref_deploy" android:summary="@string/pref_deploy_summary"/>
 
-    <PreferenceScreen android:key="pref_other" android:order="17" android:title="@string/pref_other">
-        <SwitchPreference android:key="pref_notification_icon" android:title="@string/pref_notification_icon" />
-        <SwitchPreference android:key="pref_destroy_on_quit" android:title="@string/pref_destroy_on_quit" />
-    </PreferenceScreen>
+    <Preference android:key="pref_other" android:order="17" android:title="@string/pref_other"
+        android:fragment="com.osfans.trime.settings.fragments.OtherFragment"/>
 
     <PreferenceScreen android:key="pref_help" android:order="32" android:title="@string/pref_help">
         <Preference android:key="pref_wiki" android:title="@string/pref_wiki">

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -20,6 +20,7 @@
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/ime_name">
 
     <!-- <SwitchPreference android:key="pref_ui"
@@ -38,10 +39,20 @@
         android:title="@string/pref_select"
         android:summary="@string/pref_select_summary"/>
 
-    <Preference android:key="pref_keyboard"
+    <Preference android:key="pref_schemas"
         android:order="4"
+        android:title="@string/pref_schemas"
+        android:summary="@string/pref_schemas_summary"/>
+
+    <Preference android:key="pref_keyboard"
+        android:order="5"
         android:title="@string/pref_keyboard"
         android:fragment="com.osfans.trime.settings.fragments.KeyboardFragment"/>
+
+    <Preference android:key="pref_keyboard_appearance"
+        android:order="6"
+        android:title="@string/pref_keyboard_appearance"
+        android:fragment="com.osfans.trime.settings.fragments.AppearanceFragment"/>
 
     <Preference android:key="pref_input"
         android:order="8"

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -22,86 +22,46 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/ime_name">
 
-    <SwitchPreference android:key="pref_ui" android:order="1" android:title="@string/pref_ui" android:persistent="true" />
-    <Preference android:key="pref_enable" android:order="2" android:title="@string/pref_enable" android:summary="@string/pref_enable_summary"/>
-    <Preference android:key="pref_select" android:order="3" android:title="@string/pref_select" android:summary="@string/pref_select_summary"/>
+    <SwitchPreference android:key="pref_ui"
+        android:order="1"
+        android:title="@string/pref_ui"
+        android:persistent="true" />
 
-    <Preference android:key="pref_keyboard" android:order="4" android:title="@string/pref_keyboard"
+    <Preference
+        android:key="pref_enable"
+        android:order="2"
+        android:title="@string/pref_enable"
+        android:summary="@string/pref_enable_summary"/>
+
+    <Preference android:key="pref_select"
+        android:order="3"
+        android:title="@string/pref_select"
+        android:summary="@string/pref_select_summary"/>
+
+    <Preference android:key="pref_keyboard"
+        android:order="4"
+        android:title="@string/pref_keyboard"
         android:fragment="com.osfans.trime.settings.fragments.KeyboardFragment"/>
 
-    <Preference android:key="pref_input" android:order="8" android:title="@string/pref_input"
+    <Preference android:key="pref_input"
+        android:order="8"
+        android:title="@string/pref_input"
         android:fragment="com.osfans.trime.settings.fragments.InputFragment"/>
 
-    <Preference android:key="pref_deploy" android:order="16"
-        android:title="@string/pref_deploy" android:summary="@string/pref_deploy_summary"/>
+    <!-- <Preference android:key="pref_deploy" android:order="16"
+        android:title="@string/pref_deploy" android:summary="@string/pref_deploy_summary"/> -->
 
-    <Preference android:key="pref_other" android:order="17" android:title="@string/pref_other"
+    <Preference android:key="pref_other"
+        android:order="17"
+        android:title="@string/pref_other"
         android:fragment="com.osfans.trime.settings.fragments.OtherFragment"/>
 
-    <PreferenceScreen android:key="pref_help" android:order="32" android:title="@string/pref_help">
-        <Preference android:key="pref_wiki" android:title="@string/pref_wiki">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://github.com/osfans/trime/wiki/UserGuide" />
-        </Preference>
-        <Preference android:key="pref_issues" android:title="@string/pref_issues">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://github.com/osfans/trime/issues" />
-        </Preference>
-        <Preference android:key="pref_market" android:title="@string/pref_market">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://play.google.com/store/apps/details?id=com.osfans.trime" />
-        </Preference>
-        <Preference android:key="pref_coolmarket" android:title="@string/pref_coolmarket">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="http://www.coolapk.com/apk/com.osfans.trime" />
-        </Preference>
-        <Preference android:key="pref_trime_qq" android:title="@string/pref_trime_qq"
-                    android:summary="@string/pref_trime_qq_summary">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3DzifdI0iaEYjATwYkvVzP1cjsUEWSa9Ha" />
-        </Preference>
-        <Preference android:key="pref_trime_qq2" android:title="@string/pref_trime_qq2"
-                    android:summary="@string/pref_trime_qq2_summary">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3D46XegYX4TQW366gVRKAUhTgtFYmYw7G3" />
-        </Preference>
-        <Preference android:key="pref_rime_qq" android:title="@string/pref_rime_qq"
-                    android:summary="@string/pref_rime_qq_summary">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="mqqopensdkapi://bizAgent/qm/qr?url=http%3A%2F%2Fqm.qq.com%2Fcgi-bin%2Fqm%2Fqr%3Ffrom%3Dapp%26p%3Dandroid%26k%3Dm505aYSeLZjOwWeMNAViWylZZDYqMrxV" />
-        </Preference>
-    </PreferenceScreen>
+    <!-- <PreferenceScreen android:key="pref_help" android:order="32" android:title="@string/pref_help">
 
-    <PreferenceScreen android:key="pref_about" android:order="64" android:title="@string/pref_about">
-        <Preference android:key="pref_changelog" android:title="@string/pref_changelog">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://github.com/osfans/trime" />
-        </Preference>
-        <Preference android:key="pref_librime_ver" android:title="@string/pref_librime_ver">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://github.com/rime/librime" />
-        </Preference>
-        <Preference android:key="pref_opencc_ver" android:title="@string/pref_opencc_ver">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://github.com/BYVoid/OpenCC" />
-        </Preference>
-        <Preference android:key="pref_licensing" android:title="@string/pref_licensing" android:summary="@string/pref_licensing_summary"/>
-        <Preference android:key="pref_pravcy" android:title="@string/pref_privacy">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://github.com/osfans/trime/blob/develop/PRIVACY.md" />
-        </Preference>
-        <Preference android:key="pref_pime" android:title="@string/pref_pime">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://github.com/osfans/PIME/releases" />
-        </Preference>
-        <Preference android:key="pref_donate" android:title="@string/pref_donate" android:summary="@string/pref_donate_summary">
-            <intent android:action="android.intent.action.VIEW"
-            android:data="https://qr.alipay.com/tsx03439zwna78hloqtm6bc" />
-        </Preference>
-        <Preference android:key="pref_credits" android:title="@string/pref_credits">
-            <intent android:action="android.intent.action.VIEW"
-                    android:data="https://github.com/osfans/trime/releases" />
-        </Preference>
-    </PreferenceScreen>
+    </PreferenceScreen> -->
+
+    <!-- <PreferenceScreen android:key="pref_about" android:order="64" android:title="@string/pref_about">
+
+    </PreferenceScreen> -->
 
 </PreferenceScreen>


### PR DESCRIPTION
上次 PR（#431）由于含有一些冲突无法自动合并，本 PR 从头开始提交。目前原来所有的功能几乎都能完美使用，甚至有所增强。

以下是和原设计的显著差异：
- **重新排版设置树**
  - 将“帮助与反馈”、“关于”和“部署”放入选项菜单，其中“部署”突出为按钮显示；
  - 将“方案”、“主题”和“颜色”移入顶层设置树（首设置页），“颜色”和“主题”作为新设置项“键盘外观”的子项；
  - “夜间模式”移入“其他设置”。
- **微调夜间模式**
  - 将原 SwitchPreference 换用为 ListPreference；
  - 新增“跟随系统”为默认选项，可自适应系统显示设置，另外可强制指定暗色或亮色；
- **调整设置项属性**
  - “启用输入法”和“选择键盘”均可在设置完成后隐藏；
  - 分类显示一些子设置页选项（放入 PreferenceCategory）；
  - 顶层设置树（首设置页）设置项预留图标空间；
  - 部分设置项（EditTextPreference 和 ListPreference）开启 SimpleSummaryProvider，可动态更新其设置值，
     具体包括“嵌入式编辑模式”、“共享文件夹”、“用户文件夹”和“夜间模式”。 