### PR TITLE
增加草稿箱管理器

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -858,20 +858,23 @@ liquid_keyboard:
   single_width: 60    #single类型的按键宽度
   vertical_gap: 8     #纵向按键间隙
   margin_x: 2       #左右按键间隙的1/2
-  keyboards: [emoji, math, ascii, cn, clipboard, history, exit, list , table, symbol, ids , pinyin, jp, unit, exit, grease, rusa, korea, lation, yinbiao, exit]  #tab列表
+  keyboards: [emoji, math, ascii, cn, history, clipboard, draft, list, exit, ids , jp, table, symbol, pinyin, grease, rusa, korea, lation, yinbiao, unit,  exit]  #tab列表
   exit:
     name: 返回
     type: NO_KEY
     keys: EXIT
+  history:
+    name: 常用
+    type: HISTORY
   emoji:
     type: SINGLE
-    keys: "🙂😂🤣😆🙃😅🙈🙉🙊☹😑😄🤐😨😱🌚🌝🤔❤💔♡🌹💣👌👍😣😥😮🙄😏😕😯😪😫😴😌🤑😉😋😎😍😘😚😛😜😝😒😓😔😲😷🤒😇🤓🤗🤕🙁😖😞😟😤😢😭😦😧😨😩😬😰😳😵😡😠☝✌🖕👎🙏🤘👏💪💋☘🍀🌸☕🍵🍺🍻🍦🍬🍚🍜🍲🍖🎂💤"
+    keys: "🙂😂🤣😆🙃😅🥺🙈🙉🙊☹😑😄🤐😨😱🌚🌝🤔❤💔🌹💣👌👍😣😥😮🙄😏😕😯😪😫😴😌🤑😉😋😎😍😘😚😛😜😝😒😓😔😲😷🤒😇🤓🤗🤕🙁😖😞😟😤😢😭😦😧😨😩😬😰😳😵😡😠☝✌🖕👎🙏🤘👏💪💋☘🍀🌸☕🍵🍺🍻🍦🍬🍚🍜🍲🍖🎂💤"
   clipboard:
     type: CLIPBOARD
     name: 剪贴
-  history:
-    name: 最近
-    type: HISTORY
+  draft:
+    type: DRAFT
+    name: 草稿
   math:   #tab名称
     type: SINGLE
     name: 数学
@@ -910,6 +913,7 @@ liquid_keyboard:
       - ～
   symbol:
     name: 特殊
+    type: SINGLE
     keys: "△▽○◇□☆▲▼●◆■★▷◁▶◀♻♲†⚝✡⚹✦✸✹￼�×⌫☑☒✅❎✔✘✓✗☼☽♀☻◐㏂☀☾♂☹◑㏘☜☝☞☚☟☛▪•‥…∷※♩♪♫♬§°♭♯♮‖¶№◎¤۞℗®©卍卐℡™㏇Φ↖↑↗◤㊤◥←↔→㊧㊥㊨↙↓↘◣㊦◢⇄⇅⇆⇤↩⇥❏❐◲〼▢▣⇦⇧⇨⇩⇪↶▸◂▴▾✁↷✍⏍ϟ📝✎✆☱☰☴⚿⛮⚙☲☯☵⛶☩☐☳☷☶💬🗨⟲ღ✈☂🎤🌐🔍"
   unit:
     name: 单位
@@ -950,7 +954,7 @@ liquid_keyboard:
   ids:
     type: SINGLE
     name: IDS
-    keys: "⿰⿱⿲⿳⿴⿵⿶⿷⿸⿹⿺⿻"
+    keys: "⿰⿱⿲⿳⿴⿵⿶⿷⿸⿹⿺⿻↷↔"
   jp:
     type: SINGLE
     name: 假名
@@ -3906,28 +3910,31 @@ preset_keys:
   CommitScriptText: {label: 编码, send: Shift+Return}
   CommitComment: {label: 编码, send: Control+Shift+Return}
   DeleteCandidate: {label: 删词, send: Control+Delete, functional: false}
