### PR TITLE
优化皮肤和音效包

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -79,6 +79,8 @@ style:
   latin_font: latin.ttf #西文本体
   latin_locale: en_US #西文语言
   locale: zh_CN #缺省语言 zh_TW,zh_CN,zh_HK,""
+  keyboard_height: 250 #锁定键盘高度，避免切换时键盘高度变化而造成闪烁
+  keyboard_height_land: 200 #锁定横屏下键盘高度，避免切换时键盘高度变化而造成闪烁
   preview_font: latin.ttf #按键提示字体
   preview_height: 56 #按键提示高度
   preview_offset: -32 #按键提示纵向偏移
@@ -853,6 +855,8 @@ liquid_keyboard:
   # 目前只能直接写参数，不支持变量或者fallback机制。
   # 缺少参数时，自动从style中加载参数。除非需要指定liquid_keyboard使用与主键盘不同的背景色、背景图，否则不应设置被注释掉的参数。
   author: "tumuyan"
+  row: 6              #每屏最多显示多少行按键
+  row_land: 5         #横屏每屏最多显示多少行按键
   key_height: 40      #按键高度
   key_height_land: 40 #横屏模式按键高度
   single_width: 60    #single类型的按键宽度

--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -68,6 +68,8 @@ style:
   latin_font: latin.ttf #西文字型
   latin_locale: en_US #西文語言
   locale: zh_TW #預設語言 zh_TW,zh_CN,zh_HK,""
+  keyboard_height: 250 #锁定键盘高度，避免切换时键盘高度变化而造成闪烁
+  keyboard_height_land: 200 #锁定横屏下键盘高度，避免切换时键盘高度变化而造成闪烁
   preview_font: latin.ttf #按鍵提示字型
   preview_height: 60 #按鍵提示高度
   preview_offset: -12 #按鍵提示縱向偏移
@@ -675,6 +677,8 @@ liquid_keyboard:
   # 目前只能直接写参数，不支持变量或者fallback机制。
   # 缺少参数时，自动从style中加载参数。除非需要指定liquid_keyboard使用与主键盘不同的背景色、背景图，否则不应设置被注释掉的参数。
   author: "tumuyan"
