### PR TITLE
chore: upgrade capnproto to 0.9.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/lotem/librime-octagram.git
 [submodule "app/src/main/jni/capnproto"]
 	path = app/src/main/jni/capnproto
-	url = https://github.com/lotem/capnproto.git
+	url = https://github.com/capnproto/capnproto.git
 [submodule "app/src/main/jni/librime-charcode"]
 	path = app/src/main/jni/librime-charcode
 	url = https://github.com/rime/librime-charcode

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,7 +86,7 @@ android {
 }
 
 dependencies {
-    implementation 'org.ocpsoft.prettytime:prettytime:5.0.1.Final'
+    implementation 'org.ocpsoft.prettytime:prettytime:5.0.2.Final'
     implementation 'com.blankj:utilcodex:1.30.6'
     implementation 'com.jakewharton.timber:timber:5.0.1'
     implementation "androidx.core:core-ktx:1.3.2"

--- a/script/dependency.sh
+++ b/script/dependency.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
-sudo add-apt-repository 'deb http://deb.debian.org/debian experimental main'
-sudo apt update
-sudo apt-get -t experimental -y install capnproto=0.8.0-1
+# version on submodule must match
+# update summodule if you change this
+version=0.9.1
+echo "$(nproc) thread to build"
+curl -O https://capnproto.org/capnproto-c++-${version}.tar.gz
+tar zxf capnproto-c++-${version}.tar.gz
+cd capnproto-c++-${version}
+./configure
+make -j$(nproc)
+sudo make install

--- a/script/dependency.sh
+++ b/script/dependency.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-# version on submodule must match
-# update summodule if you change this
-version=0.9.1
-echo "$(nproc) thread to build"
-curl -O https://capnproto.org/capnproto-c++-${version}.tar.gz
-tar zxf capnproto-c++-${version}.tar.gz
-cd capnproto-c++-${version}
+
+# build from submodule source, keep same version
+echo "$(nproc) threads to build"
+cd app/src/main/jni/capnproto/c++
+autoreconf -i
 ./configure
 make -j$(nproc)
 sudo make install


### PR DESCRIPTION
## Pull request
`
1. switch to official upstream repo
2. upgrade capnproto to 0.9.1
3. install capnproto from source

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
