### PR TITLE
feat: define enter key label for different sense

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -95,6 +95,15 @@ style:
   text_size: 14 #编码区字号
   vertical_correction: -5
   vertical_gap: *sgap #键盘行距
+  action_label_type: never  #是否使用App的ActionLabel内容作为Enter键的文本 only | first | last | never
+  enter_labels:  # 定义Enter键的文本
+    go: 前往
+    done: 完成
+    next: 下个
+    pre:  上个
+    search: 搜索
+    send: 发送
+    default: Enter   # 定义默认Enter键的文本
 
 fallback_colors:
   candidate_text_color: text_color
@@ -1009,7 +1018,7 @@ preset_keyboards:
       - {click: space, long_click: Mode_switch, swipe_left: "Left", swipe_right: "Right", swipe_up: Schema_switchcn, width: 30, key_back_color: bkg, key_text_color: tkg}
       - {click: '.', label: '。', long_click: liquid_keyboard_clipboard, key_back_color: bh4, key_text_color: th4}
       - {click: '/', long_click: liquid_keyboard_switch , key_text_size: "18", key_back_color: bh4, key_text_color: th4}
-      - {click: Return, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
+      - {click: Return, composing: Return1, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
 
   letter:
     author: "暖暖"
@@ -1058,7 +1067,7 @@ preset_keyboards:
       - {label: '______', click: space, long_click: space_R2, swipe_left: "Left", swipe_right: "Right", swipe_up: Keyboard_fbj, width: 30, key_back_color: bkg, key_text_color: tkg}
       - {click: '.', label: '。', long_click: Keyboard_kao, key_back_color: bh4, key_text_color: th4}
       - {click: space_R2, long_click: liquid_keyboard_switch, key_text_size: "18", key_back_color: bh4, key_text_color: th4}
-      - {click: Return, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
+      - {click: Return, composing: Return1, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
 
   number:
     author: "暖暖"
@@ -3871,7 +3880,8 @@ preset_keys:
   VOLUME_MUTE: {label: 静音, send: VOLUME_MUTE}
   # 编辑
   Shift_L: {label: Shift, preview: '⇪', functional: false, send: Shift_L}
-  Return: {label: Enter, preview: '↩', functional: false, send: Return}
+  Return: { label: enter_labels, preview: '↩', functional: false, send: Return }
+  Return1: {label: Enter, preview: '↩', functional: false, send: Return}
   Hide: {label: 隐藏, send: BACK}
   BackSpace: {label: 退格, preview: '⇦', repeatable: true, functional: false, send: BackSpace}
   space: {repeatable: false, preview: ' ', functional: false, label: '_______', send: space}

--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -87,6 +87,15 @@ style:
   long_text_font: comment.ttf #剪贴板等可能包含大段文本使用的字体
   #background_folder: #背景图保存在background目录下的哪个子目录
   key_long_text_border: 1
+  action_label_type: never  #是否使用App的ActionLabel内容作为Enter键的文本 only | first | last | never
+  enter_labels:  # 定义Enter键的文本
+    go: 前往
+    done: 完成
+    next: 下个
+    pre:  上个
+    search: 搜索
+    send: 发送
+    default: Enter   # 定义默认Enter键的文本
 
 fallback_colors:
   candidate_text_color: text_color
@@ -882,7 +891,8 @@ preset_keys:
   VOLUME_MUTE: {label: 靜音, send: VOLUME_MUTE}
   # 編輯
   Shift_L: {label: Shift, send: Shift_L, shift_lock: ascii_long}
-  Return: {label: Enter, send: Return}
+  Return: {label: enter_labels, send: Return}
+  Return1: {label: Enter, send: Return }
   Hide: {label: 隱藏, send: BACK}
   BackSpace: {label: 退格, repeatable: true, send: BackSpace}
   space: {repeatable: false, functional: false, send: space}
@@ -1025,7 +1035,7 @@ preset_keyboards:
     - {click: space, width: 30}
     - {click: "'", long_click: '"'}
     - {click: BackSpace, width: 15}
-    - {click: Return, long_click: CommitComment, width: 15}
+    - {click: Return, composing: Return1, long_click: CommitComment, width: 15}
   letter:
     __include: /preset_keyboards/default
     ascii_mode: 1
@@ -1085,7 +1095,7 @@ preset_keyboards:
     - {click: space, width: 30}
     - {click: '.', long_click: '>'}
     - {click: '/', long_click: '?'}
-    - {click: Return, long_click: CommitComment, width: 15}
+    - {click: Return, composing: Return1, long_click: CommitComment, width: 15}
   qwerty_:
     name: 預設30鍵
     author: "osfans <waxaca@163.com>"
@@ -1129,7 +1139,7 @@ preset_keyboards:
     - {click: Mode_switch, long_click: Menu}
     - {click: space, width: 40}
     - {click: BackSpace, width: 15}
-    - {click: Return, long_click: CommitComment, width: 15}
+    - {click: Return, composing: Return1, long_click: CommitComment, width: 15}
   qwerty:
     name: 預設26鍵
     author: "osfans <waxaca@163.com>"
@@ -1183,7 +1193,7 @@ preset_keyboards:
     - {click: space, width: 30}
     - {click: '.', long_click: '>'}
     - {click: '/', long_click: '?'}
-    - {click: Return, long_click: CommitComment, width: 15}
+    - {click: Return, composing: Return1, long_click: CommitComment, width: 15}
   us_intl:
     name: 美式國際
     author: "Terry Tsang <archerindigo@gmail.com>"
@@ -1378,7 +1388,7 @@ preset_keyboards:
     - {label: 'ㄦ', long_click: '"', click: "-"}
     - {long_click: '。', click: '，'}
     - {click: BackSpace, long_click: Escape, width: 10}
-    - {click: Return, long_click: CommitComment, width: 10}
+    - {click: Return, composing: Return1, long_click: CommitComment, width: 10}
   cangjie5:
     name: 倉頡五代鍵盤
     author: "皛筱晓小笨鱼"
@@ -1422,7 +1432,7 @@ preset_keyboards:
     - {click: space, width: 40}
     - {click: Mode_switch, long_click: Menu}
     - {long_click: '>', click: '.'}
-    - {click: Return, long_click: CommitComment, width: 10}
+    - {click: Return, composing: Return1, long_click: CommitComment, width: 10}
   cangjie6:
     ascii_mode: 0
     name: 倉頡六代
@@ -1480,7 +1490,7 @@ preset_keyboards:
     - {click: ",", long_click: .}
     - {click: space, width: 25}
     - {click: "'", long_click: "?"}
-    - {click: Return, long_click: CommitComment, width: 25.5}
+    - {click: Return, composing: Return1, long_click: CommitComment, width: 25.5}
   scj6:
     __include: /preset_keyboards/cangjie5
   stroke:
@@ -1505,7 +1515,7 @@ preset_keyboards:
     - {click: Keyboard_symbols, long_click: Keyboard_number, width: 10}
     - {click: space, width: 40}
     - {click: Keyboard_letter, long_click: Menu, width: 10}
-    - {click: Return, long_click: CommitComment, width: 20}
+    - {click: Return, composing: Return1, long_click: CommitComment, width: 20}
   telegraph:
     name: 電碼
     author: 熊貓阿Bo
@@ -1534,7 +1544,7 @@ preset_keyboards:
     - {click: BackSpace}
     - {click: Keyboard_letter, long_click: Menu}
     - {click: space, width: 60}
-    - {click: Return}
+    - {click: Return, composing: Return1}
   terra_pinyin:
     name: 地球拼音鍵盤
     author: 默默ㄇㄛˋ
@@ -1578,7 +1588,7 @@ preset_keyboards:
     - {click: space, width: 40}
     - {click: ".", long_click: '"'}
     - {click: '\', long_click: '.', composing: 'ˋ', send_bindings: false}  #四聲
-    - {click: Return, long_click: CommitComment}
+    - {click: Return, composing: Return1, long_click: CommitComment}
   array30:
     name: 行列30配美式國際
     author: "Terry Tsang <archerindigo@gmail.com>"

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -700,6 +700,9 @@ public class Trime extends LifecycleInputMethodService {
     if (!restarting) setNavBarColor();
     setCandidatesViewShown(!Rime.isEmpty()); // 軟鍵盤出現時顯示候選欄
 
+    mainKeyboardView.setEnterLabel(
+        attribute.imeOptions & EditorInfo.IME_MASK_ACTION, attribute.actionLabel);
+
     switch (attribute.inputType & InputType.TYPE_MASK_VARIATION) {
       case InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS:
       case InputType.TYPE_TEXT_VARIATION_PASSWORD:
@@ -708,36 +711,40 @@ public class Trime extends LifecycleInputMethodService {
       case InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD:
         Timber.i(
             "EditorInfo: private;"
-                + " packageName"
+                + " packageName="
                 + attribute.packageName
-                + "; fieldName"
+                + "; fieldName="
                 + attribute.fieldName
-                + "; actionLabel"
+                + "; actionLabel="
                 + attribute.actionLabel
-                + "; inputType"
+                + "; inputType="
                 + attribute.inputType
-                + "; &v "
+                + "; VARIATION="
                 + (attribute.inputType & InputType.TYPE_MASK_VARIATION)
-                + "; &c "
-                + (attribute.inputType & InputType.TYPE_MASK_CLASS));
+                + "; CLASS="
+                + (attribute.inputType & InputType.TYPE_MASK_CLASS)
+                + "; ACTION="
+                + (attribute.imeOptions & EditorInfo.IME_MASK_ACTION));
         normalTextEditor = false;
         break;
 
       default:
         Timber.i(
             "EditorInfo: normal;"
-                + " packageName"
+                + " packageName="
                 + attribute.packageName
-                + "; fieldName"
+                + "; fieldName="
                 + attribute.fieldName
-                + "; actionLabel"
+                + "; actionLabel="
                 + attribute.actionLabel
-                + "; inputType"
+                + "; inputType="
                 + attribute.inputType
-                + "; &v "
+                + "; VARIATION="
                 + (attribute.inputType & InputType.TYPE_MASK_VARIATION)
-                + "; &c "
-                + (attribute.inputType & InputType.TYPE_MASK_CLASS));
+                + "; CLASS="
+                + (attribute.inputType & InputType.TYPE_MASK_CLASS)
+                + "; ACTION="
+                + (attribute.imeOptions & EditorInfo.IME_MASK_ACTION));
         normalTextEditor = true;
         activeEditorInstance.cacheDraft();
         addDraft();

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -700,8 +700,13 @@ public class Trime extends LifecycleInputMethodService {
     if (!restarting) setNavBarColor();
     setCandidatesViewShown(!Rime.isEmpty()); // 軟鍵盤出現時顯示候選欄
 
-    mainKeyboardView.setEnterLabel(
-        attribute.imeOptions & EditorInfo.IME_MASK_ACTION, attribute.actionLabel);
+    if ((attribute.imeOptions & EditorInfo.IME_FLAG_NO_ENTER_ACTION)
+        == EditorInfo.IME_FLAG_NO_ENTER_ACTION) {
+      mainKeyboardView.resetEnterLabel();
+    } else {
+      mainKeyboardView.setEnterLabel(
+          attribute.imeOptions & EditorInfo.IME_MASK_ACTION, attribute.actionLabel);
+    }
 
     switch (attribute.inputType & InputType.TYPE_MASK_VARIATION) {
       case InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS:

--- a/app/src/main/java/com/osfans/trime/ime/enums/ActionLabelType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/ActionLabelType.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015-present, osfans
+ * waxaca@163.com https://github.com/osfans
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.osfans.trime.ime.enums
+
+import java.util.HashMap
+import java.util.Locale
+
+enum class ActionLabelType {
+    LAST, ONLY, FIRST, NEVER;
+
+    companion object {
+        private val convertMap: HashMap<String, ActionLabelType> = hashMapOf()
+
+        init {
+            for (type in values()) {
+                convertMap[type.toString()] = type
+            }
+        }
+
+        @JvmStatic
+        fun fromString(code: String): ActionLabelType {
+            if (code.isNullOrBlank()) return LAST
+            val type = convertMap[code.uppercase(Locale.getDefault())]
+            return type ?: LAST
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -243,6 +243,10 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
   private Map<String, String> mEnterLabels;
   private ActionLabelType actionLabelType;
 
+  public void resetEnterLabel() {
+    labelEnter = mEnterLabels.get("default");
+  }
+
   public void setEnterLabel(int action, CharSequence actionLabel) {
 
     if (actionLabelType == ActionLabelType.ONLY) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -40,12 +40,14 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
 import android.widget.PopupWindow;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import com.osfans.trime.R;
 import com.osfans.trime.databinding.KeyboardKeyPreviewBinding;
 import com.osfans.trime.ime.core.Preferences;
+import com.osfans.trime.ime.enums.ActionLabelType;
 import com.osfans.trime.ime.enums.KeyEventType;
 import com.osfans.trime.ime.lifecycle.CoroutineScopeJava;
 import com.osfans.trime.setup.Config;
@@ -237,6 +239,57 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
   private Method findStateDrawableIndex;
   private Method getStateDrawable;
 
+  private String labelEnter = "";
+  private Map<String, String> mEnterLabels;
+  private ActionLabelType actionLabelType;
+
+  public void setEnterLabel(int action, CharSequence actionLabel) {
+
+    if (actionLabelType == ActionLabelType.ONLY) {
+      if (actionLabel != null && actionLabel.length() > 0) labelEnter = actionLabel.toString();
+      else labelEnter = mEnterLabels.get("default");
+      return;
+    }
+
+    if (actionLabelType == ActionLabelType.FIRST) {
+      if (actionLabel != null && actionLabel.length() > 0) {
+        labelEnter = actionLabel.toString();
+        return;
+      }
+    }
+
+    switch (action) {
+      case EditorInfo.IME_ACTION_DONE:
+        labelEnter = mEnterLabels.get("done");
+        break;
+      case EditorInfo.IME_ACTION_GO:
+        labelEnter = mEnterLabels.get("go");
+        break;
+      case EditorInfo.IME_ACTION_NEXT:
+        labelEnter = mEnterLabels.get("next");
+        break;
+      case EditorInfo.IME_ACTION_PREVIOUS:
+        labelEnter = mEnterLabels.get("pre");
+        break;
+      case EditorInfo.IME_ACTION_SEARCH:
+        labelEnter = mEnterLabels.get("search");
+        break;
+      case EditorInfo.IME_ACTION_SEND:
+        labelEnter = mEnterLabels.get("send");
+        break;
+      case EditorInfo.IME_ACTION_NONE:
+        labelEnter = mEnterLabels.get("none");
+      default:
+        if (actionLabelType == ActionLabelType.LAST) {
+          if (actionLabel != null && actionLabel.length() > 0) {
+            labelEnter = actionLabel.toString();
+            return;
+          }
+        }
+        labelEnter = mEnterLabels.get("default");
+    }
+  }
+
   @NonNull
   private Preferences getPrefs() {
     return Preferences.Companion.defaultInstance();
@@ -343,6 +396,9 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
     REPEAT_START_DELAY = config.getLongTimeout() + 1;
     LONG_PRESS_TIMEOUT = config.getLongTimeout();
     MULTI_TAP_INTERVAL = config.getLongTimeout();
+
+    mEnterLabels = config.getmEnterLabels();
+    actionLabelType = config.getActionLabelType();
     invalidateAllKeys();
   }
 
@@ -770,7 +826,8 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
           color != null ? color : (key.isPressed() ? hilited_key_symbol_color : key_symbol_color));
 
       // Switch the character to uppercase if shift is pressed
-      final String label = key.getLabel();
+      String label = key.getLabel();
+      if (label.equals("enter_labels")) label = labelEnter;
       final String hint = key.getHint();
       int left = (key.getWidth() - padding.left - padding.right) / 2 + padding.left;
       int top = padding.top;

--- a/app/src/main/java/com/osfans/trime/setup/Config.java
+++ b/app/src/main/java/com/osfans/trime/setup/Config.java
@@ -37,6 +37,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.osfans.trime.Rime;
 import com.osfans.trime.ime.core.Preferences;
+import com.osfans.trime.ime.enums.ActionLabelType;
 import com.osfans.trime.ime.enums.SymbolKeyboardType;
 import com.osfans.trime.ime.enums.WindowsPositionType;
 import com.osfans.trime.ime.keyboard.Key;
@@ -384,6 +385,7 @@ public class Config {
       Rime.setShowSwitchArrow(getPrefs().getKeyboard().getSwitchArrowEnabled());
       reset();
       initCurrentColors();
+      initEnterLabels();
       Timber.d("init() finins");
     } catch (Exception e) {
       e.printStackTrace();
@@ -761,6 +763,34 @@ public class Config {
       names[i] = Objects.requireNonNull(m.get("name")).toString();
     }
     return names;
+  }
+
+  private Map<String, String> mEnterLabels;
+
+  public Map<String, String> getmEnterLabels() {
+    return mEnterLabels;
+  }
+
+  public ActionLabelType getActionLabelType() {
+    return ActionLabelType.fromString(getString("action_label_type"));
+  }
+
+  public void initEnterLabels() {
+    Object enter_labels = getValue("enter_labels");
+    if (enter_labels == null) mEnterLabels = new HashMap<>();
+    else mEnterLabels = (Map<String, String>) enter_labels;
+
+    String defaultEnterLabel = "Enter";
+    if (mEnterLabels.containsKey("default")) defaultEnterLabel = mEnterLabels.get("default");
+    else mEnterLabels.put("default", defaultEnterLabel);
+
+    if (!mEnterLabels.containsKey("done")) mEnterLabels.put("done", defaultEnterLabel);
+    if (!mEnterLabels.containsKey("go")) mEnterLabels.put("go", defaultEnterLabel);
+    if (!mEnterLabels.containsKey("next")) mEnterLabels.put("next", defaultEnterLabel);
+    if (!mEnterLabels.containsKey("none")) mEnterLabels.put("none", defaultEnterLabel);
+    if (!mEnterLabels.containsKey("pre")) mEnterLabels.put("pre", defaultEnterLabel);
+    if (!mEnterLabels.containsKey("search")) mEnterLabels.put("search", defaultEnterLabel);
+    if (!mEnterLabels.containsKey("send")) mEnterLabels.put("send", defaultEnterLabel);
   }
 
   public Typeface getFont(String key) {


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes #669 

#### Feature
使用皮肤定义不同情景下Enter键所显示的文字(如搜索/发送/下一个), 详见issue

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