+  row: 6              #每屏最多显示多少行按键
+  row_land: 5         #横屏每屏最多显示多少行按键
   key_height: 40      #按键高度
   key_height_land: 40 #横屏模式按键高度
   single_width: 60    #single类型的按键宽度

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -35,6 +35,7 @@ import android.os.Build.VERSION_CODES;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.os.StrictMode;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.Gravity;
@@ -349,6 +350,12 @@ public class Trime extends LifecycleInputMethodService {
 
   @Override
   public void onCreate() {
+
+    StrictMode.setVmPolicy(
+        new StrictMode.VmPolicy.Builder(StrictMode.getVmPolicy())
+            .detectLeakedClosableObjects()
+            .build());
+
     // MUST WRAP all code within Service onCreate() in try..catch to prevent any crash loops
     try {
       // Additional try..catch wrapper as the event listeners chain or the super.onCreate() method
@@ -369,8 +376,8 @@ public class Trime extends LifecycleInputMethodService {
         clipBoardMonitor();
         DraftDao.get();
       } catch (Exception e) {
+        e.printStackTrace();
         super.onCreate();
-        e.fillInStackTrace();
         return;
       }
       super.onCreate();
@@ -647,6 +654,7 @@ public class Trime extends LifecycleInputMethodService {
 
   @Override
   public View onCreateInputView() {
+    Timber.e("onCreateInputView()");
     // 初始化键盘布局
     super.onCreateInputView();
     inputRootBinding = InputRootBinding.inflate(LayoutInflater.from(this));

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -700,6 +700,14 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
 
   private void onBufferDraw() {
     if (mBuffer == null || mKeyboardChanged) {
+      Timber.i(
+          "onBufferDraw() mKeyboardChanged="
+              + mKeyboardChanged
+              + " mBuffer_is_null="
+              + (mBuffer == null)
+              + " getHeight()="
+              + getHeight());
+
       if (mBuffer == null
           || mKeyboardChanged
               && (mBuffer.getWidth() != getWidth() || mBuffer.getHeight() != getHeight())) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Sound.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Sound.java
@@ -39,7 +39,9 @@ public class Sound {
   }
 
   public static void resetProgress() {
-    if (self != null) self.progress = 0;
+    if (self != null) {
+      if (self.progress > 0) self.progress = 0;
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Sound.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Sound.java
@@ -1,5 +1,6 @@
 package com.osfans.trime.ime.keyboard;
 
+import android.media.AudioAttributes;
 import android.media.AudioManager;
 import android.media.SoundPool;
 import android.view.KeyEvent;
@@ -20,7 +21,7 @@ public class Sound {
   private List<String> files;
   private static Sound self;
   private final boolean enable;
-  private int progress = -1;
+  private int progress;
   private int[] melody;
 
   public static Sound get() {
@@ -44,9 +45,10 @@ public class Sound {
     }
   }
 
-  @SuppressWarnings("unchecked")
   public Sound(String soundPackageName) {
-    sp = new SoundPool(3, AudioManager.STREAM_SYSTEM, 0);
+    AudioAttributes audioAttributes =
+        new AudioAttributes.Builder().setLegacyStreamType(AudioManager.STREAM_SYSTEM).build();
+    sp = new SoundPool.Builder().setAudioAttributes(audioAttributes).setMaxStreams(3).build();
     keyset = new ArrayList<>();
     melody = new int[1];
     progress = -1;

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -129,10 +129,28 @@ public class LiquidKeyboard {
         config.getDrawable("liquid_keyboard_background", null, null, null, null);
     if (keyboardBackground != null) parentView.setBackground(keyboardBackground);
 
-    keyHeight = config.getLiquidPixel("key_height_land");
-    if (!isLand || keyHeight <= 0) keyHeight = config.getLiquidPixel("key_height");
-    margin_top = config.getLiquidPixel("vertical_gap");
+    int keyboardHeight = config.getPixel("keyboard_height");
+    if (isLand) {
+      int keyBoardHeightLand = config.getPixel("keyboard_height_land");
+      if (keyBoardHeightLand > 0) keyboardHeight = keyBoardHeightLand;
+    }
 
+    int row = (int) config.getLiquidFloat("row");
+    if (row > 0) {
+      if (isLand) {
+        float r = config.getLiquidFloat("row_land");
+        if (r > 0) row = (int) r;
+      }
+      float rawHeight = config.getLiquidFloat("key_height");
+      float rawVGap = config.getLiquidFloat("vertical_gap");
+      float scale = (float) keyboardHeight / ((rawHeight + rawVGap) * row);
+      margin_top = (int) Math.ceil(rawVGap * scale);
+      keyHeight = keyboardHeight / row - margin_top;
+    } else {
+      keyHeight = config.getLiquidPixel("key_height_land");
+      if (!isLand || keyHeight <= 0) keyHeight = config.getLiquidPixel("key_height");
+      margin_top = config.getLiquidPixel("vertical_gap");
+    }
     Timber.i("config keyHeight=" + keyHeight + " marginTop=" + margin_top);
 
     if (isLand) single_width = config.getLiquidPixel("single_width_land");

--- a/app/src/main/java/com/osfans/trime/settings/components/SchemaPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/settings/components/SchemaPickerDialog.kt
@@ -14,7 +14,6 @@ import com.osfans.trime.util.createLoadingDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -159,7 +158,7 @@ class SchemaPickerDialog(
 
     private suspend fun doInBackground(): String = withContext(Dispatchers.IO) {
         initSchemas()
-        delay(1000) // Simulate async task
+//        delay(1000) // Simulate async task
         return@withContext "OK"
     }
 

--- a/app/src/main/java/com/osfans/trime/settings/components/SoundPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/settings/components/SoundPickerDialog.kt
@@ -12,7 +12,6 @@ import com.osfans.trime.util.createLoadingDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -87,7 +86,7 @@ class SoundPickerDialog(
 
     private suspend fun doInBackground(): String = withContext(Dispatchers.IO) {
         setSound()
-        delay(500) // Simulate async task
+//        delay(500) // Simulate async task
         return@withContext "OK"
     }
 

--- a/app/src/main/java/com/osfans/trime/settings/components/ThemePickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/settings/components/ThemePickerDialog.kt
@@ -12,7 +12,6 @@ import com.osfans.trime.util.createLoadingDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -97,7 +96,7 @@ class ThemePickerDialog(
 
     private suspend fun doInBackground(): String = withContext(Dispatchers.IO) {
         setTheme()
-        delay(500) // Simulate async task
+//        delay(500) // Simulate async task
         return@withContext "OK"
     }
 

--- a/app/src/main/java/com/osfans/trime/setup/Config.java
+++ b/app/src/main/java/com/osfans/trime/setup/Config.java
@@ -704,6 +704,15 @@ public class Config {
     return Float.parseFloat(o.toString());
   }
 
+  public float getLiquidFloat(String key) {
+    if (liquidKeyboard != null) {
+      if (liquidKeyboard.containsKey(key)) {
+        return YamlUtils.INSTANCE.getFloat(liquidKeyboard, key, 0);
+      }
+    }
+    return getFloat(key);
+  }
+
   public float getFloat(String key, float defaultValue) {
     final Object o = getValue(key, defaultValue);
     if (o == null) return defaultValue;


### PR DESCRIPTION
## Pull request
1. 修复了音效包的Sound类没有正确的reset的问题（错误reset后，非melody类型的音效所有按键都只播放第一个音效）。
2. 改善键盘载入用时，最为显著的是音效包和配色可以瞬刷
3. 在皮肤中增加键盘高度参数，方便快速调整整个键盘的高度。因此从源头解决了不同键盘有高度差时，屏幕闪烁的问题。
```

style:
  keyboard_height: 250 #锁定键盘高度，避免切换时键盘高度变化而造成闪烁
  keyboard_height_land: 200 #锁定横屏下键盘高度，避免切换时键盘高度变化而造成闪烁

preset_keyboards:
  keyboard_name:
    auto_height_index: 0 #吸收缩放后的余数的行

```

4. 在皮肤中增加了liquidKeyboard每屏显示的按键行数的参数。

```
liquid_keyboard:
  row: 6              #每屏最多显示多少行按键
  row_land: 5         #横屏每屏最多显示多少行按键

```
5. 在皮肤中增加了liquidKeyboard每屏显示的按键行数的参数。


#### Key Height Design 
新的键盘尺寸计算方式如下：
1. default键盘的高度 = 其他键盘的高度 = liquidKeyboard键盘高度 = ` keyboard_height`或`keyboard_height_land`的dp值（float，允许小数）转换为px
2. 当键盘高度与keyboard_height不一致时，每行按键等比例缩放按键高度高度（padding不参与运算）；
3. 由于高度只能取整数，行之间的间距向上取整数 ，按键高度遵循四舍五入，如存在余数，由 auto_height_index 指定的行吸收 。第一行即0，第二行为1，以此类推；特别的，当值为负数时，为倒序序号（-1即倒数第一个）;当值大于按键行数时，为最后一行。
4. liquidKeyboard的计算方式相对简易， 按键高度 + 行之间的间距 = 键盘高度 / `row`或`row_land` ，取整方式参见上一条。


#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
7. GitHub action ci pass
8. At least one contributor reviews and votes
9. Can be merged clean without conflicts
10. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
