### PR TITLE
improve(settings): Switching UI mode doesn't need to relaunch the app…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "androidx.preference:preference-ktx:1.1.1"
     implementation "androidx.fragment:fragment-ktx:1.2.4"
+    implementation "com.google.android.material:material:1.3.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'

--- a/app/src/main/java/com/osfans/trime/Function.java
+++ b/app/src/main/java/com/osfans/trime/Function.java
@@ -45,7 +45,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-/** 實現打開指定程序、打開{@link Pref 輸入法全局設置}對話框等功能 */
+/** 實現打開指定程序、打開{@link PrefMainActivity 輸入法全局設置}對話框等功能 */
 public class Function {
   private static String TAG = Function.class.getSimpleName();
   private static SparseArray<String> sApplicationLaunchKeyCategories;

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -23,11 +23,9 @@ import androidx.fragment.app.Fragment
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
-import com.osfans.trime.Function
 import com.osfans.trime.R
 import com.osfans.trime.databinding.PrefActivityBinding
 import com.osfans.trime.settings.components.SchemaPickerDialog
-import com.osfans.trime.util.AppVersionUtils
 import com.osfans.trime.util.RimeUtils
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
@@ -132,6 +130,7 @@ class PrefMainActivity: AppCompatActivity(),
                 true
             }
             R.id.preference__menu_deploy -> {
+                @Suppress("DEPRECATION")
                 val progressDialog = ProgressDialog(this).apply {
                     setMessage(getString(R.string.deploy_progress))
                     show()

--- a/app/src/main/java/com/osfans/trime/settings/fragments/AppearanceFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/AppearanceFragment.kt
@@ -3,7 +3,6 @@ package com.osfans.trime.settings.fragments
 import android.os.Bundle
 import android.view.Menu
 import androidx.core.view.forEach
-import androidx.core.view.forEachIndexed
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.osfans.trime.R

--- a/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/InputFragment.kt
@@ -9,11 +9,9 @@ import androidx.core.view.forEach
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
-import androidx.preference.SwitchPreference
-import com.osfans.trime.Function
+import androidx.preference.SwitchPreferenceCompat
 import com.osfans.trime.R
 import com.osfans.trime.settings.components.ResetAssetsDialog
-import com.osfans.trime.settings.components.SchemaPickerDialog
 import com.osfans.trime.util.RimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -82,7 +80,7 @@ class InputFragment: PreferenceFragmentCompat(), CoroutineScope {
     }
 
     private fun setBackgroundSyncSummary(context: Context?) {
-        val syncBgPref = findPreference<SwitchPreference>("pref_sync_bg")
+        val syncBgPref = findPreference<SwitchPreferenceCompat>("pref_sync_bg")
         if (context == null) {
             if (syncBgPref?.isChecked == true) {
                 syncBgPref.setSummaryOn(R.string.pref_sync_bg_never)

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -2,7 +2,6 @@ package com.osfans.trime.settings.fragments
 
 import android.content.ComponentName
 import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -14,7 +13,6 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import com.osfans.trime.R
 import com.osfans.trime.ime.core.Trime
-import com.osfans.trime.settings.PrefMainActivity
 
 class OtherFragment: PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -7,7 +7,9 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.Menu
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.view.forEach
+import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import com.osfans.trime.R
@@ -19,6 +21,16 @@ class OtherFragment: PreferenceFragmentCompat(),
     private val prefs get() = PreferenceManager.getDefaultSharedPreferences(context)
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.other_preference)
+        findPreference<ListPreference>("pref__settings_theme")?.setOnPreferenceChangeListener { _, newValue ->
+            val uiMode = when (newValue) {
+                "auto" -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                "light" -> AppCompatDelegate.MODE_NIGHT_NO
+                "dark" -> AppCompatDelegate.MODE_NIGHT_YES
+                else -> AppCompatDelegate.MODE_NIGHT_UNSPECIFIED
+            }
+            AppCompatDelegate.setDefaultNightMode(uiMode)
+            true
+        }
 
         setHasOptionsMenu(true)
     }
@@ -35,12 +47,6 @@ class OtherFragment: PreferenceFragmentCompat(),
                 if (sharedPreferences?.getBoolean(key, false) == true) {
                     trime?.showStatusIcon(R.drawable.status)
                 } else { trime.hideStatusIcon() }
-            }
-            "pref__settings_theme" -> {
-                (activity as PrefMainActivity).finish()
-                val intent = Intent(context, PrefMainActivity::class.java)
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_HISTORY
-                requireContext().startActivity(intent)
             }
         }
     }

--- a/app/src/main/res/layout/preference_widget_seekbar.xml
+++ b/app/src/main/res/layout/preference_widget_seekbar.xml
@@ -34,7 +34,7 @@
         android:layout_gravity="center"
         android:maxLines="1" />
 