+  #切换键盘
+  Keyboard_letter: { label: 字母, functional: true, send: Eisu_toggle, select: default }
+  Keyboard_default: { label: 返回, functional: false, send: Eisu_toggle, select: .default }
+  Keyboard_switch: { label: 键盘, functional: true, send: Eisu_toggle, select: .next }
+  Keyboard_number: { label: 123, functional: false, send: Eisu_toggle, select: number }
+  Keyboard_numberb: { label: 123, functional: false, send: Eisu_toggle, select: numberb }
+  Keyboard_symbols: { label: 更多, functional: false, send: Eisu_toggle, select: symbols }
+  Keyboard_move: { label: ❖, functional: true, send: Eisu_toggle, select: move }
+  Keyboard_next: { label: 后退, functional: false, send: Eisu_toggle, select: .next }
+  Keyboard_last: { label: 后退, functional: false, send: Eisu_toggle, select: .last }
+  Keyboard_last_lock: { label: 返回, send: Eisu_toggle, select: .last_lock } #直接切換到下一键盘
+  liquid_keyboard_switch: { label: 更多, send: function, command: liquid_keyboard, option: "特殊" }
+  liquid_keyboard_switch2: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 更多 ] }
+  liquid_keyboard_emoji: { label: 🙂, send: function, command: liquid_keyboard, option: "emoji" }
+  liquid_keyboard_clipboard: { label: 剪贴, send: function, command: liquid_keyboard, option: "剪贴" }
   # rime状态
   Mode_switch: {toggle: ascii_mode, functional: false, send: Mode_switch, states: [ 中文, 西文 ]}
   Zenkaku_Hankaku: {toggle: full_shape, send: Mode_switch, states: [ 半角, 全角 ]}
   Henkan: {toggle: simplification, send: Mode_switch, states: [ 汉字, 汉字 ]}
   Charset_switch: {toggle: extended_charset, send: Mode_switch, states: [ 常用, 增广 ]}
   Punct_switch: {toggle: ascii_punct, send: Mode_switch, states: [ 。，, ．， ]}
-  liquid_keyboard_switch: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 更多 ] }
-  liquid_keyboard_clipboard: {label: 剪贴板, send: function, command: liquid_keyboard, option: "剪贴"}
   # trime设置
   IME_switch: {label: 🌐, send: LANGUAGE_SWITCH} #彈出對話框選擇輸入法
   IME_last: {label: 上一输入法, send: LANGUAGE_SWITCH, select: .last} #直接切換到上一輸入法
   IME_next: {label: 下一输入法, send: LANGUAGE_SWITCH, select: .next} #直接切換到下一輸入法
-  Keyboard_letter: {label: 字母, functional: true, send: Eisu_toggle, select: default}
-  Keyboard_default: {label: 返回, functional: false, send: Eisu_toggle, select: .default}
-  Keyboard_switch: {label: 键盘, functional: true, send: Eisu_toggle, select: .next}
-  Keyboard_number: {label: 123, functional: false, send: Eisu_toggle, select: number}
-  Keyboard_numberb: {label: 123, functional: false, send: Eisu_toggle, select: numberb}
-  Keyboard_symbols: {label: 更多, functional: false, send: Eisu_toggle, select: symbols}
-  Keyboard_move: {label: ❖, functional: true, send: Eisu_toggle, select: move}
-  Keyboard_next: {label: 后退, functional: false, send: Eisu_toggle, select: .next}
-  Keyboard_last: {label: 后退, functional: false, send: Eisu_toggle, select: .last}
-  Keyboard_last_lock: {label: 返回, send: Eisu_toggle, select: .last_lock} #直接切換到下一键盘
   Schema_switch: {label: 下一方案, functional: false, send: Control+Shift+1}
   Schema_Eng: {label: En, functional: true, send: Control+Shift+0}
   Theme_settings: {label: 主题, send: SETTINGS, option: "theme"}

