### PR TITLE
chore(jni): allow specifying prebuilt JNI libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
     }
 
     signingConfigs {
-       release {
-       }
+        release {
+        }
     }
 
     buildTypes {
@@ -25,6 +25,17 @@ android {
             //proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-android.txt'
             signingConfig signingConfigs.release
         }
+    }
+
+    // Use prebuilt JNI library if the 'app/prebuilt' exists
+    //
+    // Steps to generate the prebuilt directory:
+    // $ ./gradlew app:assembleRelease
+    // $ cp --recursive app/build/intermediates/stripped_native_libs/universalRelease/out/lib app/prebuilt
+    if (file("prebuilt").exists()) {
+        sourceSets.main.jniLibs.srcDirs = ['prebuilt']
+    } else {
+        externalNativeBuild.cmake.path = "src/main/jni/CMakeLists.txt"
     }
 
     def propsFile = rootProject.file('keystore.properties') //store release config in keystore.properties
@@ -47,7 +58,6 @@ android {
 
     externalNativeBuild {
         cmake {
-            path "src/main/jni/CMakeLists.txt"
             // TODO: upgrade to 3.18
             // see https://issuetracker.google.com/issues/187134648
             version "3.10.2"


### PR DESCRIPTION
The next step is adding a CI to push prebuilt to releases, and a
method to download them before build

So users don't have to fetch submodules anymore

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
