### PR TITLE
完善候选词悬浮窗

### DIFF
--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -43,6 +43,7 @@ style:
     margin_x: 5 #水平邊距
     margin_y: 5 #豎直邊距
     margin_bottom: 0 #底部边距 （用于适配特定背景图）
+    real_margin: 3 #屏幕左右边缘和悬浮窗之间的距离
     line_spacing: 0 #候选詞的行間距(px)
     line_spacing_multiplier: 1.2 #候选詞的行間距(倍數)
     spacing: 1 #與預編輯或邊緣的距離

--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -8,6 +8,8 @@ author: osfans #作者資訊
 style:
   auto_caps: false #自動句首大寫:true|false|ascii
   background_dim_amount: 0.5
+  #root_background: #ddeeeeee # 整个键盘区+候选栏的背景图/色
+  #candidate_background: #eeeeeeee #候选栏的背景图/色
   candidate_font: han.ttf #候選字型
   candidate_padding: 5 #候選項內邊距
   candidate_spacing: 0.5 #候選間距
@@ -22,12 +24,16 @@ style:
   hanb_font: hanb.ttf #擴充字型
   horizontal: true #水平模式
   horizontal_gap: 1 #鍵水平間距
+  keyboard_padding: 0 #竖屏模式下，屏幕左右两侧与键盘的距离（曲面屏减少误触）
+  keyboard_padding_landscape: 40 #横屏模式下，屏幕左右两侧与键盘的距离（避免横屏UI变形）
+  keyboard_padding_portrait: 20 #竖屏模式下，屏幕下边缘与键盘的距离（避免误触发全面屏手势）
   layout: #懸浮窗口設置
     position: fixed #位置：left|right|left_up|right_up|fixed|bottom_left|bottom_right|top_left|top_right(left、right需要>=Android5.0)
     min_length: 5 #最小詞長
     max_length: 10 #超過字數則換行
     sticky_lines: 0 #固頂行數
     max_entries: 1 #最大詞條數
+    min_check: 3 #只要前n个候选词有长度大于等于min_length的词，就会把长度符合以及之前的词全部加到悬浮窗内。
     all_phrases: false #所有滿足條件的詞語都顯示在窗口
     border: 2 #邊框寬度
     max_width: 230 #最大寬度，超過則自動換行
@@ -36,6 +42,7 @@ style:
     min_height: 0 #最小高度
     margin_x: 5 #水平邊距
     margin_y: 5 #豎直邊距
+    margin_bottom: 0 #底部边距 （用于适配特定背景图）
     line_spacing: 0 #候选詞的行間距(px)
     line_spacing_multiplier: 1.2 #候选詞的行間距(倍數)
     spacing: 1 #與預編輯或邊緣的距離

