### PR TITLE
Skip to install dependency if hit cache

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -4,15 +4,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependency
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
-          sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
-          sudo apt update
-          sudo apt-get -t experimental -y install capnproto=0.8.0-1
-          sudo apt-get -y install opencc inkscape
-
       - name: Checkout last commit
         uses: actions/checkout@v2
         with:
@@ -47,6 +38,10 @@ jobs:
 
       - name: Spotless code style check
         run: make spotless
+
+      - name: Install dependency
+        if: ${{ !steps.jni-cache.outputs.cache-hit }}
+        run: ./script/dependency.sh
 
       - name: Build Trime
         run: make debug

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload Trime artifact
         uses: actions/upload-artifact@v2
         with:
-          name: outputs
+          name: trime.zip
           path: app/build/outputs/apk/**/*.apk
           # keep 360 days
           retention-days: 360

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -4,14 +4,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependency
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
-          sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
-          sudo apt update
-          sudo apt-get -t experimental -y install capnproto=0.8.0-1
-
       - name: Checkout last commit
         uses: actions/checkout@v2
         with:
@@ -46,6 +38,10 @@ jobs:
 
       - name: Spotless code style check
         run: make spotless
+
+      - name: Install dependency
+        if: ${{ !steps.jni-cache.outputs.cache-hit }}
+        run: ./script/dependency.sh
 
       - name: Build Trime
         run: make debug

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload Trime artifact
         uses: actions/upload-artifact@v2
         with:
-          name: outputs
+          name: trime.zip
           path: app/build/outputs/apk/**/*.apk
           # keep 30 days
           retention-days: 30

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -7,15 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependency
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
-          sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
-          sudo apt update
-          sudo apt-get -t experimental -y install capnproto=0.8.0-1
-          sudo apt-get -y install opencc inkscape
-
       - name: Checkout last commit
         uses: actions/checkout@v2
         with:
@@ -55,6 +46,10 @@ jobs:
           
       - name: Spotless code style check
         run: make spotless
+
+      - name: Install dependency
+        if: ${{ !steps.jni-cache.outputs.cache-hit }}
+        run: ./script/dependency.sh
 
       - name: Build Trime
         run: make debug

--- a/script/dependency.sh
+++ b/script/dependency.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
+sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
+sudo apt update
+sudo apt-get -t experimental -y install capnproto=0.8.0-1


### PR DESCRIPTION
## Pull request

1. extract dependency installation to standalone script
2. ignore installation if we have hit cache
3. change multiple artifacts to 'trime.zip'

We can save about 47s of ci time

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
