### PR TITLE
chore: disable universal APK that includes all ABIs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,7 @@ android {
             include "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
 
             // Specifies that we do not want to also generate a universal APK that includes all ABIs.
-            universalApk true
+            universalApk false
         }
     }
 }


### PR DESCRIPTION
## Pull request

The debug universal is about 17.2MB in per pull request ci
and commit ci artifactory zip, it's so big for slow github
download speed

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
