### PR TITLE
fix: crash when typing with Shift key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation "androidx.core:core-ktx:1.3.2"
     implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "androidx.preference:preference-ktx:1.1.1"
-    implementation "androidx.fragment:fragment-ktx:1.3.0"
+    implementation "androidx.fragment:fragment-ktx:1.3.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -48,12 +48,10 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.Window;
 import android.view.WindowManager;
-import android.view.WindowManager.*;
 import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
-
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.PopupWindow;
@@ -62,20 +60,19 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.blankj.utilcode.util.BarUtils;
-import com.osfans.trime.ime.text.Candidate;
-import com.osfans.trime.ime.text.Composition;
-import com.osfans.trime.ime.keyboard.Event;
-import com.osfans.trime.util.Function;
-import com.osfans.trime.ime.keyboard.Key;
-import com.osfans.trime.ime.keyboard.Keyboard;
-import com.osfans.trime.ime.keyboard.KeyboardSwitch;
-import com.osfans.trime.ime.keyboard.KeyboardView;
 import com.osfans.trime.R;
 import com.osfans.trime.Rime;
 import com.osfans.trime.databinding.CompositionContainerBinding;
 import com.osfans.trime.databinding.InputRootBinding;
 import com.osfans.trime.ime.enums.InlineModeType;
 import com.osfans.trime.ime.enums.WindowsPositionType;
+import com.osfans.trime.ime.keyboard.Event;
+import com.osfans.trime.ime.keyboard.Key;
+import com.osfans.trime.ime.keyboard.Keyboard;
+import com.osfans.trime.ime.keyboard.KeyboardSwitch;
+import com.osfans.trime.ime.keyboard.KeyboardView;
+import com.osfans.trime.ime.text.Candidate;
+import com.osfans.trime.ime.text.Composition;
 import com.osfans.trime.ime.text.xScrollView;
 import com.osfans.trime.settings.PrefMainActivity;
 import com.osfans.trime.settings.components.ColorPickerDialog;
@@ -83,6 +80,7 @@ import com.osfans.trime.settings.components.SchemaPickerDialog;
 import com.osfans.trime.settings.components.ThemePickerDialog;
 import com.osfans.trime.setup.Config;
 import com.osfans.trime.setup.IntentReceiver;
+import com.osfans.trime.util.Function;
 import com.osfans.trime.util.LocaleUtils;
 
 import java.util.Locale;
@@ -1090,8 +1088,8 @@ public class Trime extends InputMethodService
     }
     String s = text.toString();
     String t;
-    final Pattern p = Pattern.compile("^(\\{[^{}]+}).*$");
-    final Pattern pText = Pattern.compile("^((\\{Escape})?[^{}]+).*$");
+    final Pattern p = Pattern.compile("^(\\{[^{}]+\\}).*$");
+    final Pattern pText = Pattern.compile("^((\\{Escape\\})?[^{}]+).*$");
     while (s.length() > 0) {
       Matcher m = pText.matcher(s);
       if (m.matches()){


### PR DESCRIPTION
also:
- Update implementation `fragment-ktx` to 1.3.2


这个正则表达式弄得我很迷，AS 说有有多余的字符，但是真的按照提示去掉了，输入上档时就会报错崩溃 ...... 以及把这个正则表达放入[工具](https://regex101.com)中按 Java 8 标准检测也提示有语法错误......