### PR TITLE
增加全屏模式，若干优化

### DIFF
--- a/app/src/main/java/com/osfans/trime/Config.java
+++ b/app/src/main/java/com/osfans/trime/Config.java
@@ -32,6 +32,7 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.NinePatchDrawable;
 import android.os.SystemClock;
+import android.util.Log;
 import android.util.TypedValue;
 
 import com.osfans.trime.enums.WindowsPositionType;
@@ -115,6 +116,8 @@ public class Config {
 
     getPrefs().getOther().setClipboardOutputRules(s);
   }
+
+  public String getFullscreenMode(){ return getPrefs().getKeyboard().getFullscreenMode();}
 
   public String getTheme() {
     return themeName;
@@ -215,7 +218,7 @@ public class Config {
       assets = assetManager.list(assetPath);
       if (assets.length == 0) {
         // Files
-        copyFile(context, path, overwrite); 
+        copyFile(context, path, overwrite);
       } else {
         // Dirs
         File dir = new File(getSharedDataDir(), path);
@@ -239,8 +242,10 @@ public class Config {
     try {
       String assetPath = new File(RIME, filename).getPath();
       in = assetManager.open(assetPath);
-      String newFileName = new File(filename.endsWith(".bin") ? getUserDataDir() : getSharedDataDir(), filename).getPath();
-      if (new File(newFileName).exists() && !overwrite) return true;
+      File f = new File(getSharedDataDir(), filename);
+      String newFileName = f.getPath();
+      Log.d("copyFile()","from="+assetPath+" to="+newFileName+" overwrite="+overwrite);
+      if (f.exists() && !overwrite) return true;
       out = new FileOutputStream(newFileName);
       int BLK_SIZE = 1024;
       byte[] buffer = new byte[BLK_SIZE];

--- a/app/src/main/java/com/osfans/trime/IntentReceiver.java
+++ b/app/src/main/java/com/osfans/trime/IntentReceiver.java
@@ -23,6 +23,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.osfans.trime.util.RimeUtils;
 

--- a/app/src/main/java/com/osfans/trime/ime/core/Preferences.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/Preferences.kt
@@ -145,6 +145,7 @@ class Preferences(
             const val POPUP_KEY_PRESS_ENABLED =  "keyboard__show_key_popup"
             const val SWITCHES_ENABLED =         "keyboard__show_switches"
             const val SWITCH_ARROW_ENABLED =     "keyboard__show_switch_arrow"
+            const val FULLSCREEN_MODE =          "keyboard__fullscreen_mode"
 
             const val SOUND_ENABLED =          "keyboard__key_sound"
             const val SOUND_VOLUME =           "keyboard__key_sound_volume"
@@ -162,6 +163,9 @@ class Preferences(
         var inlinePreedit: InlineModeType
             get()  = InlineModeType.fromString(prefs.getPref(INLINE_PREEDIT_MODE, "preview"))
             set(v) = prefs.setPref(INLINE_PREEDIT_MODE, v)
+        var fullscreenMode: String
+            get()  = prefs.getPref(FULLSCREEN_MODE, "auto")
+            set(v) = prefs.setPref(FULLSCREEN_MODE, v)
         var softCursorEnabled: Boolean = false
             get() = prefs.getPref(SOFT_CURSOR_ENABLED, true)
             private set
@@ -284,6 +288,6 @@ class Preferences(
             set(v) = prefs.setPref(CLIPBOARD_OUTPUT_RULES, v)
         var clipboardManagerRules: String
             get()  = prefs.getPref(CLIPBOARD_MANAGER_RULES, "")
-            set(v) = prefs.setPref(CLIPBOARD_MANAGER_RULES, "")
+            set(v) = prefs.setPref(CLIPBOARD_MANAGER_RULES, v)
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -50,6 +50,7 @@ import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.PopupWindow;
 
@@ -390,7 +391,7 @@ public class Trime extends InputMethodService
   public void invalidate() {
     Rime.get(this);
     if (mConfig != null) mConfig.destroy();
-    mConfig = new Config(this);
+    mConfig = Config.get(this);
     reset();
     mNeedUpdateRimeOption = true;
   }
@@ -1345,6 +1346,73 @@ public class Trime extends InputMethodService
   }
 
 
+  @Override
+  public void updateFullscreenMode(){
+    super.updateFullscreenMode();
+//  to-do  需要获取到文本编辑框、完成按钮，设置其色彩和尺寸。
+    View inputArea = getWindow().findViewById(android.R.id.inputArea);
+    int layoutHeight = isFullscreenMode()?
+      WindowManager.LayoutParams.WRAP_CONTENT:WindowManager.LayoutParams.MATCH_PARENT;
+
+    if(isFullscreenMode()){
+      android.util.Log.d("isFullScreen","");
+      inputArea.setBackgroundColor(parseColor("#ff660000"));
+    }else{
+      android.util.Log.d("isFullScreen","");
+      inputArea.setBackgroundColor(parseColor("#ffdddddd"));
+    }
+
+    updateViewHeight(mInputRoot, layoutHeight);
+    updateViewHeight(inputArea, layoutHeight);
+    updateLayoutGravity( inputArea, Gravity.BOTTOM);
+  }
+
+  public boolean onEvaluateFullscreenMode() {
+    if(orientation != Configuration.ORIENTATION_LANDSCAPE)
+      return false;
+    switch (mConfig.getFullscreenMode()){
+      case "auto":
+        EditorInfo ei = getCurrentInputEditorInfo();
+        if ( ei != null  && (ei.imeOptions & EditorInfo.IME_FLAG_NO_FULLSCREEN) != 0) {
+          return false;
+        }
+      case "always":
+        return true;
+      case "never":
+        return false;
+    }
+    return false;
+  }
+
+  public void updateViewHeight(View view,  int layoutHeight) {
+    if(null == view)
+      return;
+    LayoutParams params = view.getLayoutParams();
+    if (params != null && params.height != layoutHeight){
+      params.height = layoutHeight;
+      view.setLayoutParams(params);
+    }
+  }
+
+  public void updateLayoutGravity(View view, int layoutGravity) {
+    if(null == view)
+      return;
+    LayoutParams params = view.getLayoutParams();
+
+    if (params instanceof LinearLayout.LayoutParams) {
+      LinearLayout.LayoutParams lp = (LinearLayout.LayoutParams)params;
+      if (lp.gravity != layoutGravity) {
+        lp.gravity = layoutGravity;
+        view.setLayoutParams(params);
+      }
+    } else if (params instanceof FrameLayout.LayoutParams) {
+      LinearLayout.LayoutParams lp = (LinearLayout.LayoutParams)params;
+      if (lp.gravity != layoutGravity) {
+        lp.gravity = layoutGravity;
+        view.setLayoutParams(params);
+      }
+    }
+  }
 
   private String ClipBoardString="";
 

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -46,6 +46,7 @@ import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.WindowManager.*;
 import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
@@ -160,7 +161,7 @@ public class Trime extends InputMethodService
     winPos = WindowsPositionType.DRAG;
     winX = offsetX;
     winY = offsetY;
-    android.util.Log.d("updateWindow", "winX="+winX+" winY="+winY);
+    Log.info("updateWindow: winX="+winX+" winY="+winY);
     mFloatingWindow.update(winX, winY, -1, -1, true);
   }
 
@@ -1352,14 +1353,16 @@ public class Trime extends InputMethodService
 //  to-do  需要获取到文本编辑框、完成按钮，设置其色彩和尺寸。
     View inputArea = getWindow().findViewById(android.R.id.inputArea);
     int layoutHeight = isFullscreenMode()?
-      WindowManager.LayoutParams.WRAP_CONTENT:WindowManager.LayoutParams.MATCH_PARENT;
+      LayoutParams.WRAP_CONTENT:LayoutParams.MATCH_PARENT;
 
     if(isFullscreenMode()){
-      android.util.Log.d("isFullScreen","");
+      Log.info("isFullScreen");
+      //全屏模式下，当键盘布局包含透明色时，用户能透过键盘看到待输入App的UI，影响全屏体验。故需填色。当前固定填充淡粉色，用于测试。
       inputArea.setBackgroundColor(parseColor("#ff660000"));
     }else{
-      android.util.Log.d("isFullScreen","");
-      inputArea.setBackgroundColor(parseColor("#ffdddddd"));
+      Log.info("isFullScreen");
+      //非全屏模式下，这个颜色似乎不会体现出来。为避免出现问题，填充浅灰色
+      inputArea.setBackgroundColor(parseColor("#dddddddd"));
     }
 
     updateViewHeight(mInputRoot, layoutHeight);

--- a/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/PrefMainActivity.kt
@@ -145,7 +145,7 @@ class PrefMainActivity: AppCompatActivity(),
                             Log.e(FRAGMENT_TAG, "Deploy Exception: $ex")
                         } finally {
                             progressDialog.dismiss()
-                            exitProcess(0)
+//                              exitProcess(0)
                         }
                     }.run()
                 }

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -45,7 +45,7 @@ class OtherFragment: PreferenceFragmentCompat(),
     override fun onPreferenceTreeClick(preference: Preference?): Boolean {
         return when (preference?.key) {
             "other__clipboard_manager" -> {
-                PreferenceManager.getDefaultSharedPreferences(context).getString("pref_clipboard_manager", "")
+                PreferenceManager.getDefaultSharedPreferences(context).getString(preference?.key, "")
                     ?.let {
                         ClipBoardManagerDialog(requireContext(),
                             it

--- a/app/src/main/java/com/osfans/trime/util/RimeUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/RimeUtils.kt
@@ -1,6 +1,8 @@
 package com.osfans.trime.util
 
 import android.content.Context
+import android.widget.Toast
+import com.osfans.trime.R
 import com.osfans.trime.Rime
 import kotlin.system.exitProcess
 
@@ -17,6 +19,7 @@ object RimeUtils {
     fun deploy(context: Context) {
         Rime.destroy()
         Rime.get(context, true)
+        Toast.makeText(context,context.getString(R.string.deploy_finish), Toast.LENGTH_LONG).show();
     }
 
     fun sync(context: Context) = Rime.syncUserData(context)

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -122,4 +122,11 @@
     <string name="other__clipboard_output_title">剪贴板过滤规则(每行为一条正则表达式)</string>
     <string name="other__clipboard_manager_summary">剪贴板内容变化时，自动发送剪贴板内容给选定的应用</string>
     <string name="keyboard__show_switche_arrow_title">在候选栏中显示状态时带箭头符号</string>
+    <string name="keyboard__fullscreen_mode_title">横屏时全屏编辑</string>
+    <string name="deploy_finish">部署完成</string>
+    <string-array name="keyboard__fullscreen_mode_entries">
+        <item>自动</item>
+        <item>总是</item>
+        <item>从不</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -123,4 +123,11 @@
     <string name="other__clipboard_output_title">剪貼板過濾規則(每行爲一條正則規則)</string>
     <string name="other__clipboard_manager_summary">剪貼板內容變化時，自動發送剪貼板內容給選定的應用</string>
     <string name="keyboard__show_switche_arrow_title">在候選欄中顯示狀態時帶箭頭符號</string>
+    <string name="keyboard__fullscreen_mode_title">橫屏時全屏編輯</string>
+    <string name="deploy_finish">部署完成</string>
+    <string-array name="keyboard__fullscreen_mode_entries">
+        <item>自動</item>
+        <item>總是</item>
+        <item>從不</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -35,8 +35,11 @@
         <item>light</item>
         <item>dark</item>
     </string-array>
-
-
+    <string-array name="keyboard__fullscreen_mode_values">
+        <item>auto</item>
+        <item>always</item>
+        <item>never</item>
+    </string-array>
     <string name="default_shared_data_dir" translatable="false">/sdcard/rime</string>
     <string name="conf__default_user_data_dir" translatable="false">/sdcard/rime</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,4 +123,11 @@
     <string name="other__clipboard_output_title">Clipboard Output Rules</string>
     <string name="other__clipboard_manager_summary">Send clipboard text to the selected App when the Clipboard is modified.</string>
     <string name="keyboard__show_switche_arrow_title">Show arrow for candidate switch</string>
+    <string name="keyboard__fullscreen_mode_title">Landscape fullscreen input</string>
+    <string name="deploy_finish">Deploy finish</string>
+    <string-array name="keyboard__fullscreen_mode_entries">
+        <item>auto</item>
+        <item>always</item>
+        <item>never</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -14,6 +14,13 @@
             android:entryValues="@array/keyboard__inline_values"
             android:defaultValue="preview"
             app:useSimpleSummaryProvider="true"/>
+        <ListPreference android:key="keyboard__fullscreen_mode"
+            app:iconSpaceReserved="false"
+            android:title="@string/keyboard__fullscreen_mode_title"
+            android:entries="@array/keyboard__fullscreen_mode_entries"
+            android:entryValues="@array/keyboard__fullscreen_mode_values"
+            android:defaultValue="preview"
+            app:useSimpleSummaryProvider="true"/>
         <SwitchPreferenceCompat android:key="keyboard__soft_cursor"
             app:iconSpaceReserved="false"
             android:title="@string/keyboard__soft_cursor_title"


### PR DESCRIPTION

- [x]  增加全屏模式（全屏模式下的文本框、按钮样式的设置目前无法实现）
- [x]  修复config重构造成的剪贴板管理器失效
- [x]  简化asset路径算法。asset实际上需要全部拷贝到公用目录，并不需要多次判断
- [x]  部署结束toast消息，不自动退出