### PR TITLE
fix(ci): set 90 retention days in commit ci

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -55,5 +55,5 @@ jobs:
         with:
           name: trime.zip
           path: app/build/outputs/apk/**/*.apk
-          # keep 360 days
-          retention-days: 360
+          # keep 90 days
+          retention-days: 90


### PR DESCRIPTION
## Pull request

Warning: 'Retention days is greater than the max value allowed by the repository setting, reduce retention to 90 days'

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
