### PR TITLE
chore: enable building multiple apks per abi

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,24 +64,23 @@ android {
         }
     }
 
-    flavorDimensions 'cpuArch'
-    productFlavors {
-        arm {
-            dimension 'cpuArch'
-            ndk {
-                abiFilters 'arm64-v8a', 'armeabi-v7a'
-            }
-        }
-        x86 {
-            dimension 'cpuArch'
-            ndk {
-                abiFilters 'x86_64', 'x86'
-            }
-        }
-        universal {
-            dimension 'cpuArch'
-            // include all default ABIs. with NDK-r16,  it is:
-            //   armeabi-v7a, arm64-v8a, x86, x86_64
+    splits {
+        // Configures multiple APKs based on ABI.
+        abi {
+            // Enables building multiple APKs per ABI.
+            enable true
+
+            // By default all ABIs are included, so use reset() and include to specify that we only
+            // want APKs for x86 and x86_64.
+
+            // Resets the list of ABIs that Gradle should create APKs for to none.
+            reset()
+
+            // Specifies a list of ABIs that Gradle should create APKs for.
+            include "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
+
+            // Specifies that we do not want to also generate a universal APK that includes all ABIs.
+            universalApk true
         }
     }
 }


### PR DESCRIPTION
## Pull request

#### Feature
Describe feature of pull request

Enable multiple apks per abi ensures smaller apk,
and users can choose best fit by themself.

tree -h app/build/outputs/apk/
app/build/outputs/apk/
└── [ 256]  release
    ├── [1.5K]  output-metadata.json
    ├── [4.9M]  trime-3.2.4-arm64-v8a-release.apk
    ├── [4.8M]  trime-3.2.4-armeabi-v7a-release.apk
    ├── [9.2M]  trime-3.2.4-universal-release.apk
    ├── [5.1M]  trime-3.2.4-x86-release.apk
    └── [5.1M]  trime-3.2.4-x86_64-release.apk

1 directory, 6 files

https://developer.android.com/studio/build/configure-apk-splits.html#configure-density-split

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
