### PR TITLE
Enable manually trigger jni build with trick

### DIFF
--- a/magic.txt
+++ b/magic.txt
@@ -1,0 +1,3 @@
+# increase this number will invalid jni cache
+# this number will count the trigger
+0

--- a/script/cache-hash.sh
+++ b/script/cache-hash.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-JNI_FILES="app/build.gradle app/src/main/jni/cmake/* app/src/main/jni/librime_jni/* app/src/main/jni/CMakeLists.txt"
+JNI_FILES="magic.txt app/build.gradle app/src/main/jni/cmake/* app/src/main/jni/librime_jni/* app/src/main/jni/CMakeLists.txt"
 
 hash=$(git submodule status)
 hash=$hash$(sha256sum $JNI_FILES)


### PR DESCRIPTION
## Pull request

Enable manually trigger jni build with trick

#### Issue tracker
Fixes will automatically close the related issue

Fixes #608

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