--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -921,17 +921,21 @@ preset_keys:
   Henkan: {toggle: simplification, send: Mode_switch, states: [ 漢字, 汉字 ]}
   Charset_switch: {toggle: extended_charset, send: Mode_switch, states: [ 常用, 增廣 ]}
   Punct_switch: {toggle: ascii_punct, send: Mode_switch, states: [ 。，, ．， ]}
-  # trime設定
-  IME_switch: {label: 🌐, send: LANGUAGE_SWITCH} #彈出對話框選擇輸入法
-  IME_last: {label: 上一輸入法, send: LANGUAGE_SWITCH, select: .last} #直接切換到上一輸入法
-  IME_next: {label: 下一輸入法, send: LANGUAGE_SWITCH, select: .next} #直接切換到下一輸入法
+  #切换键盘
   Keyboard_symbols: {label: 符號, send: Eisu_toggle, select: symbols}
   Keyboard_number: {label: 數字, send: Eisu_toggle, select: number}
   Keyboard_letter: {label: 字母, send: Eisu_toggle, select: default}
   Keyboard_default: {label: 返回, send: Eisu_toggle, select: .default}
   Keyboard_switch: {label: 鍵盤, send: Eisu_toggle, select: .next}
+  liquid_keyboard_switch: { label: 更多, send: function, command: liquid_keyboard, option: "特殊" }
+  liquid_keyboard_switch2: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 更多 ] }
+  liquid_keyboard_emoji: { label: 🙂, send: function, command: liquid_keyboard, option: "emoji" }
+  liquid_keyboard_clipboard: { label: 剪贴, send: function, command: liquid_keyboard, option: "剪贴" }
+  # trime設定
+  IME_switch: { label: 🌐, send: LANGUAGE_SWITCH } #彈出對話框選擇輸入法
+  IME_last: { label: 上一輸入法, send: LANGUAGE_SWITCH, select: .last } #直接切換到上一輸入法
+  IME_next: { label: 下一輸入法, send: LANGUAGE_SWITCH, select: .next } #直接切換到下一輸入法
   Schema_switch: {label: 下一方案, send: Control+Shift+1}
-  liquid_keyboard_switch: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 更多 ] }
   one_hand_switch_1: {toggle: _one_hand_mode_1, send: Mode_switch, states: [ 左手, 普通 ]}
   one_hand_switch_2: {toggle: _one_hand_mode_2, send: Mode_switch, states: [ 右手, 普通 ]}
   one_hand_switch_3: {toggle: _one_hand_mode_3, send: Mode_switch, states: [ 左手, 右手 ]}

--- a/app/src/main/java/com/osfans/trime/draft/DraftAdapter.java
+++ b/app/src/main/java/com/osfans/trime/draft/DraftAdapter.java
@@ -1,4 +1,4 @@
-package com.osfans.trime.clipboard;
+package com.osfans.trime.draft;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -19,16 +19,16 @@ import com.osfans.trime.ime.symbol.SimpleKeyBean;
 import com.osfans.trime.setup.Config;
 import java.util.List;
 
-public class ClipboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+public class DraftAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
   private final Context myContext;
   private final List<SimpleKeyBean> list;
   private int keyMarginX, keyMarginTop;
   private Integer textColor;
   private float textSize;
   private Typeface textFont;
-  private Config config;
+  private Drawable background;
 
-  public ClipboardAdapter(Context context, List<SimpleKeyBean> itemlist) {
+  public DraftAdapter(Context context, List<SimpleKeyBean> itemlist) {
     myContext = context;
     list = itemlist;
   }
@@ -43,12 +43,16 @@ public class ClipboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     this.keyMarginTop = keyMarginTop;
 
     //  边框尺寸、圆角、字号直接读取主题通用参数。配色优先读取 liquidKeyboard 专用参数。
-    config = Config.get(myContext);
+    Config config = Config.get(myContext);
     textColor = config.getLiquidColor("long_text_color");
     if (textColor == null) textColor = config.getLiquidColor("key_text_color");
 
     textSize = config.getFloat("key_long_text_size");
     if (textSize <= 0) textSize = config.getFloat("label_text_size");
+
+    background =
+        config.getDrawable(
+            "long_text_back_color", "key_border", "key_long_text_border", "round_corner", null);
 
     textFont = config.getFont("long_text_font");
   }
