### PR TITLE
fix(jni): fix librime third-party plugins

### DIFF
--- a/app/src/main/jni/cmake/RimePlugins.cmake
+++ b/app/src/main/jni/cmake/RimePlugins.cmake
@@ -1,3 +1,4 @@
+# if you want to add some new plugins, add them to librime_jni/rime_jni.cc too
 set(RIME_PLUGINS
   librime-lua
   librime-charcode

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -411,8 +411,19 @@ int registerNativeMethods(JNIEnv *env, const char * className, const JNINativeMe
     return JNI_TRUE;
 }
 
+extern void rime_require_module_lua();
+extern void rime_require_module_charcode();
+extern void rime_require_module_grammar(); // librime-octagram
+// librime is compiled as a static library, we have to link modules explicitly
+static void declare_librime_module_dependencies() {
+    rime_require_module_lua();
+    rime_require_module_charcode();
+    rime_require_module_grammar();
+}
+
 jint JNI_OnLoad(JavaVM* vm, void* reserved)
 {
+    declare_librime_module_dependencies();
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
         return -1;

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -413,12 +413,12 @@ int registerNativeMethods(JNIEnv *env, const char * className, const JNINativeMe
 
 extern void rime_require_module_lua();
 extern void rime_require_module_charcode();
-extern void rime_require_module_grammar(); // librime-octagram
+extern void rime_require_module_octagram();
 // librime is compiled as a static library, we have to link modules explicitly
 static void declare_librime_module_dependencies() {
     rime_require_module_lua();
     rime_require_module_charcode();
-    rime_require_module_grammar();
+    rime_require_module_octagram();
 }
 
 jint JNI_OnLoad(JavaVM* vm, void* reserved)


### PR DESCRIPTION
Making librime a static library breaks third-party plugins, this patch fixed it

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #656, #665

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
