### PR TITLE
feat: add sound package support

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Preferences.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/Preferences.kt
@@ -172,6 +172,7 @@ class Preferences(
 
             const val SOUND_ENABLED = "keyboard__key_sound"
             const val SOUND_VOLUME = "keyboard__key_sound_volume"
+            const val SOUND_PACKAGE = "keyboard__key_sound_package"
 
             const val VIBRATION_ENABLED = "keyboard__key_vibration"
             const val VIBRATION_DURATION = "keyboard__key_vibration_duration"
@@ -208,6 +209,9 @@ class Preferences(
         var soundEnabled: Boolean = false
             get() = prefs.getPref(SOUND_ENABLED, false)
             private set
+        var soundPackage: String
+            get() = prefs.getPref(SOUND_PACKAGE, "")
+            set(v) = prefs.setPref(SOUND_PACKAGE, v)
         var soundVolume: Int = 0
             get() = prefs.getPref(SOUND_VOLUME, 100)
             private set

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -78,6 +78,7 @@ import com.osfans.trime.ime.text.TextInputManager;
 import com.osfans.trime.settings.PrefMainActivity;
 import com.osfans.trime.settings.components.ColorPickerDialog;
 import com.osfans.trime.settings.components.SchemaPickerDialog;
+import com.osfans.trime.settings.components.SoundPickerDialog;
 import com.osfans.trime.settings.components.ThemePickerDialog;
 import com.osfans.trime.setup.Config;
 import com.osfans.trime.setup.IntentReceiver;
@@ -940,6 +941,10 @@ public class Trime extends LifecycleInputMethodService {
   /** 彈出{@link ThemePickerDialog 主題對話框} */
   public void showThemeDialog() {
     new ThemePickerDialog(this).show();
+  }
+  /** 彈出{@link SoundPickerDialog 音效包对话框} */
+  public void showSoundDialog() {
+    new SoundPickerDialog(this).show();
   }
 
   /** Hides the IME and launches {@link PrefMainActivity}. */

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/InputFeedbackManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/InputFeedbackManager.kt
@@ -91,18 +91,21 @@ class InputFeedbackManager(
     fun keyPressSound(keyCode: Int? = null) {
         if (prefs.keyboard.soundEnabled) {
             val soundVolume = prefs.keyboard.soundVolume
-            val effect = when (keyCode) {
-                KeyEvent.KEYCODE_SPACE -> AudioManager.FX_KEYPRESS_SPACEBAR
-                KeyEvent.KEYCODE_DEL -> AudioManager.FX_KEYPRESS_DELETE
-                KeyEvent.KEYCODE_ENTER -> AudioManager.FX_KEYPRESS_RETURN
-                else -> AudioManager.FX_KEYPRESS_STANDARD
-            }
-
-            if (soundVolume > 0) {
-                audioManager!!.playSoundEffect(
-                    effect,
-                    (1 - (ln((101.0 - soundVolume)) / ln(101.0))).toFloat()
-                )
+            if (Sound.get().isEnable)
+                Sound.get().play(keyCode, soundVolume)
+            else {
+                if (soundVolume > 0) {
+                    val effect = when (keyCode) {
+                        KeyEvent.KEYCODE_SPACE -> AudioManager.FX_KEYPRESS_SPACEBAR
+                        KeyEvent.KEYCODE_DEL -> AudioManager.FX_KEYPRESS_DELETE
+                        KeyEvent.KEYCODE_ENTER -> AudioManager.FX_KEYPRESS_RETURN
+                        else -> AudioManager.FX_KEYPRESS_STANDARD
+                    }
+                    audioManager!!.playSoundEffect(
+                        effect,
+                        (1 - (ln((101.0 - soundVolume)) / ln(101.0))).toFloat()
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Sound.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Sound.java
@@ -1,0 +1,181 @@
+package com.osfans.trime.ime.keyboard;
+
+import android.media.AudioManager;
+import android.media.SoundPool;
+import android.view.KeyEvent;
+import com.osfans.trime.util.DataUtils;
+import com.osfans.trime.util.YamlUtils;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class Sound {
+  private final SoundPool sp; // 声明SoundPool的引用
+  private int currStreamId; // 当前正播放的streamId
+  private int lastKeycode; // 上次按键的键盘码
+  private int[] sound; // 音频文件列表
+  private final List<Key> keyset;
+  private static Sound self;
+  private final boolean enable;
+
+  public static Sound get() {
+    return self;
+  }
+
+  public static Sound get(String soundPackageName) {
+    if (self != null) self.sp.release();
+    self = new Sound(soundPackageName);
+    return self;
+  }
+
+  public boolean isEnable() {
+    return enable;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Sound(String soundPackageName) {
+    sp = new SoundPool(3, AudioManager.STREAM_MUSIC, 0);
+    keyset = new ArrayList<>();
+    Map<String, ?> m = YamlUtils.INSTANCE.loadMap(soundPackageName + ".sound", "");
+    if (m != null) {
+      String path = DataUtils.getUserDataDir() + File.separator + "sound" + File.separator;
+      if (m.containsKey("folder")) path = path + m.get("folder") + File.separator;
+
+      if (m.containsKey("sound")) {
+        List<String> files = (List<String>) m.get("sound");
+        sound = new int[files.size()];
+        int i = 0;
+        for (String file : files) {
+          sound[i] = sp.load(path + file, 1);
+          i++;
+        }
+
+        if (m.containsKey("keyset")) {
+          List<Map<String, ?>> n = (List<Map<String, ?>>) m.get("keyset");
+          for (Map<String, ?> o : n) {
+            int max = -1, min = -1;
+            boolean inOrder = true;
+            int[] sounds = new int[1];
+            Object keys;
+
+            if (o.containsKey("inOrder")) {
+              Object _inOrder = o.get("inOrder");
+              if (_inOrder != null) inOrder = (_inOrder.equals("true"));
+            }
+            if (o.containsKey("sounds")) {
+              List<?> s = (List<?>) o.get("sounds");
+              assert s != null;
+              if (s.size() > 1) sounds = new int[s.size()];
+              for (int j = 0; j < s.size(); j++) {
+                String t = (String) s.get(j);
+                if (t.matches("\\d+")) sounds[j] = Integer.parseInt(t);
+                else {
+                  int k = files.indexOf(t);
+                  sounds[j] = Math.max(k, 0);
+                }
+              }
+            }
+            if (o.containsKey("keys")) {
+              keys = o.get("keys");
+              if (keys instanceof List) keyset.add(new Key((List<?>) keys, inOrder, sounds));
+            } else {
+              if (o.containsKey("max")) max = getKeycode(o.get("max"));
+              if (o.containsKey("min")) min = getKeycode(o.get("min"));
+              keyset.add(new Key(min, max, inOrder, sounds));
+            }
+          }
+          enable = true;
+          return;
+        }
+      }
+    }
+    enable = false;
+  }
+
+  public void play(Integer keycode, Integer volume) {
+    if (volume > 0) {
+      if (sound.length > 0) {
+        float soundVolume = volume / 100f;
+        if (lastKeycode != keycode) {
+          lastKeycode = keycode;
+          for (Key key : keyset) {
+            currStreamId = key.getSound(keycode);
+            if (currStreamId >= 0) {
+              sp.play(sound[currStreamId], soundVolume, soundVolume, 0, 0, 1.0f);
+              return;
+            }
+          }
+          currStreamId = 0;
+        }
+        sp.play(sound[currStreamId], soundVolume, soundVolume, 0, 0, 1.0f);
+      }
+    }
+  }
+
+  public static int getKeycode(Object string) {
+    String keyName = ((String) string).toUpperCase(Locale.ROOT);
+    if (keyName.startsWith("KEYCODE_")) return KeyEvent.keyCodeFromString(keyName);
+    else return KeyEvent.keyCodeFromString("KEYCODE_" + keyName);
+  }
+
+  private static class Key {
+    private int max, min;
+    private boolean inOrder;
+    private int[] sounds;
+    private List<Integer> keys;
+
+    public Key(int min, int max, boolean inOrder, int[] sound) {
+      if (max < min) return;
+      this.max = max;
+      this.min = min;
+      this.inOrder = inOrder;
+      this.sounds = sound;
+      this.keys = null;
+    }
+
+    public Key(List<?> keys, boolean inOrder, int[] sound) {
+      this.keys = new ArrayList<>();
+      if (keys.size() > 0) {
+        int i = 0;
+        //                Object key = keys.get(0);
+        //                if(key instanceof String)
+        {
+          for (; i < keys.size(); i++) {
+            this.keys.add(getKeycode(keys.get(i)));
+          }
+        }
+        /*
+        yaml不能直接识别int，为避免keycode和键名0-9无法区分，暂时不支持keycode参数
+        else if(key instanceof Integer){
+            for(;i<keys.size();i++){
+                 int keyCode =(Integer) keys.get(i);
+                    this.keys[i] = keyCode;
+            }
+        }*/
+      }
+      this.inOrder = inOrder;
+      this.sounds = sound;
+    }
+
+    public int getSound(int keycode) {
+      if (sounds.length < 1) return -1;
+
+      if (keys != null) {
+        int i = keys.indexOf(keycode);
+        if (i >= 0) {
+          if (!inOrder) i = (int) (Math.random() * sounds.length);
+          return sounds[i % sounds.length];
+        }
+      } else {
+        if (keycode >= min && keycode <= max) {
+          if (inOrder) return sounds[(keycode - min) % sounds.length];
+          int i = (int) (Math.random() * sounds.length);
+          return sounds[i % sounds.length];
+        }
+      }
+      return -1;
+    }
+  }
+}

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -347,6 +347,7 @@ class TextInputManager private constructor() :
                     "theme" -> trime.showThemeDialog()
                     "color" -> trime.showColorDialog()
                     "schema" -> trime.showSchemaDialog()
+                    "sound" -> trime.showSoundDialog()
                     else -> trime.launchSettings()
                 }
             }

--- a/app/src/main/java/com/osfans/trime/settings/components/SoundPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/settings/components/SoundPickerDialog.kt
@@ -22,8 +22,8 @@ class SoundPickerDialog(
 ) : CoroutineScope by MainScope() {
 
     private val config = Config.get(context)
-    private val themeKeys: Array<String?>
-    private val themeNames: Array<String?>
+    private val soundPackageFiles: Array<String?>
+    private val soundPackageNames: Array<String?>
     private var checkedId: Int = 0
     val pickerDialog: AlertDialog
 
@@ -31,12 +31,11 @@ class SoundPickerDialog(
     private val progressDialog: ProgressDialog
 
     init {
-        val themeFile = config.soundPackage + ".sound.yaml"
-        themeKeys = Config.getSoundPackages()
-        themeKeys.sort()
-        checkedId = themeKeys.binarySearch(themeFile)
+        soundPackageFiles = Config.getSoundPackages()
+        soundPackageFiles.sort()
+        checkedId = soundPackageFiles.binarySearch(config.soundPackage + ".sound.yaml")
 
-        themeNames = Config.getYamlFileNames(themeKeys)
+        soundPackageNames = Config.getYamlFileNames(soundPackageFiles)
 
         // Init picker
         pickerDialog = AlertDialog.Builder(context, R.style.AlertDialogTheme).apply {
@@ -45,7 +44,7 @@ class SoundPickerDialog(
             setNegativeButton(android.R.string.cancel, null)
             setPositiveButton(android.R.string.ok) { _, _ -> execute() }
             setSingleChoiceItems(
-                themeNames, checkedId
+                soundPackageNames, checkedId
             ) { _, id -> checkedId = id }
         }.create()
         // Init progress dialog
@@ -70,8 +69,8 @@ class SoundPickerDialog(
     }
 
     private fun setSound() {
-        if (checkedId >= 0 && checkedId <themeKeys.size)
-            config.soundPackage = themeKeys[checkedId]?.replace(".sound.yaml", "")
+        if (checkedId >= 0 && checkedId <soundPackageFiles.size)
+            config.soundPackage = soundPackageFiles[checkedId]?.replace(".sound.yaml", "")
     }
 
     /** 调用该方法显示对话框 **/

--- a/app/src/main/java/com/osfans/trime/settings/components/SoundPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/settings/components/SoundPickerDialog.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /** 顯示配色方案列表 */
-class ThemePickerDialog(
+class SoundPickerDialog(
     private val context: Context
 ) : CoroutineScope by MainScope() {
 
@@ -26,33 +26,21 @@ class ThemePickerDialog(
     private val themeNames: Array<String?>
     private var checkedId: Int = 0
     val pickerDialog: AlertDialog
+
     @Suppress("DEPRECATION")
     private val progressDialog: ProgressDialog
 
     init {
-        val themeFile = config.theme + ".yaml"
-        themeKeys = Config.getThemeKeys(true)
+        val themeFile = config.soundPackage + ".sound.yaml"
+        themeKeys = Config.getSoundPackages()
         themeKeys.sort()
         checkedId = themeKeys.binarySearch(themeFile)
 
-        val themeMap = HashMap<String, String>().apply {
-            put("tongwenfeng", context.getString(R.string.pref_themes_name_tongwenfeng))
-            put("trime", context.getString(R.string.pref_themes_name_trime))
-        }
-        val nameArray = Config.getYamlFileNames(themeKeys)
-        themeNames = arrayOfNulls(nameArray.size)
+        themeNames = Config.getYamlFileNames(themeKeys)
 
-        for (i in nameArray.indices) {
-            val themeName = themeMap[nameArray[i]]
-            if (themeName == null) {
-                themeNames[i] = nameArray[i]
-            } else {
-                themeNames[i] = themeName
-            }
-        }
         // Init picker
         pickerDialog = AlertDialog.Builder(context, R.style.AlertDialogTheme).apply {
-            setTitle(R.string.looks__selected_theme_title)
+            setTitle(R.string.keyboard__key_sound_package_title)
             setCancelable(true)
             setNegativeButton(android.R.string.cancel, null)
             setPositiveButton(android.R.string.ok) { _, _ -> execute() }
@@ -63,14 +51,15 @@ class ThemePickerDialog(
         // Init progress dialog
         @Suppress("DEPRECATION")
         progressDialog = ProgressDialog(context).apply {
-            setMessage(context.getString(R.string.themes_progress))
+            setMessage(context.getString(R.string.sound_progress))
             setCancelable(false)
         }
     }
 
     private fun appendDialogParams(dialog: Dialog) {
         dialog.window?.let { window ->
-            window.attributes.token = Trime.getServiceOrNull()?.window?.window?.decorView?.windowToken
+            window.attributes.token =
+                Trime.getServiceOrNull()?.window?.window?.decorView?.windowToken
             window.attributes.type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
             } else {
@@ -80,7 +69,9 @@ class ThemePickerDialog(
         }
     }
 
-    private fun setTheme() { config.theme = themeKeys[checkedId]?.replace(".yaml", "") }
+    private fun setSound() {
+        config.soundPackage = themeKeys[checkedId]?.replace(".sound.yaml", "")
+    }
 
     /** 调用该方法显示对话框 **/
     fun show() {
@@ -100,13 +91,12 @@ class ThemePickerDialog(
     }
 
     private suspend fun doInBackground(): String = withContext(Dispatchers.IO) {
-        setTheme()
+        setSound()
         delay(500) // Simulate async task
         return@withContext "OK"
     }
 
     private fun onPostExecute() {
         progressDialog.dismiss()
-        Trime.getServiceOrNull()?.initKeyboard() // 實時生效
     }
 }

--- a/app/src/main/java/com/osfans/trime/settings/components/SoundPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/settings/components/SoundPickerDialog.kt
@@ -70,7 +70,8 @@ class SoundPickerDialog(
     }
 
     private fun setSound() {
-        config.soundPackage = themeKeys[checkedId]?.replace(".sound.yaml", "")
+        if (checkedId >= 0 && checkedId <themeKeys.size)
+            config.soundPackage = themeKeys[checkedId]?.replace(".sound.yaml", "")
     }
 
     /** 调用该方法显示对话框 **/

--- a/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
@@ -4,11 +4,13 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.Menu
 import androidx.core.view.forEach
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.osfans.trime.R
 import com.osfans.trime.Rime
 import com.osfans.trime.ime.core.Preferences
 import com.osfans.trime.ime.core.Trime
+import com.osfans.trime.settings.components.SoundPickerDialog
 
 class KeyboardFragment :
     PreferenceFragmentCompat(),
@@ -45,7 +47,15 @@ class KeyboardFragment :
             }
         }
     }
-
+    override fun onPreferenceTreeClick(preference: Preference?): Boolean {
+        return when (preference?.key) {
+            "keyboard__key_sound_package" -> {
+                SoundPickerDialog(requireContext()).show()
+                true
+            }
+            else -> super.onPreferenceTreeClick(preference)
+        }
+    }
     override fun onResume() {
         super.onResume()
         preferenceScreen.sharedPreferences.registerOnSharedPreferenceChangeListener(this)

--- a/app/src/main/java/com/osfans/trime/setup/Config.java
+++ b/app/src/main/java/com/osfans/trime/setup/Config.java
@@ -277,38 +277,40 @@ public class Config {
 
   public void setSoundPackage(String name) {
     soundPackageName = name;
-    // copy soundpackage yaml file from sound folder to build folder
-    try {
-      InputStream in =
-          new FileInputStream(
-              DataUtils.getUserDataDir()
-                  + File.separator
-                  + "sound"
-                  + File.separator
-                  + name
-                  + ".sound.yaml");
-      OutputStream out =
-          new FileOutputStream(
-              DataUtils.getUserDataDir()
-                  + File.separator
-                  + "build"
-                  + File.separator
-                  + name
-                  + ".sound.yaml");
+    String path =
+        DataUtils.getUserDataDir()
+            + File.separator
+            + "sound"
+            + File.separator
+            + name
+            + ".sound.yaml";
+    File file = new File(path);
+    if (file.exists()) {
+      // copy soundpackage yaml file from sound folder to build folder
+      try {
+        InputStream in = new FileInputStream(file);
+        OutputStream out =
+            new FileOutputStream(
+                DataUtils.getUserDataDir()
+                    + File.separator
+                    + "build"
+                    + File.separator
+                    + name
+                    + ".sound.yaml");
 
-      byte[] buffer = new byte[1024];
-      int len;
-      while ((len = in.read(buffer)) > 0) {
-        out.write(buffer, 0, len);
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+          out.write(buffer, 0, len);
+        }
+
+        Timber.i("setSoundPackage = " + soundPackageName);
+      } catch (Exception e) {
+        e.printStackTrace();
       }
-
-      getPrefs().getKeyboard().setSoundPackage(soundPackageName);
-      Sound.get(soundPackageName);
-
-      Timber.i("setSoundPackage = " + soundPackageName);
-    } catch (Exception e) {
-      e.printStackTrace();
     }
+    getPrefs().getKeyboard().setSoundPackage(soundPackageName);
+    Sound.get(soundPackageName);
   }
 
   private void init() {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -163,4 +163,6 @@
     <string name="external_storage_permission_granted">已授予存储权限</string>
     <string name="external_storage_permission_denied">已拒绝授权存储权限，部署或读取方案和配置功能或不可用</string>
     <string name="alert_window_access_required">同文输入法需要允许显示在其他应用上方以能显示应用外悬浮窗或对话框，点击“确定”以授权。</string>
+    <string name="keyboard__key_sound_package_title">按键音效包</string>
+    <string name="sound_progress">正在应用音效...</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -164,4 +164,6 @@
     <string name="external_storage_permission_granted">已授予儲存許可權</string>
     <string name="external_storage_permission_denied">已拒絕授權儲存許可權，部署或讀取方案和配置功能或不可用</string>
     <string name="alert_window_access_required">同文輸入法需要允許顯示在其他應用上方以能顯示應用外懸浮窗或對話方塊，點選“確定”以授權。</string>
+    <string name="keyboard__key_sound_package_title">按鍵音效包</string>
+    <string name="sound_progress">正在應用音效...</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,4 +164,6 @@
     <string name="external_storage_permission_granted">External storage permission is granted</string>
     <string name="external_storage_permission_denied">External storage permission was denied, deployment or reading schemas and config may not be available</string>
     <string name="alert_window_access_required">TRIME need alert window permission to show up popup window or dialog, tap OK to grant the permission.</string>
+    <string name="keyboard__key_sound_package_title">Key Sound Package</string>
+    <string name="sound_progress">Loading sound...</string>
 </resources>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -19,7 +19,7 @@
             android:title="@string/keyboard__fullscreen_mode_title"
             android:entries="@array/keyboard__fullscreen_mode_entries"
             android:entryValues="@array/keyboard__fullscreen_mode_values"
-            android:defaultValue="preview"
+            android:defaultValue="auto_show"
             app:useSimpleSummaryProvider="true"/>
         <SwitchPreferenceCompat android:key="keyboard__soft_cursor"
             app:iconSpaceReserved="false"
@@ -49,6 +49,9 @@
         <SwitchPreferenceCompat android:key="keyboard__key_sound"
             app:iconSpaceReserved="false"
             android:title="@string/keyboard__key_sound_title"/>
+        <Preference android:key="keyboard__key_sound_package"
+            app:iconSpaceReserved="false"
+            android:title="@string/keyboard__key_sound_package_title" />
         <com.osfans.trime.settings.components.DialogSeekBarPreference
             app:allowDividerAbove="false"
             android:key="keyboard__key_sound_volume"


### PR DESCRIPTION
## Pull request
为键盘增加音效包支持。

音效包格式定义及使用说明：  
 https://github.com/tumuyan/trime-without-CMake/wiki/%E5%90%8C%E6%96%87%E6%8C%89%E9%94%AE%E9%9F%B3%E6%95%88

#### Issue tracker
Fixes will automatically close the related issue

Fixes #636

#### Feature
增加了按键音效包的支持。 音效包是独立于皮肤、方案的一套文件，包含一个.sound.yaml后缀的配置文件，以及一个包含音频文件的子目录。

如何应用音效包
1. 下载制作好的音效压缩包
2. 在用户目录下新建sound子目录
3. 解压压缩包，并把压缩包中的子目录、xxxx.sound.yaml移动到sound目录中
4. 打开偏好设置-按键效果-按键音效包选择你喜欢的音效包。


#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