@@ -60,7 +64,7 @@ public class ClipboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     return new ItemViewHolder(view);
   }
 
-  static class ItemViewHolder extends RecyclerView.ViewHolder {
+  private static class ItemViewHolder extends RecyclerView.ViewHolder {
     public ItemViewHolder(View view) {
       super(view);
 
@@ -76,10 +80,9 @@ public class ClipboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
   @Override
   public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int index) {
 
-    if (viewHolder instanceof ClipboardAdapter.ItemViewHolder) {
+    if (viewHolder instanceof ItemViewHolder) {
       SimpleKeyBean searchHistoryBean = list.get(index);
-      final ClipboardAdapter.ItemViewHolder itemViewHold =
-          ((ClipboardAdapter.ItemViewHolder) viewHolder);
+      final ItemViewHolder itemViewHold = ((ItemViewHolder) viewHolder);
 
       if (textFont != null) itemViewHold.mTitle.setTypeface(textFont);
 
@@ -108,11 +111,16 @@ public class ClipboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
       }
 
-      Drawable background =
-          config.getDrawable(
-              "long_text_back_color", "key_border", "key_long_text_border", "round_corner", null);
+      if (background != null)
+        itemViewHold.listItemLayout.setBackground(
+            Config.get(myContext)
+                .getDrawable(
+                    "long_text_back_color",
+                    "key_border",
+                    "key_long_text_border",
+                    "round_corner",
+                    null));
 
-      if (background != null) itemViewHold.listItemLayout.setBackground(background);
       // 如果设置了回调，则设置点击事件
       if (mOnItemClickListener != null) {
         itemViewHold.listItemLayout.setOnClickListener(

--- a/app/src/main/java/com/osfans/trime/draft/DraftBean.java
+++ b/app/src/main/java/com/osfans/trime/draft/DraftBean.java
@@ -1,0 +1,61 @@
+package com.osfans.trime.draft;
+
+import com.osfans.trime.ime.symbol.SimpleKeyBean;
+
+public class DraftBean extends SimpleKeyBean {
+  private long time;
+  private String text;
+  private final String html;
+  private int type;
+
+  public long getTime() {
+    return time;
+  }
+
+  public String getHtml() {
+    return html;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public int getType() {
+    return type;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  public void setTime(long time) {
+    this.time = time;
+  }
+
+  public void setType(int type) {
+    this.type = type;
+  }
+
+  public DraftBean(String text) {
+    this.text = text;
+    this.time = System.currentTimeMillis();
+    this.type = 0;
+    this.html = "";
+  }
+
+  @SuppressWarnings("unused")
+  public DraftBean(String text, String html) {
+    this.text = text;
+    this.time = System.currentTimeMillis();
+    this.type = 1;
+    this.html = html;
+  }
+
+  @SuppressWarnings("unused")
+  public DraftBean(String text, String html, int type, long time) {
+    this.text = text;
+    this.time = time;
+    this.type = type;
+    this.html = html;
+  }
+}

--- a/app/src/main/java/com/osfans/trime/draft/DraftDao.java
+++ b/app/src/main/java/com/osfans/trime/draft/DraftDao.java
@@ -1,0 +1,92 @@
+package com.osfans.trime.draft;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import androidx.annotation.NonNull;
+import com.osfans.trime.ime.core.Trime;
+import com.osfans.trime.ime.symbol.SimpleKeyBean;
+import java.util.ArrayList;
+import java.util.List;
+import timber.log.Timber;
+
+public class DraftDao {
+
+  private SQLiteOpenHelper helper;
+  private static DraftDao self;
+
+  public static DraftDao get() {
+    if (null == self) self = new DraftDao();
+    return self;
+  }
+
+  public DraftDao() {}
+
+  public void insert(@NonNull DraftBean clipboardBean) {
+    helper = new DraftlHelper(Trime.getService(), "draft.db", null, 1);
+    SQLiteDatabase db = helper.getWritableDatabase();
+    db.execSQL(
+        "insert into t_clipboard(text,html,type,time) values(?,?,?,?)",
+        new Object[] {
+          clipboardBean.getText(),
+          clipboardBean.getHtml(),
+          clipboardBean.getType(),
+          clipboardBean.getTime()
+        });
+    db.close();
+  }
+
+  /** 删除文字相同的剪贴板记录，插入新记录 * */
+  public void add(@NonNull DraftBean clipboardBean) {
+    helper = new DraftlHelper(Trime.getService(), "draft.db", null, 1);
+    SQLiteDatabase db = helper.getWritableDatabase();
+    db.delete("t_clipboard", "text=?", new String[] {clipboardBean.getText()});
+    db.execSQL(
+        "insert into t_clipboard(text,html,type,time) values(?,?,?,?)",
+        new Object[] {
+          clipboardBean.getText(),
+          clipboardBean.getHtml(),
+          clipboardBean.getType(),
+          clipboardBean.getTime()
+        });
+    db.close();
+  }
+
+  public void update(@NonNull DraftBean clipboardBean) {
+    helper = new DraftlHelper(Trime.getService(), "draft.db", null, 1);
+    SQLiteDatabase db = helper.getWritableDatabase();
+    db.execSQL(
+        "insert into t_clipboard(text,html,type,time) values(?,?,?,?)",
+        new Object[] {
+          clipboardBean.getText(),
+          clipboardBean.getHtml(),
+          clipboardBean.getType(),
+          clipboardBean.getTime()
+        });
+    db.close();
+  }
+
+  public List<SimpleKeyBean> getAllSimpleBean(int size) {
+
+    List<SimpleKeyBean> list = new ArrayList<>();
+    if (size == 0) return list;
+
+    String sql = "select text , html , type , time from t_clipboard ORDER BY time DESC";
+    if (size > 0) sql = sql + " limit 0," + size;
+
+    helper = new DraftlHelper(Trime.getService(), "draft.db", null, 1);
+
+    SQLiteDatabase db = helper.getWritableDatabase();
+    Cursor cursor = db.rawQuery(sql, null);
+    if (cursor != null) {
+      while (cursor.moveToNext()) {
+        DraftBean v = new DraftBean(cursor.getString(0));
+        list.add(v);
+      }
+      cursor.close();
+    }
+    db.close();
+    Timber.d("getAllSimpleBean() size=%s limit=%s", list.size(), size);
+    return list;
+  }
+}

--- a/app/src/main/java/com/osfans/trime/draft/DraftlHelper.java
+++ b/app/src/main/java/com/osfans/trime/draft/DraftlHelper.java
@@ -1,0 +1,34 @@
+package com.osfans.trime.draft;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import androidx.annotation.NonNull;
+import timber.log.Timber;
+
+public class DraftlHelper extends SQLiteOpenHelper {
+
+  public static final String CREATE_STUDENT =
+      "create table t_clipboard ("
+          + "id integer primary key, text TEXT, html TEXT, type integer, time integer)";
+
+  public DraftlHelper(
+      Context context, String name, SQLiteDatabase.CursorFactory factory, int version) {
+    super(context, name, factory, version);
+  }
+
+  @Override
+  public void onOpen(SQLiteDatabase db) {
+    Timber.i("open db");
+    super.onOpen(db);
+  }
+
+  @Override
+  public void onCreate(@NonNull SQLiteDatabase db) {
+    Timber.i("create db");
+    db.execSQL(CREATE_STUDENT);
+  }
+
+  @Override
+  public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {}
+}

--- a/app/src/main/java/com/osfans/trime/ime/core/Preferences.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/Preferences.kt
@@ -299,7 +299,9 @@ class Preferences(
             const val CLICK_CANDIDATE_AND_COMMIT = "other__click_candidate_and_commit"
             const val CLIPBOARD_COMPARE_RULES = "other__clipboard_compare"
             const val CLIPBOARD_OUTPUT_RULES = "other__clipboard_output"
-            const val CLIPBOARD_MANAGER_RULES = "other__clipboard_manager"
+            const val DRAFT_OUTPUT_RULES = "other__draft_output"
+            const val DRAFT_LIMIT = "other__draft_limit"
+            const val CLIPBOARD_LIMIT = "other__clipboard_limit"
         }
         var uiMode: String
             get() = prefs.getPref(UI_MODE, "auto")
@@ -325,8 +327,14 @@ class Preferences(
         var clipboardOutputRules: String
             get() = prefs.getPref(CLIPBOARD_OUTPUT_RULES, "")
             set(v) = prefs.setPref(CLIPBOARD_OUTPUT_RULES, v)
-        var clipboardManagerRules: String
-            get() = prefs.getPref(CLIPBOARD_MANAGER_RULES, "0")
-            set(v) = prefs.setPref(CLIPBOARD_MANAGER_RULES, v)
+        var draftOutputRules: String
+            get() = prefs.getPref(DRAFT_OUTPUT_RULES, "")
+            set(v) = prefs.setPref(DRAFT_OUTPUT_RULES, v)
+        var clipboardLimit: String
+            get() = prefs.getPref(CLIPBOARD_LIMIT, "50")
+            set(v) = prefs.setPref(CLIPBOARD_LIMIT, v)
+        var draftLimit: String
+            get() = prefs.getPref(DRAFT_LIMIT, "20")
+            set(v) = prefs.setPref(DRAFT_LIMIT, v)
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -60,6 +60,7 @@ import com.osfans.trime.clipboard.ClipboardDao;
 import com.osfans.trime.common.ViewUtils;
 import com.osfans.trime.databinding.CompositionRootBinding;
 import com.osfans.trime.databinding.InputRootBinding;
+import com.osfans.trime.draft.DraftDao;
 import com.osfans.trime.ime.enums.WindowsPositionType;
 import com.osfans.trime.ime.keyboard.Event;
 import com.osfans.trime.ime.keyboard.InputFeedbackManager;
@@ -360,8 +361,11 @@ public class Trime extends LifecycleInputMethodService {
 
         keyboardSwitcher = new KeyboardSwitcher();
 
-        liquidKeyboard = new LiquidKeyboard(this, getImeConfig().getClipboardMaxSize());
+        liquidKeyboard =
+            new LiquidKeyboard(
+                this, getImeConfig().getClipboardLimit(), getImeConfig().getDraftLimit());
         clipBoardMonitor();
+        DraftDao.get();
       } catch (Exception e) {
         super.onCreate();
         e.fillInStackTrace();
@@ -418,7 +422,7 @@ public class Trime extends LifecycleInputMethodService {
   }
 
   private void hideCompositionView() {
-    if (isPopupWindowMovable.equals("once")) {
+    if (isPopupWindowMovable != null && isPopupWindowMovable.equals("once")) {
       popupWindowPos = getImeConfig().getWinPos();
     }
 
@@ -693,10 +697,13 @@ public class Trime extends LifecycleInputMethodService {
     bindKeyboardToInputView();
     if (!restarting) setNavBarColor();
     setCandidatesViewShown(!Rime.isEmpty()); // 軟鍵盤出現時顯示候選欄
+    activeEditorInstance.cacheDraft();
+    addDraft();
   }
 
   @Override
   public void onFinishInputView(boolean finishingInput) {
+    addDraft();
     super.onFinishInputView(finishingInput);
     // Dismiss any pop-ups when the input-view is being finished and hidden.
     mainKeyboardView.closing();
@@ -1013,6 +1020,7 @@ public class Trime extends LifecycleInputMethodService {
    */
   private boolean performEnter(int keyCode) { // 回車
     if (keyCode == KeyEvent.KEYCODE_ENTER) {
+      activeEditorInstance.cacheDraft();
       if (textInputManager.getPerformEnterAsLineBreak()) {
         commitText("\n");
       } else {
@@ -1141,8 +1149,9 @@ public class Trime extends LifecycleInputMethodService {
     final Config imeConfig = getImeConfig();
     clipBoard.addPrimaryClipChangedListener(
         () -> {
-          if (imeConfig.getClipboardMaxSize() != 0) {
+          if (imeConfig.getClipboardLimit() != 0) {
             final ClipData clipData = clipBoard.getPrimaryClip();
+            if (clipData == null) return;
             final ClipData.Item item = clipData.getItemAt(0);
             if (item == null) return;
 
@@ -1157,5 +1166,20 @@ public class Trime extends LifecycleInputMethodService {
             }
           }
         });
+  }
+
+  private String draftString = "", draftCache = "";
+
+  private void addDraft() {
+    draftCache = activeEditorInstance.getDraftCache();
+    if (draftCache.isEmpty() || draftCache.trim().equals(draftString)) return;
+
+    if (getImeConfig().getDraftLimit() != 0) {
+      Timber.i("addDraft() cache=%s, string=%s", draftString, draftCache);
+      if (StringUtils.mismatch(draftCache, getImeConfig().getDraftOutput())) {
+        draftString = draftCache.trim();
+        liquidKeyboard.addDraftData(draftCache);
+      }
+    }
   }
 }

--- a/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
@@ -10,6 +10,9 @@ enum class SymbolKeyboardType {
     //  剪贴板（大段文本自动缩略，按键长度自适应。）
     CLIPBOARD,
 
+    //  文本框编辑历史，即“草稿箱”
+    DRAFT,
+
     //  近期上屏符号历史（需要区分来源并提示？）
     HISTORY,
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/InputFeedbackManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/InputFeedbackManager.kt
@@ -29,7 +29,7 @@ class InputFeedbackManager(
         try {
             vibrator = ims.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
             audioManager = ims.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
-            tts = TextToSpeech(ims) { }
+            tts = TextToSpeech(ims.applicationContext) { }
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/OtherFragment.kt
@@ -61,6 +61,11 @@ class OtherFragment :
                     sharedPreferences?.getString(key, "")
                 )
             }
+            "other__draft_output" -> {
+                Config.get(context).setDraftOutput(
+                    sharedPreferences?.getString(key, "")
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/setup/Config.java
+++ b/app/src/main/java/com/osfans/trime/setup/Config.java
@@ -91,7 +91,7 @@ public class Config {
 
   private static final Pattern pattern = Pattern.compile("\\s*\n\\s*");
 
-  private String[] clipBoardCompare, clipBoardOutput;
+  private String[] clipBoardCompare, clipBoardOutput, draftOutput;
 
   @NonNull
   private Preferences getPrefs() {
@@ -107,12 +107,9 @@ public class Config {
     deployTheme();
     init();
     setSoundFromColor();
-    prepareCLipBoardRule();
-  }
-
-  private void prepareCLipBoardRule() {
     clipBoardCompare = getPrefs().getOther().getClipboardCompareRules().trim().split("\n");
     clipBoardOutput = getPrefs().getOther().getClipboardOutputRules().trim().split("\n");
+    draftOutput = getPrefs().getOther().getDraftOutputRules().trim().split("\n");
   }
 
   public String[] getClipBoardCompare() {
@@ -123,8 +120,16 @@ public class Config {
     return clipBoardOutput;
   }
 
-  public int getClipboardMaxSize() {
-    return Integer.parseInt(getPrefs().getOther().getClipboardManagerRules());
+  public String[] getDraftOutput() {
+    return draftOutput;
+  }
+
+  public int getClipboardLimit() {
+    return Integer.parseInt(getPrefs().getOther().getClipboardLimit());
+  }
+
+  public int getDraftLimit() {
+    return Integer.parseInt(getPrefs().getOther().getDraftLimit());
   }
 
   public void setClipBoardCompare(String str) {
@@ -139,6 +144,13 @@ public class Config {
     clipBoardOutput = s.split("\n");
 
     getPrefs().getOther().setClipboardOutputRules(s);
+  }
+
+  public void setDraftOutput(String str) {
+    String s = pattern.matcher(str).replaceAll("\n").trim();
+    draftOutput = s.split("\n");
+
+    getPrefs().getOther().setDraftOutputRules(s);
   }
 
   public String getTheme() {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -165,4 +165,6 @@
     <string name="alert_window_access_required">同文输入法需要允许显示在其他应用上方以能显示应用外悬浮窗或对话框，点击“确定”以授权。</string>
     <string name="keyboard__key_sound_package_title">按键音效包</string>
     <string name="sound_progress">正在应用音效...</string>
+    <string name="other__draft_manager_title">草稿箱管理器</string>
+    <string name="other__draft_output_title">草稿箱过滤规则\n每行为一条正则，与规则匹配的文本不会被缓存</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -166,4 +166,6 @@
     <string name="alert_window_access_required">同文輸入法需要允許顯示在其他應用上方以能顯示應用外懸浮窗或對話方塊，點選“確定”以授權。</string>
     <string name="keyboard__key_sound_package_title">按鍵音效包</string>
     <string name="sound_progress">正在應用音效...</string>
+    <string name="other__draft_manager_title">草稿箱管理器</string>
+    <string name="other__draft_output_title">草稿箱過濾規則\n每行爲一條正則表達式，與規則匹配的內容不會被緩存</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,4 +166,6 @@
     <string name="alert_window_access_required">TRIME need alert window permission to show up popup window or dialog, tap OK to grant the permission.</string>
     <string name="keyboard__key_sound_package_title">Key Sound Package</string>
     <string name="sound_progress">Loading sound...</string>
+    <string name="other__draft_manager_title">Draft Manager</string>
+    <string name="other__draft_output_title">Draft Filter</string>
 </resources>

--- a/app/src/main/res/xml/other_preference.xml
+++ b/app/src/main/res/xml/other_preference.xml
@@ -33,12 +33,14 @@
         app:iconSpaceReserved="false"
         android:title="@string/other__click_candidate_and_commit" />
 
+
+
     <ListPreference
         android:defaultValue="100"
         app:iconSpaceReserved="false"
         app:entries="@array/other__clipboard_manager_entries"
         app:entryValues="@array/other__clipboard_manager_values"
-        app:key="other__clipboard_manager"
+        app:key="other__clipboard_limit"
         app:title="@string/other__clipboard_manager_title"
         app:useSimpleSummaryProvider="true" />
 
@@ -50,6 +52,21 @@
     <EditTextPreference android:key="other__clipboard_output"
         app:iconSpaceReserved="false"
         android:title="@string/other__clipboard_output_title"
+        android:defaultValue=""
+        app:useSimpleSummaryProvider="true"/>
+
+
+    <ListPreference
+        app:iconSpaceReserved="false"
+        app:entries="@array/other__clipboard_manager_entries"
+        app:entryValues="@array/other__clipboard_manager_values"
+        app:key="other__draft_limit"
+        app:title="@string/other__draft_manager_title"
+        app:useSimpleSummaryProvider="true" />
+
+    <EditTextPreference android:key="other__draft_output"
+        app:iconSpaceReserved="false"
+        android:title="@string/other__draft_output_title"
         android:defaultValue=""
         app:useSimpleSummaryProvider="true"/>
 </PreferenceScreen>


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes #510 

#### Feature
Add new feather: Draft
在唤起和隐藏键盘时，自动缓存文本框的内容。代码基本从剪贴板管理器复制而来，与剪贴板管理器一起显示在liquidKeyboard中。
默认皮肤已经添加了草稿箱的功能。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
