### PR TITLE
feat: add sticky_lines_land for candidate window

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -45,6 +45,7 @@ style:
     min_length: 4 #候选窗口最小词长
     max_length: 14 #超过字数则换行
     sticky_lines: 1 #固顶行数
+    sticky_lines_land: 0 #横屏模式下的固顶行数
     max_entries: 5 #候选窗口最大词条数
     border: 0 #候选窗口边框宽度
     max_width: 360 #最大宽度，超过则自动换行

--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -33,6 +33,7 @@ style:
     min_length: 5 #最小詞長
     max_length: 10 #超過字數則換行
     sticky_lines: 0 #固頂行數
+    sticky_lines_land: 0 #横屏模式下的固顶行数
     max_entries: 1 #最大詞條數
     min_check: 3 #只要前n个候选词有长度大于等于min_length的词，就会把长度符合以及之前的词全部加到悬浮窗内。
     all_phrases: false #所有滿足條件的詞語都顯示在窗口

--- a/app/src/main/java/com/osfans/trime/ime/landscapeinput/LandscapeInputUIMode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/landscapeinput/LandscapeInputUIMode.kt
@@ -1,13 +1,18 @@
 package com.osfans.trime.ime.landscapeinput
 
+import java.util.Locale
+import kotlin.collections.HashMap
+
 enum class LandscapeInputUIMode {
     AUTO_SHOW,
     ALWAYS_SHOW,
     NEVER_SHOW;
 
     companion object {
-        fun fromString(string: String): LandscapeInputUIMode {
-            return valueOf(string.uppercase())
+        private val convertMap: HashMap<String, LandscapeInputUIMode> = hashMapOf()
+        fun fromString(mode: String): LandscapeInputUIMode {
+            val type = convertMap[mode.uppercase(Locale.getDefault())]
+            return type ?: AUTO_SHOW
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/text/Composition.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Composition.java
@@ -21,6 +21,7 @@ package com.osfans.trime.ime.text;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.os.Build.VERSION;
@@ -60,7 +61,7 @@ public class Composition extends AppCompatTextView {
   private Integer key_back_color;
   private Typeface tfText, tfLabel, tfCandidate, tfComment;
   private final int[] composition_pos = new int[2];
-  private int max_length, sticky_lines;
+  private int max_length, sticky_lines, sticky_lines_land;
   private int max_entries = Candidate.getMaxCandidateCount();
   private boolean candidate_use_cursor, show_comment;
   private int highlightIndex;
@@ -261,6 +262,7 @@ public class Composition extends AppCompatTextView {
     setPadding(margin_x, margin_y, margin_x, margin_bottom);
     max_length = config.getInt("layout/max_length");
     sticky_lines = config.getInt("layout/sticky_lines");
+    sticky_lines_land = config.getInt("layout/sticky_lines_land");
     movable = config.getString("layout/movable");
     all_phrases = config.getBoolean("layout/all_phrases");
     tfLabel = config.getFont("label_font");
@@ -366,6 +368,12 @@ public class Composition extends AppCompatTextView {
     String line = Config.getString(m, "sep");
 
     int line_length = 0;
+    int sticky_lines_now = sticky_lines;
+    if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+      sticky_lines_now = sticky_lines_land;
+    }
+    //    Timber.d("sticky_lines_now = %d", sticky_lines_now);
+
     String[] labels = Rime.getSelectLabels();
     int i = -1;
     candidate_num = 0;
@@ -384,7 +392,7 @@ public class Composition extends AppCompatTextView {
       final String line_sep;
       if (candidate_num == 0) {
         line_sep = sep;
-      } else if ((sticky_lines > 0 && sticky_lines >= i)
+      } else if ((sticky_lines_now > 0 && sticky_lines_now >= i)
           || (max_length > 0 && line_length + cand.length() > max_length)) {
         line_sep = "\n";
         line_length = 0;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #
https://github.com/osfans/trime/issues/607

#### Feature
Add sticky_lines_land for candidate window
横屏竖屏下，悬浮窗显示候选词的样式显然不宜完全相同。但是为横屏模式完全重写一套参数似乎并不合适。增加的sticky_lines_land控制皮肤在横屏模式下，与竖屏模式显示不同的行数；从而一定程度缓解了这个问题。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
