### PR TITLE
chore: remove workaround todo tag

### DIFF
--- a/app/src/main/jni/cmake/RimePlugins.cmake
+++ b/app/src/main/jni/cmake/RimePlugins.cmake
@@ -38,8 +38,5 @@ execute_process(COMMAND ln -s
 
 # librime-charcode
 option(BUILD_WITH_ICU "" OFF)
-# workaround for librime-charcode
-# it included asio but not used
-# TODO: fix it in upstream
 # TODO: replace with TOUCH after cmake >= 3.12
 file(WRITE "${CMAKE_BINARY_DIR}/include/boost/asio.hpp" "")


### PR DESCRIPTION
## Pull request

`The include is needed for Windows build.`

See: https://github.com/rime/librime-charcode/pull/2#issuecomment-1029886568

#### Issue tracker

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
