### PR TITLE
改善输入法引导界面的兼容性

### DIFF
--- a/app/src/main/java/com/osfans/trime/common/InputMethodUtils.kt
+++ b/app/src/main/java/com/osfans/trime/common/InputMethodUtils.kt
@@ -4,11 +4,15 @@ import android.content.Context
 import android.content.Intent
 import android.provider.Settings
 import android.view.inputmethod.InputMethodManager
+import com.osfans.trime.BuildConfig
 import com.osfans.trime.TrimeApplication
 import timber.log.Timber
 
 object InputMethodUtils {
-    private const val IME_ID: String = "com.osfans.trime/.TrimeImeService"
+
+    private const val IME_ID0: String = "com.osfans.trime/.TrimeImeService"
+    private const val IME_ID1: String = BuildConfig.APPLICATION_ID + "/com.osfans.trime.TrimeImeService"
+    //    var packageName = javaClass.getPackage().name
     private val context: Context
         get() = TrimeApplication.getInstance().applicationContext
 
@@ -17,8 +21,11 @@ object InputMethodUtils {
             context.contentResolver,
             Settings.Secure.ENABLED_INPUT_METHODS
         ) ?: "(none)"
+
         Timber.i("List of active IMEs: $activeImeIds")
-        return activeImeIds.split(":").contains(IME_ID)
+        if (activeImeIds.split(":").contains(IME_ID0))
+            return true
+        return activeImeIds.split(":").contains(IME_ID1)
     }
 
     fun checkIsTrimeSelected(): Boolean {
@@ -27,7 +34,9 @@ object InputMethodUtils {
             Settings.Secure.DEFAULT_INPUT_METHOD
         ) ?: "(none)"
         Timber.i("Selected IME: $selectedImeIds")
-        return selectedImeIds == IME_ID
+        if (selectedImeIds == IME_ID0)
+            return true
+        return selectedImeIds == IME_ID1
     }
 
     fun showImeEnablerActivity(context: Context) {


### PR DESCRIPTION
## Pull request
改善输入法引导界面的兼容性

#### Feature
由于原引导界面判断的值是写死的字符串，当APK的包名被修改后，引导界面无法正确判断已经选择过输入法。
此PR增加了一次判断，从而修复了这个问题。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
