### PR TITLE
feat: add sound package support

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -67,6 +67,7 @@ import com.osfans.trime.ime.keyboard.Key;
 import com.osfans.trime.ime.keyboard.Keyboard;
 import com.osfans.trime.ime.keyboard.KeyboardSwitcher;
 import com.osfans.trime.ime.keyboard.KeyboardView;
+import com.osfans.trime.ime.keyboard.Sound;
 import com.osfans.trime.ime.lifecycle.LifecycleInputMethodService;
 import com.osfans.trime.ime.symbol.LiquidKeyboard;
 import com.osfans.trime.ime.symbol.TabManager;
@@ -681,6 +682,7 @@ public class Trime extends LifecycleInputMethodService {
   @Override
   public void onStartInputView(EditorInfo attribute, boolean restarting) {
     super.onStartInputView(attribute, restarting);
+    Sound.get().resetProgress();
     for (EventListener listener : eventListeners) {
       if (listener != null) listener.onStartInputView(activeEditorInstance, restarting);
     }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Sound.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Sound.java
@@ -17,8 +17,11 @@ public class Sound {
   private int lastKeycode; // 上次按键的键盘码
   private int[] sound; // 音频文件列表
   private final List<Key> keyset;
+  private List<String> files;
   private static Sound self;
   private final boolean enable;
+  private int progress = -1;
+  private int[] melody;
 
   public static Sound get() {
     return self;
@@ -34,6 +37,10 @@ public class Sound {
     return enable;
   }
 
+  public void resetProgress() {
+    progress = 0;
+  }
+
   @SuppressWarnings("unchecked")
   public Sound(String soundPackageName) {
     sp = new SoundPool(3, AudioManager.STREAM_MUSIC, 0);
@@ -44,7 +51,7 @@ public class Sound {
       if (m.containsKey("folder")) path = path + m.get("folder") + File.separator;
 
       if (m.containsKey("sound")) {
-        List<String> files = (List<String>) m.get("sound");
+        files = (List<String>) m.get("sound");
         sound = new int[files.size()];
         int i = 0;
         for (String file : files) {
@@ -52,7 +59,17 @@ public class Sound {
           i++;
         }
 
-        if (m.containsKey("keyset")) {
+        if (m.containsKey("melody")) {
+          progress = 0;
+          List<String> n = (List<String>) m.get("melody");
+          melody = new int[n.size()];
+          for (int j = 0; j < n.size(); j++) {
+            melody[j] = getSoundIndex(n.get(j));
+          }
+          enable = true;
+          return;
+        } else if (m.containsKey("keyset")) {
+          progress = -1;
           List<Map<String, ?>> n = (List<Map<String, ?>>) m.get("keyset");
           for (Map<String, ?> o : n) {
             int max = -1, min = -1;
@@ -69,12 +86,7 @@ public class Sound {
               assert s != null;
               if (s.size() > 1) sounds = new int[s.size()];
               for (int j = 0; j < s.size(); j++) {
-                String t = (String) s.get(j);
-                if (t.matches("\\d+")) sounds[j] = Integer.parseInt(t);
-                else {
-                  int k = files.indexOf(t);
-                  sounds[j] = Math.max(k, 0);
-                }
+                sounds[j] = getSoundIndex(s.get(j));
               }
             }
             if (o.containsKey("keys")) {
@@ -98,7 +110,11 @@ public class Sound {
     if (volume > 0) {
       if (sound.length > 0) {
         float soundVolume = volume / 100f;
-        if (lastKeycode != keycode) {
+        if (progress >= 0) {
+          progress++;
+          if (progress >= melody.length) progress = 0;
+          currStreamId = sound[melody[progress]];
+        } else if (lastKeycode != keycode) {
           lastKeycode = keycode;
           for (Key key : keyset) {
             currStreamId = key.getSound(keycode);
@@ -118,6 +134,14 @@ public class Sound {
     String keyName = ((String) string).toUpperCase(Locale.ROOT);
     if (keyName.startsWith("KEYCODE_")) return KeyEvent.keyCodeFromString(keyName);
     else return KeyEvent.keyCodeFromString("KEYCODE_" + keyName);
+  }
+
+  public int getSoundIndex(Object obj) {
+    String t = (String) obj;
+    if (t.matches("\\d+")) return Integer.parseInt(t);
+
+    int k = files.indexOf(t);
+    return Math.max(k, 0);
   }
 
   private static class Key {


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
为按键音效增加melody参数，melody包含一个列表。melody类似midi音乐的效果，当音效包内包含1 2 3 4 5 6 7不同音阶的音效，并且包含melody: [0, 0, 5, 5, 6]，只要持续按按键，无论按任何按键，都会持续循环播放音阶1 1 6 6 7，但是由于按键速度不稳定，音乐速度也会非常不稳定，所以并不适合复杂的音乐。当键盘收起并重新弹出时，演奏进度自动复位。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
