### PR TITLE
优化候选栏和悬浮窗

### DIFF
--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -8,6 +8,8 @@ author: osfans #作者資訊
 style:
   auto_caps: false #自動句首大寫:true|false|ascii
   background_dim_amount: 0.5
+  #root_background: #ddeeeeee # 整个键盘区+候选栏的背景图/色
+  #candidate_background: #eeeeeeee #候选栏的背景图/色
   candidate_font: han.ttf #候選字型
   candidate_padding: 5 #候選項內邊距
   candidate_spacing: 0.5 #候選間距
@@ -22,12 +24,16 @@ style:
   hanb_font: hanb.ttf #擴充字型
   horizontal: true #水平模式
   horizontal_gap: 1 #鍵水平間距
+  keyboard_padding: 0 #竖屏模式下，屏幕左右两侧与键盘的距离（曲面屏减少误触）
+  keyboard_padding_landscape: 40 #横屏模式下，屏幕左右两侧与键盘的距离（避免横屏UI变形）
+  keyboard_padding_portrait: 20 #竖屏模式下，屏幕下边缘与键盘的距离（避免误触发全面屏手势）
   layout: #懸浮窗口設置
     position: fixed #位置：left|right|left_up|right_up|fixed|bottom_left|bottom_right|top_left|top_right(left、right需要>=Android5.0)
     min_length: 5 #最小詞長
     max_length: 10 #超過字數則換行
     sticky_lines: 0 #固頂行數
     max_entries: 1 #最大詞條數
+    min_check: 3 #只要前n个候选词有长度大于等于min_length的词，就会把长度符合以及之前的词全部加到悬浮窗内。
     all_phrases: false #所有滿足條件的詞語都顯示在窗口
     border: 2 #邊框寬度
     max_width: 230 #最大寬度，超過則自動換行
@@ -36,6 +42,7 @@ style:
     min_height: 0 #最小高度
     margin_x: 5 #水平邊距
     margin_y: 5 #豎直邊距
+    margin_bottom: 0 #底部边距 （用于适配特定背景图）
     line_spacing: 0 #候选詞的行間距(px)
     line_spacing_multiplier: 1.2 #候选詞的行間距(倍數)
     spacing: 1 #與預編輯或邊緣的距離

--- a/app/src/main/java/com/osfans/trime/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/Keyboard.java
@@ -98,6 +98,8 @@ public class Keyboard {
     mDisplayWidth = dm.widthPixels;
     if(land)
       mDisplayWidth = mDisplayWidth -  config.getPixel("keyboard_padding_landscape")*2;
+    else
+      mDisplayWidth = mDisplayWidth -  config.getPixel("keyboard_padding")*2;
     /* Height of the screen */
     int mDisplayHeight = dm.heightPixels;
     //Log.v(TAG, "keyboard's display metrics:" + dm);

--- a/app/src/main/java/com/osfans/trime/KeyboardSwitch.java
+++ b/app/src/main/java/com/osfans/trime/KeyboardSwitch.java
@@ -95,16 +95,6 @@ public class KeyboardSwitch {
     reset(context);
   }
 
-  private boolean land;
-  public void init(int displayWidth,boolean isLand) {
-    if ((currentId >= 0) && (displayWidth == currentDisplayWidth)) {
-      return;
-    }
-    land = isLand;
-    currentDisplayWidth = displayWidth;
-    reset(context);
-  }
-
   public Keyboard getCurrentKeyboard() {
     return mKeyboards[currentId];
   }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1205,7 +1205,7 @@ public class Trime extends InputMethodService
     if (mCandidateContainer != null) {
       if (mShowWindow) {
         int start_num = mComposition.setWindow(min_length,min_check);
-        mCandidate.setText(start_num);
+        mCandidate.setText(start_num - 1);
         if (isWinFixed() || !cursorUpdated) mFloatingWindowTimer.postShowFloatingWindow();
       } else {
         mCandidate.setText(0);

--- a/app/src/main/res/layout-land/input_root.xml
+++ b/app/src/main/res/layout-land/input_root.xml
@@ -9,7 +9,7 @@
         android:layout_width="10dp"
         android:layout_height="match_parent" />
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
@@ -18,6 +18,7 @@
 
         <com.osfans.trime.xScrollView
             android:id="@+id/scroll"
+            android:scrollbars="none"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:fillViewport="true">

--- a/app/src/main/res/layout/input_root.xml
+++ b/app/src/main/res/layout/input_root.xml
@@ -6,6 +6,7 @@
 
     <com.osfans.trime.xScrollView
         android:id="@+id/scroll"
+        android:scrollbars="none"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fillViewport="true">
@@ -20,9 +21,21 @@
         </LinearLayout>
     </com.osfans.trime.xScrollView>
 
-    <com.osfans.trime.KeyboardView
-        android:id="@+id/keyboard"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        />
+        android:orientation="horizontal">
+        <View
+            android:id="@+id/spacer_left"
+            android:layout_width="0dp"
+            android:layout_height="match_parent" />
+        <com.osfans.trime.KeyboardView
+            android:id="@+id/keyboard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <View
+            android:id="@+id/spacer_right"
+            android:layout_width="0dp"
+            android:layout_height="match_parent" />
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
此次提交可能存在bug,已观察到偶发性输入法崩溃,需追踪错误
- [x] 考虑到曲面屏同样需要保留屏幕左右两侧到按键区域的间隙， 增加参数keyboard_padding。横屏和竖屏布局略有差异，横屏按键区域与候选栏同步缩小，而竖屏只缩小了按键区域
- [x] 候选栏去除滚动条，减少UI缝合感。
- [x] 修改悬浮窗
增加皮肤参数 layout/min_check 只要前n个候选词有长度大于等于min_length的词，就会把长度符合以及之前的词全部加到悬浮窗内。和原有参数all_phrases不同，all_phrases会让悬浮窗显示的长词和候选栏的词重复，min_check是让前半部分的候选词不分长短全部上屏了。
- [x] 修改trime.yaml，添加新增的皮肤参数