-    <SeekBar
+    <androidx.appcompat.widget.AppCompatSeekBar
         android:id="@+id/seekBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -6,5 +6,5 @@
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:background="@color/colorPrimary"
-    android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
-    app:popupTheme="@style/ThemeOverlay.MaterialComponents.Light" />
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -6,5 +6,5 @@
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:background="@color/colorPrimary"
-    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-    app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+    android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
+    app:popupTheme="@style/ThemeOverlay.MaterialComponents.Light" />

--- a/app/src/main/res/values/theme.xml
+++ b/app/src/main/res/values/theme.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="PreferenceTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:colorAccent" tools:targetApi="lollipop">@color/colorAccent</item>
-    </style>
-</resources>

--- a/app/src/main/res/values/theme.xml
+++ b/app/src/main/res/values/theme.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="PreferenceTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="PreferenceTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!--
     <style name="PreferenceTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:colorAccent" tools:targetApi="lollipop">@color/colorAccent</item>
-    </style> -->
+    </style>
 </resources>

--- a/app/src/main/res/xml/input_preference.xml
+++ b/app/src/main/res/xml/input_preference.xml
@@ -21,7 +21,7 @@
         android:title="@string/pref_sync"
         android:summary="@string/pref_sync_summary"/>
 
-    <SwitchPreference android:key="pref_sync_bg"
+    <SwitchPreferenceCompat android:key="pref_sync_bg"
         app:iconSpaceReserved="false"
         android:title="@string/pref_sync_bg"
         android:summary="@string/pref_sync_bg_tip"

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -14,19 +14,19 @@
             android:entryValues="@array/inline_values"
             android:defaultValue="preview"
             app:useSimpleSummaryProvider="true"/>
-        <SwitchPreference android:key="soft_cursor"
+        <SwitchPreferenceCompat android:key="soft_cursor"
             app:iconSpaceReserved="false"
             android:title="@string/soft_cursor"
             android:defaultValue="true"/>
-        <SwitchPreference android:key="show_window"
+        <SwitchPreferenceCompat android:key="show_window"
             app:iconSpaceReserved="false"
             android:title="@string/show_window"
             android:defaultValue="true"/>
-        <SwitchPreference android:key="show_preview"
+        <SwitchPreferenceCompat android:key="show_preview"
             app:iconSpaceReserved="false"
             android:title="@string/show_preview"
             android:defaultValue="false"/>
-        <SwitchPreference android:key="show_switches"
+        <SwitchPreferenceCompat android:key="show_switches"
             app:iconSpaceReserved="false"
             android:title="@string/show_switches"
             android:defaultValue="true" />
@@ -35,7 +35,7 @@
     <PreferenceCategory app:iconSpaceReserved="false"
         app:title="@string/pref_keyboard__effect"
         app:key="pref_keyboard__effect" >
-        <SwitchPreference android:key="key_sound"
+        <SwitchPreferenceCompat android:key="key_sound"
             app:iconSpaceReserved="false"
             android:title="@string/key_sound"/>
         <com.osfans.trime.settings.components.DialogSeekBarPreference
@@ -49,7 +49,7 @@
             android:defaultValue="100"
             app:unit="%"
             android:dependency="key_sound"/>
-        <SwitchPreference android:key="key_vibrate"
+        <SwitchPreferenceCompat android:key="key_vibrate"
             app:iconSpaceReserved="false"
             android:title="@string/key_vibrate"/>
         <com.osfans.trime.settings.components.DialogSeekBarPreference
@@ -75,10 +75,10 @@
             app:unit=""
             android:dependency="key_vibrate"/>
         <!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
-        <SwitchPreference android:key="speak_key"
+        <SwitchPreferenceCompat android:key="speak_key"
             app:iconSpaceReserved="false"
             android:title="@string/speak_key"/>
-        <SwitchPreference android:key="speak_commit"
+        <SwitchPreferenceCompat android:key="speak_commit"
             app:iconSpaceReserved="false"
             android:title="@string/speak_commit"/>
         <com.osfans.trime.settings.components.DialogSeekBarPreference

--- a/app/src/main/res/xml/other_preference.xml
+++ b/app/src/main/res/xml/other_preference.xml
@@ -17,10 +17,10 @@
         app:summaryOn="@string/pref__others__show_app_icon_tips_on"
         app:summaryOff="@string/pref__others__show_app_icon_tips_off"/>
 
-    <SwitchPreference android:key="pref_notification_icon"
+    <SwitchPreferenceCompat android:key="pref_notification_icon"
         app:iconSpaceReserved="false"
         android:title="@string/pref_notification_icon" />
-    <SwitchPreference android:key="pref_destroy_on_quit"
+    <SwitchPreferenceCompat android:key="pref_destroy_on_quit"
         app:iconSpaceReserved="false"
         android:title="@string/pref_destroy_on_quit" />
 </PreferenceScreen>


### PR DESCRIPTION
… anymore

Also did:
- ~~Use Material Components instead of pure AppCompat~~

改进：
- 切换夜间模式不再需要重启 App 了，点击即生效；
- ~~使用 Material Design 组件。~~ **（去掉了，会出现些难以调整的奇怪的样式问题，暂时放弃）**
