### PR TITLE
增加功能及bug修复

### DIFF
--- a/app/src/main/java/com/osfans/trime/Composition.java
+++ b/app/src/main/java/com/osfans/trime/Composition.java
@@ -232,7 +232,6 @@ public class Composition extends TextView {
     margin_x = config.getPixel("layout/margin_x");
     margin_y = config.getPixel("layout/margin_y");
     margin_bottom = config.getPixel("layout/margin_bottom",margin_y);
-    System.out.println("Composition setPadding=" + margin_x+", "+margin_y+", "+margin_bottom);
     setPadding(margin_x, margin_y, margin_x, margin_bottom);
     max_length = config.getInt("layout/max_length");
     sticky_lines = config.getInt("layout/sticky_lines");

--- a/app/src/main/java/com/osfans/trime/Composition.java
+++ b/app/src/main/java/com/osfans/trime/Composition.java
@@ -228,10 +228,12 @@ public class Composition extends TextView {
     setMinHeight(config.getPixel("layout/min_height"));
     setMaxWidth(config.getPixel("layout/max_width"));
     setMaxHeight(config.getPixel("layout/max_height"));
-    int margin_x, margin_y;
+    int margin_x, margin_y, margin_bottom;
     margin_x = config.getPixel("layout/margin_x");
     margin_y = config.getPixel("layout/margin_y");
-    setPadding(margin_x, margin_y, margin_x, margin_y);
+    margin_bottom = config.getPixel("layout/margin_bottom",margin_y);
+    System.out.println("Composition setPadding=" + margin_x+", "+margin_y+", "+margin_bottom);
+    setPadding(margin_x, margin_y, margin_x, margin_bottom);
     max_length = config.getInt("layout/max_length");
     sticky_lines = config.getInt("layout/sticky_lines");
     movable = config.getString("layout/movable");

--- a/app/src/main/java/com/osfans/trime/Config.java
+++ b/app/src/main/java/com/osfans/trime/Config.java
@@ -116,8 +116,6 @@ public class Config {
     SharedPreferences.Editor edit = mPref.edit();
     edit.putString("pref_clipboard_compare", s);
     edit.apply();
-
-    System.out.println("setClipBoardCompare "+s);
   }
 
   public void setClipBoardOutput(String str) {
@@ -687,11 +685,8 @@ public class Config {
           Bitmap bitmap= BitmapFactory.decodeFile(name);
           byte[] chunk = bitmap.getNinePatchChunk();
           // 如果.9.png没有经过第一步，那么chunk就是null, 只能按照普通方式加载
-          if(NinePatch.isNinePatchChunk(chunk)) {
+          if(NinePatch.isNinePatchChunk(chunk))
             return new NinePatchDrawable(bitmap, chunk, new Rect(), null);
-          }else{
-            System.out.println("drawableObject() chunk null, file="+name);
-          }
         }
         return new BitmapDrawable(BitmapFactory.decodeFile(name));
       }

--- a/app/src/main/java/com/osfans/trime/Config.java
+++ b/app/src/main/java/com/osfans/trime/Config.java
@@ -485,6 +485,15 @@ public class Config {
     return parseColor(o.toString());
   }
 
+  public Integer getColor(String key,Integer defaultValue) {
+    Object o = getColorObject(key);
+    if (o == null) {
+      o = ((Map<String, Object>) presetColorSchemes.get("default")).get(key);
+    }
+    if (o == null) return defaultValue;
+    return parseColor(o.toString());
+  }
+
   public static Drawable getColorDrawable(Context context, Map m, String k) {
     if (m.containsKey(k)) {
       Object o = m.get(k);

--- a/app/src/main/java/com/osfans/trime/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/Keyboard.java
@@ -19,6 +19,7 @@
 package com.osfans.trime;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.util.DisplayMetrics;
 import android.view.KeyEvent;
@@ -80,6 +81,7 @@ public class Keyboard {
 
   private boolean mLock; //切換程序時記憶鍵盤
   private String mAsciiKeyboard; //英文鍵盤
+  private boolean land=false; //橫屏模式下，键盘左右两侧到屏幕边缘的距离
 
   /**
    * Creates a keyboard from the given xml key layout file.
@@ -87,17 +89,27 @@ public class Keyboard {
    * @param context the application or service context
    */
   public Keyboard(Context context) {
+
+    land =  ( context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) ;
+
+    Config config = Config.get(context);
+
     DisplayMetrics dm = context.getResources().getDisplayMetrics();
     mDisplayWidth = dm.widthPixels;
+    if(land)
+      mDisplayWidth = mDisplayWidth -  config.getPixel("keyboard_padding_landscape")*2;
     /* Height of the screen */
     int mDisplayHeight = dm.heightPixels;
     //Log.v(TAG, "keyboard's display metrics:" + dm);
 
-    Config config = Config.get(context);
     mDefaultHorizontalGap = config.getPixel("horizontal_gap");
     mDefaultVerticalGap = config.getPixel("vertical_gap");
     mDefaultWidth = (int) (mDisplayWidth * config.getDouble("key_width") / 100);
+
     mDefaultHeight = config.getPixel("key_height");
+    if(land)
+      mDefaultHeight = config.getPixel("key_height_land",mDefaultHeight);
+
     mProximityThreshold = (int) (mDefaultWidth * SEARCH_DISTANCE);
     mProximityThreshold = mProximityThreshold * mProximityThreshold; // Square it for comparison
     mRoundCorner = config.getFloat("round_corner");

--- a/app/src/main/java/com/osfans/trime/KeyboardSwitch.java
+++ b/app/src/main/java/com/osfans/trime/KeyboardSwitch.java
@@ -95,6 +95,16 @@ public class KeyboardSwitch {
     reset(context);
   }
 
+  private boolean land;
+  public void init(int displayWidth,boolean isLand) {
+    if ((currentId >= 0) && (displayWidth == currentDisplayWidth)) {
+      return;
+    }
+    land = isLand;
+    currentDisplayWidth = displayWidth;
+    reset(context);
+  }
+
   public Keyboard getCurrentKeyboard() {
     return mKeyboards[currentId];
   }

--- a/app/src/main/java/com/osfans/trime/Rime.java
+++ b/app/src/main/java/com/osfans/trime/Rime.java
@@ -159,8 +159,11 @@ public class Rime {
         Integer value = (Integer) o.get("value");
         if (value == null) value = 0;
         candidates[i].text = states.get(value).toString();
-        candidates[i].comment =
-            o.containsKey("options") ? "" : kRightArrow + states.get(1 - value).toString();
+
+        if (showSwitchArrow)
+          candidates[i].comment = o.containsKey("options") ? "" : kRightArrow + states.get(1 - value).toString();
+        else
+          candidates[i].comment = o.containsKey("options") ? "" : states.get(1 - value).toString();
         i++;
       }
       return candidates;
@@ -226,9 +229,14 @@ public class Rime {
   public static int META_ALT_ON = get_modifier_by_name("Alt");
   public static int META_RELEASE_ON = get_modifier_by_name("Release");
   private static boolean showSwitches = true;
+  private static boolean showSwitchArrow = false;
 
   public static void setShowSwitches(boolean show) {
     showSwitches = show;
+  }
+
+  public static void setShowSwitchArrow(boolean show){
+    showSwitchArrow = show;
   }
 
   public static boolean hasMenu() {

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -83,6 +83,7 @@ import java.util.Locale;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import static android.graphics.Color.parseColor;
 
 /** {@link InputMethodService 輸入法}主程序 */
 public class Trime extends InputMethodService
@@ -435,13 +436,13 @@ public class Trime extends InputMethodService
 
         Drawable d2 = mConfig.getDrawable("candidate_background");
         if (d2 == null) {
-            mCandidateContainer.setBackgroundColor(mConfig.getColor("back_color"));
+            mCandidateContainer.setBackgroundColor(mConfig.getColor("back_color",parseColor("#00ffffff")));
         } else
             mCandidateContainer.setBackgroundDrawable(d2);
 
       Drawable d3 = mConfig.getDrawable("root_background");
       if (d3 == null) {
-        mInputRoot.setBackgroundColor(mConfig.getColor("root_background"));
+        mInputRoot.setBackgroundColor(mConfig.getColor("root_background",parseColor("#00ffffff")));
       } else
         mInputRoot.setBackgroundDrawable(d3);
     }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -391,21 +391,16 @@ public class Trime extends InputMethodService
 
     private void loadBackground() {
 
-      if (//self.getResources().getConfiguration().orientation
-              orientation == Configuration.ORIENTATION_LANDSCAPE) {
+      if (
+        orientation == Configuration.ORIENTATION_LANDSCAPE) {
         int padding = mConfig.getPixel("keyboard_padding_landscape");
-//        mKeyboardView.setPadding(
-//                padding, mKeyboardView.getPaddingTop()
-//                , padding, mKeyboardView.getPaddingBottom());
-//        mInputRoot.findViewById(R.id.spacer_left).setMinimumWidth(padding);
-//        mInputRoot.findViewById(R.id.spacer_right).setMinimumWidth(padding);
 
-        View view =  mInputRoot.findViewById(R.id.spacer_left);
+        View view = mInputRoot.findViewById(R.id.spacer_left);
         LayoutParams layoutParams = view.getLayoutParams();
         layoutParams.width = padding;
         view.setLayoutParams(layoutParams);
 
-        view =  mInputRoot.findViewById(R.id.spacer_right);
+        view = mInputRoot.findViewById(R.id.spacer_right);
         layoutParams = view.getLayoutParams();
         layoutParams.width = padding;
         view.setLayoutParams(layoutParams);
@@ -1401,8 +1396,6 @@ public class Trime extends InputMethodService
               intent.setType("text/plain");
               intent.putExtra(Intent.EXTRA_TEXT, text);
               intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-
-//              intent.setComponent(new ComponentName("com.fooview.android.fooview", "com.fooview.android.fooview.FooClipboardProxy"));
               intent.setComponent(new ComponentName(ClipBoardManager[0],ClipBoardManager[1]));
 
               self.startActivity(intent);

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1155,8 +1155,9 @@ public class Trime extends InputMethodService
       }
     } else if (i == -4) onKey(KeyEvent.KEYCODE_PAGE_UP, 0);
     else if (i == -5) onKey(KeyEvent.KEYCODE_PAGE_DOWN, 0);
-    else if (Rime.selectCandidate(i)) {
-      commitText();
+    else // if (Rime.selectCandidate(i))
+    {
+      handleKey(KeyEvent.KEYCODE_1+i,0);
     }
   }
 

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -125,19 +125,16 @@ class OtherFragment: PreferenceFragmentCompat(),
     /** 顯示輸入法可以分享剪贴板给哪些App */
     class ClipBoardManagerDialog(private val context: Context, val value: String) {
         private val config = Config.get(context)
-        /** 內置數據列表 */
 
         /** 回廠對話框 */
         val resetDialog: AlertDialog
 
         init {
-//            var list: ArrayList<String> = ArrayList<String>();
             var values: ArrayList<String> = ArrayList<String>();
 
             val intent = Intent(Intent.ACTION_SEND)
             intent.type = "text/plain"
             intent.putExtra(Intent.EXTRA_TEXT, "Trime test")
-//            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             val packageManager = context.packageManager
             val resolveInfos = packageManager.queryIntentActivities(intent, 0)
 
@@ -146,7 +143,6 @@ class OtherFragment: PreferenceFragmentCompat(),
             for (i in resolveInfos.indices) {
                 values.add(resolveInfos[i].activityInfo.packageName + "," + resolveInfos[i].activityInfo.name);
                 items[i] = resolveInfos[i].loadLabel(packageManager) as String?;
-//                println("res=" + resolveInfos[i].loadLabel(packageManager) + resolveInfos[i].activityInfo)
             }
             val builder: AlertDialog.Builder = AlertDialog.Builder(context)
             builder.setTitle(R.string.pref_clipboard_manager)

--- a/app/src/main/java/com/osfans/trime/xScrollView.java
+++ b/app/src/main/java/com/osfans/trime/xScrollView.java
@@ -1,0 +1,241 @@
+package com.osfans.trime;
+
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.animation.TranslateAnimation;
+import android.widget.HorizontalScrollView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class xScrollView extends HorizontalScrollView {
+
+    private View inner;
+    private float x;
+    private Rect normal = new Rect();
+    private boolean isCount = false;
+    private boolean isMoveing = false;
+    private boolean doneUp=false,doneDown=false;
+    private int initLeft;
+    private int left;
+    private View views;
+
+    private Runnable pageDownAction, pageUpAction;
+
+
+    public xScrollView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public void setPageStr(Runnable pageDownAction,Runnable pageUpAction) {
+        this.pageDownAction = pageDownAction;
+        this.pageUpAction = pageUpAction;
+    }
+
+    /**
+     * Based on the XML generated view work done.
+     * The function in the creation of the view of the last call.
+     * after all sub-view has been added.
+     * Even if the sub-class covered the onFinishInflate method.
+     * it should also call the parent class method to make the method to be implemented.
+     */
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        if (getChildCount() > 0) {
+            inner = getChildAt(0);
+        }
+    }
+
+    /**
+     * Touch event handling
+     **/
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        if (inner != null) {
+            commOnTouchEvent(ev);
+        }
+        return super.onTouchEvent(ev);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        if (ev.getAction() == MotionEvent.ACTION_UP) {
+            if (views != null) {
+                //Views.getDrawer().closeDrawers();
+            }
+        }
+        return super.onInterceptTouchEvent(ev);
+    }
+
+    /**
+     * Slide event (let the speed of sliding into the original 1/2)
+     */
+    @Override
+    public void fling(int velocityY) {
+        super.fling(velocityY / 2);
+    }
+
+    /***
+     * Touch the event
+     *
+     * @param ev
+     */
+    public void commOnTouchEvent(MotionEvent ev) {
+        int action = ev.getAction();
+        switch (action) {
+            case MotionEvent.ACTION_DOWN:
+                break;
+
+            case MotionEvent.ACTION_UP:
+                isMoveing = false;
+                // Fingers loose
+                if (isNeedAnimation()) {
+                    animation();
+                }
+
+                break;
+            /**Excluding the first mobile calculation.
+             *  because the first time can not know the y coordinates.
+             *  in MotionEvent.ACTION_DOWN not get.
+             *  because this time is MyScrollView touch event passed to the LIstView child item above.
+             *  So from the second calculation But we also have to initialize.
+             *  that is. the first time to move the sliding distance to 0.
+             *  After the record is accurate on the normal implementation.
+             */
+            case MotionEvent.ACTION_MOVE:
+                final float preX = x;// When the y coordinate is pressed
+                float nowX = ev.getX();// Always y-coordinate
+                int deltaX = (int) (nowX - preX);// Slide distance
+                if (!isCount) {
+                    deltaX = 0; // Here to 0.
+                }
+
+//              to-do 翻页后、手指抬起前，降低滑动速度增加阻尼感
+                if(inner.getLeft()>100 && Rime.hasLeft()){
+                    pageUpAction.run();
+                    if(inner.getWidth()>this.getWidth())
+                        inner.layout(this.getWidth()-inner.getWidth()-400  , inner.getTop(),
+                                this.getWidth() - 400, inner.getBottom());
+                }else if(inner.getWidth() - inner.getRight()>100 && Rime.hasRight()){
+                    pageDownAction.run();
+                    if(inner.getWidth()>this.getWidth())
+                        inner.layout(  400, inner.getTop(),
+                                this.getWidth() + 400, inner.getBottom());
+
+                }else{
+                    // When the scroll to the top or the most when it will not scroll, then move the layout.
+                    isNeedMove();
+
+//                System.out.println("MotionEvent "+isMoveing+" d="+deltaX+" left="+left+" LR="+inner.getLeft()+", "+inner.getRight()+" scrollX="+this.getScrollX());
+
+                    if (isMoveing) {
+                        // Initialize the head rectangle
+                        if (normal.isEmpty()) {
+                            // Save the normal layout position
+                            normal.set(inner.getLeft(), inner.getTop(),
+                                    inner.getRight(), inner.getBottom());
+                        }
+
+                        // Move the layout
+                        inner.layout(inner.getLeft() + deltaX / 3, inner.getTop(),
+                                inner.getRight() + deltaX / 3, inner.getBottom());
+
+                        left += (deltaX / 6);
+                    }
+
+                    isCount = true;
+                    x = nowX;
+                }
+
+
+
+                break;
+
+            default:
+                break;
+
+        }
+    }
+
+    /**
+     * Retract animation
+     */
+    public void animation() {
+        TranslateAnimation taa = new TranslateAnimation(0, 0, left + 200,
+                initLeft + 200);
+        taa.setDuration(200);
+        TranslateAnimation ta = null;
+        // Turn on moving animation
+        ta = new TranslateAnimation(inner.getLeft(), normal.left, 0, 0);
+        ta.setDuration(200);
+        inner.startAnimation(ta);
+        // Set back to the normal layout position
+        inner.layout(normal.left, normal.top, normal.right, normal.bottom);
+        normal.setEmpty();
+
+        isCount = false;
+        x = 0;// Fingers loose to 0..
+
+    }
+
+    // Whether you need to turn on animation
+    public boolean isNeedAnimation() {
+        return !normal.isEmpty();
+    }
+
+    /***
+     * Whether you need to move the layout inner.getMeasuredHeight (): get the total height of the control
+     *
+     * GetHeight (): Get the height of the screen.
+     *
+     * @return
+     */
+    public void isNeedMove() {
+        int scrollY = getScrollY();
+        if (scrollY == 0) {
+            isMoveing = true;
+        }
+    }
+
+    public void setContextView(View view) {
+        this.views = view;
+    }
+
+
+
+    private String getInnerText() {
+        List<View> list = getAllChildViews(this);
+        StringBuffer buffer = new StringBuffer() ;
+
+        for(View v:list){
+            if(v instanceof TextView){
+                buffer.append(((TextView)v).getText());
+            }
+        }
+
+        return buffer.toString().trim();
+    }
+
+    private List<View> getAllChildViews(View view) {
+        List<View> allchildren = new ArrayList<View>();
+        if (view instanceof ViewGroup) {
+            ViewGroup vp = (ViewGroup) view;
+            for (int i = 0; i < vp.getChildCount(); i++) {
+                View viewchild = vp.getChildAt(i);
+                allchildren.add(viewchild);
+                //再次 调用本身（递归）
+                allchildren.addAll(getAllChildViews(viewchild));
+            }
+        }
+        return allchildren;
+    }
+
+} 

--- a/app/src/main/java/com/osfans/trime/xScrollView.java
+++ b/app/src/main/java/com/osfans/trime/xScrollView.java
@@ -134,7 +134,7 @@ public class xScrollView extends HorizontalScrollView {
                     // When the scroll to the top or the most when it will not scroll, then move the layout.
                     isNeedMove();
 
-//                System.out.println("MotionEvent "+isMoveing+" d="+deltaX+" left="+left+" LR="+inner.getLeft()+", "+inner.getRight()+" scrollX="+this.getScrollX());
+//                Log.i("MotionEvent "+isMoveing," d="+deltaX+" left="+left+" LR="+inner.getLeft()+", "+inner.getRight()+" scrollX="+this.getScrollX());
 
                     if (isMoveing) {
                         // Initialize the head rectangle

--- a/app/src/main/java/com/osfans/trime/xScrollView.java
+++ b/app/src/main/java/com/osfans/trime/xScrollView.java
@@ -134,7 +134,7 @@ public class xScrollView extends HorizontalScrollView {
                     // When the scroll to the top or the most when it will not scroll, then move the layout.
                     isNeedMove();
 
-//                Log.i("MotionEvent "+isMoveing," d="+deltaX+" left="+left+" LR="+inner.getLeft()+", "+inner.getRight()+" scrollX="+this.getScrollX());
+//                Log.d("MotionEvent "+isMoveing," d="+deltaX+" left="+left+" LR="+inner.getLeft()+", "+inner.getRight()+" scrollX="+this.getScrollX());
 
                     if (isMoveing) {
                         // Initialize the head rectangle

--- a/app/src/main/java/com/osfans/trime/xScrollView.java
+++ b/app/src/main/java/com/osfans/trime/xScrollView.java
@@ -69,7 +69,7 @@ public class xScrollView extends HorizontalScrollView {
     public boolean onInterceptTouchEvent(MotionEvent ev) {
         if (ev.getAction() == MotionEvent.ACTION_UP) {
             if (views != null) {
-                //Views.getDrawer().closeDrawers();
+
             }
         }
         return super.onInterceptTouchEvent(ev);
@@ -155,8 +155,6 @@ public class xScrollView extends HorizontalScrollView {
                     x = nowX;
                 }
 
-
-
                 break;
 
             default:
@@ -208,34 +206,4 @@ public class xScrollView extends HorizontalScrollView {
     public void setContextView(View view) {
         this.views = view;
     }
-
-
-
-    private String getInnerText() {
-        List<View> list = getAllChildViews(this);
-        StringBuffer buffer = new StringBuffer() ;
-
-        for(View v:list){
-            if(v instanceof TextView){
-                buffer.append(((TextView)v).getText());
-            }
-        }
-
-        return buffer.toString().trim();
-    }
-
-    private List<View> getAllChildViews(View view) {
-        List<View> allchildren = new ArrayList<View>();
-        if (view instanceof ViewGroup) {
-            ViewGroup vp = (ViewGroup) view;
-            for (int i = 0; i < vp.getChildCount(); i++) {
-                View viewchild = vp.getChildAt(i);
-                allchildren.add(viewchild);
-                //再次 调用本身（递归）
-                allchildren.addAll(getAllChildViews(viewchild));
-            }
-        }
-        return allchildren;
-    }
-
 } 

--- a/app/src/main/res/layout-land/input_root.xml
+++ b/app/src/main/res/layout-land/input_root.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <View
+        android:id="@+id/spacer_left"
+        android:layout_width="10dp"
+        android:layout_height="match_parent" />
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_weight="1"
+        >
+
+        <com.osfans.trime.xScrollView
+            android:id="@+id/scroll"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fillViewport="true">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.osfans.trime.Candidate
+                    android:id="@+id/candidate"
+                    android:layout_width="1000dp"
+                    android:layout_height="120dp" />
+            </LinearLayout>
+        </com.osfans.trime.xScrollView>
+
+        <com.osfans.trime.KeyboardView
+            android:id="@+id/keyboard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <View
+        android:id="@+id/spacer_right"
+        android:layout_width="10dp"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/candidate_container.xml
+++ b/app/src/main/res/layout/candidate_container.xml
@@ -19,7 +19,7 @@
  */
 -->
 
-<HorizontalScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.osfans.trime.xScrollView xmlns:android="http://schemas.android.com/apk/res/android"
   android:id="@+id/scroll"
   android:layout_width="wrap_content"
   android:layout_height="wrap_content"
@@ -34,4 +34,4 @@
         android:layout_height="120dp"
         />
   </LinearLayout>
-</HorizontalScrollView>
+</com.osfans.trime.xScrollView>

--- a/app/src/main/res/layout/input_root.xml
+++ b/app/src/main/res/layout/input_root.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.osfans.trime.xScrollView
+        android:id="@+id/scroll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true">
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <com.osfans.trime.Candidate
+                android:id="@+id/candidate"
+                android:layout_width="1000dp"
+                android:layout_height="120dp"/>
+        </LinearLayout>
+    </com.osfans.trime.xScrollView>
+
+    <com.osfans.trime.KeyboardView
+        android:id="@+id/keyboard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+</LinearLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -117,4 +117,9 @@
     <string name="pref__others__show_app_icon_tips_on">此选项仅对部分 ROM 有效</string>
     <string name="pref__others__show_app_icon_tips_off">在某些 ROM 中，您仍会看到图标显示，并可能在点击它后转到系统的应用信息页</string>
     <string name="pref__default">默认</string>
+    <string name="pref_clipboard_manager">剪贴板管理器</string>
+    <string name="pref_clipboard_compare">剪贴板去重规则(每行为一条正则表达式)</string>
+    <string name="pref_clipboard_output">剪贴板过滤规则(每行为一条正则表达式)</string>
+    <string name="pref_clipboard_manager_summary">剪贴板内容变化时，自动发送剪贴板内容给选定的应用</string>
+    <string name="show_switche_arrow">在候选栏中显示状态时带箭头符号</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -118,4 +118,9 @@
     <string name="pref__others__show_app_icon">在啟動器中顯示圖示</string>
     <string name="pref__others__show_app_icon_tips_off">在某些 ROM 中，您仍會看到圖示顯示，並可能在>點選它後轉到系統的應用資訊頁</string>
     <string name="pref__default">預設</string>
+    <string name="pref_clipboard_manager">剪貼板管理器</string>
+    <string name="pref_clipboard_compare">剪貼板去重規則(每行爲一條正則規則)</string>
+    <string name="pref_clipboard_output">剪貼板過濾規則(每行爲一條正則規則)</string>
+    <string name="pref_clipboard_manager_summary">剪貼板內容變化時，自動發送剪貼板內容給選定的應用</string>
+    <string name="show_switche_arrow">在候選欄中顯示狀態時帶箭頭符號</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,4 +118,9 @@
     <string name="pref__others__show_app_icon_tips_on">This option is only available on some ROMs</string>
     <string name="pref__others__show_app_icon_tips_off">In some ROMs, you will still see this icon in the launcher and may go to the system\'s app information page after tapping it</string>
     <string name="pref__default">Default</string>
+    <string name="pref_clipboard_manager">Clipboard Manager</string>
+    <string name="pref_clipboard_compare">Clipboard Compare Rules</string>
+    <string name="pref_clipboard_output">Clipboard Output Rules</string>
+    <string name="pref_clipboard_manager_summary">Send clipboard text to the selected App when the Clipboard is modified.</string>
+    <string name="show_switche_arrow">Show arrow for candidate switch</string>
 </resources>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -30,6 +30,10 @@
             app:iconSpaceReserved="false"
             android:title="@string/show_switches"
             android:defaultValue="true" />
+        <SwitchPreferenceCompat android:key="show_switche_arrow"
+            app:iconSpaceReserved="false"
+            android:title="@string/show_switche_arrow"
+            android:defaultValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory app:iconSpaceReserved="false"

--- a/app/src/main/res/xml/other_preference.xml
+++ b/app/src/main/res/xml/other_preference.xml
@@ -23,4 +23,20 @@
     <SwitchPreferenceCompat android:key="pref_destroy_on_quit"
         app:iconSpaceReserved="false"
         android:title="@string/pref_destroy_on_quit" />
+
+    <Preference android:key="pref_clipboard_manager"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_clipboard_manager"
+        android:summary="@string/pref_clipboard_manager_summary"/>
+
+    <EditTextPreference android:key="pref_clipboard_compare"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_clipboard_compare"
+        android:defaultValue=""
+        app:useSimpleSummaryProvider="true"/>
+    <EditTextPreference android:key="pref_clipboard_output"
+        app:iconSpaceReserved="false"
+        android:title="@string/pref_clipboard_output"
+        android:defaultValue=""
+        app:useSimpleSummaryProvider="true"/>
 </PreferenceScreen>


### PR DESCRIPTION
- [x]  按数字键和点击候选词,上屏内容不一致的问题  https://github.com/osfans/trime/pull/458#discussion_r679964958
- [x]  增加.9图支持,解决画面拉伸问题(背景图需要以.9.png结尾)
- [x]  候选词背景图(皮肤增加参数 /style/candidate_background)
- [x]  增加开关:候选栏开关的提示是否显示箭头(有奇怪的bug,需要刷新主题或者切换方案之类的操作才会有效)入口在偏好设置-视图-在候选栏中显示状态时带箭头符号
- [x]  增加参数:横屏按键高度(这里没有生效),横屏键盘左右padding,竖屏全面屏抬起键盘的高度 对应参数均在/style/keyboard_padding_landscape,  /style/keyboard_padding_portrait
- [x]  候选词栏滑动到顶部、尾部的阻尼效果
- [x]  候选词滑动到尾部、顶部自动翻页
- [x]  修复翻页时候选词栏没有复位的bug
- [x]  候选与键盘使用一张完整的图(皮肤增加/style/root_background参数),候选栏与键盘原有背景图叠加在其上显示
- [x]  解决bilibili横屏无候选词的bug
- [x]  增加剪贴板API。在其他设置中，增加了剪贴板3个选项。当剪贴板内容发生变化时，自动发送剪贴板内容给指定的应用。选项“去重规则”和“过滤规则”每一行为一条正则表达式。每次通知剪贴板管理器，都会保存“去重规则”处理过的string。如果相邻两次剪贴内容，使用“去重规则”处理过后，内容不变，则不通知。如果内容与“过滤规则”匹配，则不通知指定App