--- a/app/src/main/java/com/osfans/trime/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/Keyboard.java
@@ -98,6 +98,8 @@ public class Keyboard {
     mDisplayWidth = dm.widthPixels;
     if(land)
       mDisplayWidth = mDisplayWidth -  config.getPixel("keyboard_padding_landscape")*2;
+    else
+      mDisplayWidth = mDisplayWidth -  config.getPixel("keyboard_padding")*2;
     /* Height of the screen */
     int mDisplayHeight = dm.heightPixels;
     //Log.v(TAG, "keyboard's display metrics:" + dm);

--- a/app/src/main/java/com/osfans/trime/KeyboardSwitch.java
+++ b/app/src/main/java/com/osfans/trime/KeyboardSwitch.java
@@ -95,16 +95,6 @@ public class KeyboardSwitch {
     reset(context);
   }
 
-  private boolean land;
-  public void init(int displayWidth,boolean isLand) {
-    if ((currentId >= 0) && (displayWidth == currentDisplayWidth)) {
-      return;
-    }
-    land = isLand;
-    currentDisplayWidth = displayWidth;
-    reset(context);
-  }
-
   public Keyboard getCurrentKeyboard() {
     return mKeyboards[currentId];
   }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -110,7 +110,8 @@ public class Trime extends InputMethodService
   private int winX, winY; //候選窗座標
   private int candSpacing; //候選窗與邊緣間距
   private boolean cursorUpdated = false; //光標是否移動
-  private int min_length;
+  private int min_length; //上悬浮窗的候选词的最小词长
+  private int min_check; // 第一屏候选词数量少于设定值，则候选词上悬浮窗。（也就是说，第一屏存在长词）此选项大于1时，min_length等参数失效
   private boolean mTempAsciiMode; //臨時中英文狀態
   private boolean mAsciiMode; //默認中英文狀態
   private boolean reset_ascii_mode; //重置中英文狀態
@@ -265,6 +266,7 @@ public class Trime extends InputMethodService
     movable = mConfig.getString("layout/movable");
     candSpacing = mConfig.getPixel("layout/spacing");
     min_length = mConfig.getInt("layout/min_length");
+    min_check = mConfig.getInt("layout/min_check");
     reset_ascii_mode = mConfig.getBoolean("reset_ascii_mode");
     auto_caps = mConfig.getString("auto_caps");
     mShowWindow = getPrefs().getKeyboard().getFloatingWindowEnabled()
@@ -390,25 +392,27 @@ public class Trime extends InputMethodService
 
     private void loadBackground() {
 
-      if (
-        orientation == Configuration.ORIENTATION_LANDSCAPE) {
-        int padding = mConfig.getPixel("keyboard_padding_landscape");
 
-        View view = mInputRoot.findViewById(R.id.spacer_left);
-        LayoutParams layoutParams = view.getLayoutParams();
-        layoutParams.width = padding;
-        view.setLayoutParams(layoutParams);
+      int padding = mConfig.getPixel("keyboard_padding");
 
-        view = mInputRoot.findViewById(R.id.spacer_right);
-        layoutParams = view.getLayoutParams();
-        layoutParams.width = padding;
-        view.setLayoutParams(layoutParams);
-
+      if ( orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        padding = mConfig.getPixel("keyboard_padding_landscape");
       } else {
         mKeyboardView.setPadding(
                 mKeyboardView.getPaddingLeft(), mKeyboardView.getPaddingTop()
                 , mKeyboardView.getPaddingRight(), mConfig.getPixel("keyboard_padding_portrait"));
       }
+
+      View spacer = mInputRoot.findViewById(R.id.spacer_left);
+      LayoutParams layoutParams = spacer.getLayoutParams();
+      layoutParams.width = padding;
+      spacer.setLayoutParams(layoutParams);
+
+      spacer = mInputRoot.findViewById(R.id.spacer_right);
+      layoutParams = spacer.getLayoutParams();
+      layoutParams.width = padding;
+      spacer.setLayoutParams(layoutParams);
+
 
       GradientDrawable gd = new GradientDrawable();
         gd.setStroke(mConfig.getPixel("layout/border"), mConfig.getColor("border_color"));
@@ -658,11 +662,8 @@ public class Trime extends InputMethodService
     }
     Rime.get(this);
     if (reset_ascii_mode) mAsciiMode = false;
-    int padding = 0;
-    if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-      padding = mConfig.getPixel("keyboard_padding_landscape");
-    }
-    mKeyboardSwitch.init(getMaxWidth() - padding * 2); //橫豎屏切換時重置鍵盤
+
+    mKeyboardSwitch.init(getMaxWidth()); //橫豎屏切換時重置鍵盤
 
     // Select a keyboard based on the input type of the editing field.
     mKeyboardSwitch.setKeyboard(keyboard);
@@ -1203,7 +1204,7 @@ public class Trime extends InputMethodService
       cursorUpdated = ic.requestCursorUpdates(1);
     if (mCandidateContainer != null) {
       if (mShowWindow) {
-        int start_num = mComposition.setWindow(min_length);
+        int start_num = mComposition.setWindow(min_length,min_check);
         mCandidate.setText(start_num);
         if (isWinFixed() || !cursorUpdated) mFloatingWindowTimer.postShowFloatingWindow();
       } else {

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -112,6 +112,7 @@ public class Trime extends InputMethodService
   private boolean cursorUpdated = false; //光標是否移動
   private int min_length; //上悬浮窗的候选词的最小词长
   private int min_check; // 第一屏候选词数量少于设定值，则候选词上悬浮窗。（也就是说，第一屏存在长词）此选项大于1时，min_length等参数失效
+  private int real_margin; // 悬浮窗与屏幕两侧的间距
   private boolean mTempAsciiMode; //臨時中英文狀態
   private boolean mAsciiMode; //默認中英文狀態
   private boolean reset_ascii_mode; //重置中英文狀態
@@ -158,6 +159,7 @@ public class Trime extends InputMethodService
     winPos = WindowsPositionType.DRAG;
     winX = offsetX;
     winY = offsetY;
+    android.util.Log.d("updateWindow", "winX="+winX+" winY="+winY);
     mFloatingWindow.update(winX, winY, -1, -1, true);
   }
 
@@ -245,13 +247,20 @@ public class Trime extends InputMethodService
       }
       if (x < 0) x = 0;
       if (x > mCandidateContainer.getWidth() - mFloatingWindow.getWidth()) {
+//        此处存在bug，暂未梳理原有算法的问题，单纯根据真机横屏显示长候选词超出屏幕进行了修复
+//        log： mCandidateContainer.getWidth()=1328  mFloatingWindow.getWidth()= 1874 导致x结果为负，超出屏幕。
         x = mCandidateContainer.getWidth() - mFloatingWindow.getWidth();
+        if (x < 0) x = 0;
       }
       if (y < 0) y = 0;
       if (y > mParentLocation[1] - mFloatingWindow.getHeight() - candSpacing) { //candSpacing爲負時，可覆蓋部分鍵盤
         y = mParentLocation[1] - mFloatingWindow.getHeight() - candSpacing;
       }
       y -= getStatusBarHeight(); //不包含狀態欄
+
+      if(x<real_margin)
+        x=real_margin;
+
       if (!mFloatingWindow.isShowing()) {
         mFloatingWindow.showAtLocation(mCandidateContainer, Gravity.START | Gravity.TOP, x, y);
       } else {
@@ -267,6 +276,7 @@ public class Trime extends InputMethodService
     candSpacing = mConfig.getPixel("layout/spacing");
     min_length = mConfig.getInt("layout/min_length");
     min_check = mConfig.getInt("layout/min_check");
+    real_margin = mConfig.getPixel("layout/real_margin");
     reset_ascii_mode = mConfig.getBoolean("reset_ascii_mode");
     auto_caps = mConfig.getString("auto_caps");
     mShowWindow = getPrefs().getKeyboard().getFloatingWindowEnabled()

--- a/app/src/main/res/layout-land/input_root.xml
+++ b/app/src/main/res/layout-land/input_root.xml
@@ -9,7 +9,7 @@
         android:layout_width="10dp"
         android:layout_height="match_parent" />
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
@@ -18,6 +18,7 @@
 
         <com.osfans.trime.xScrollView
             android:id="@+id/scroll"
+            android:scrollbars="none"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:fillViewport="true">

--- a/app/src/main/res/layout/input_root.xml
+++ b/app/src/main/res/layout/input_root.xml
@@ -6,6 +6,7 @@
 
     <com.osfans.trime.xScrollView
         android:id="@+id/scroll"
+        android:scrollbars="none"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fillViewport="true">
@@ -20,9 +21,21 @@
         </LinearLayout>
     </com.osfans.trime.xScrollView>
 
-    <com.osfans.trime.KeyboardView
-        android:id="@+id/keyboard"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        />
+        android:orientation="horizontal">
+        <View
+            android:id="@+id/spacer_left"
+            android:layout_width="0dp"
+            android:layout_height="match_parent" />
+        <com.osfans.trime.KeyboardView
+            android:id="@+id/keyboard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <View
+            android:id="@+id/spacer_right"
+            android:layout_width="0dp"
+            android:layout_height="match_parent" />
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
由于上游已经合并了https://github.com/osfans/trime/pull/466 ，故关闭 https://github.com/osfans/trime/pull/467 并重新提交。
对悬浮窗进行完善，并对https://github.com/osfans/trime/pull/462 提交的代码做了一些完善。
- [x]  候选栏去除滚动条，减少UI缝合感。
- [x]  皮肤增加参数keyboard_padding。用于竖屏状态下，为曲面屏添加屏幕左右两侧到键盘区域的间隙。注意横屏和竖屏布局略有差异，横屏按键区域与候选栏同步缩小，而竖屏只缩小了按键区域。
- [x]  修改悬浮窗，增加皮肤参数 layout/min_check，只要前n个候选词有长度大于等于min_length的词，就会把长度符合以及之前的词全部加到悬浮窗内。和原有参数all_phrases不同，all_phrases会让悬浮窗显示的长词和候选栏的词重复，min_check是让前半部分的候选词不分长短全部上屏。
- [x]  修改悬浮窗，增加皮肤参数layout/real_margin。原有皮肤参数margin_x margin_y本质是padding参数，控制悬浮窗文本和边框的距离。引入的新参数可以控制屏幕左右边缘和悬浮窗之间的距离。
- [x]  对悬浮窗超出屏幕左侧进行了表面修复。
- [x]  修改trime.yaml，添加近期新增的皮肤参数