### PR TITLE
优化键盘和皮肤

### DIFF
--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -1040,6 +1040,7 @@ preset_keyboards:
   letter:
     __include: /preset_keyboards/default
     ascii_mode: 1
+    reset_ascii_mode: true  #显示键盘时重置为ascii_mode指定的状态
     lock: false
   qwerty0:
     name: 預設36鍵

--- a/app/src/main/java/com/osfans/trime/Rime.java
+++ b/app/src/main/java/com/osfans/trime/Rime.java
@@ -353,15 +353,18 @@ public class Rime {
     return keycode <= 0 || keycode == XK_VoidSymbol;
   }
 
+  // KeyProcess 调用JNI方法发送keycode和mask
   private static boolean onKey(int keycode, int mask) {
-    Timber.i("onkey(), keycode=%s, mask=%s", keycode, mask);
+    Timber.i("\t<TrimeInput>\tonkey()\tkeycode=%s, mask=%s", keycode, mask);
     if (isVoidKeycode(keycode)) return false;
     final boolean b = process_key(keycode, mask);
-    Timber.i("onkey(), keycode=%s, mask=%s, process_key result=%s", keycode, mask, b);
+    Timber.i(
+        "\t<TrimeInput>\tonkey()\tkeycode=%s, mask=%s, process_key result=%s", keycode, mask, b);
     getContexts();
     return b;
   }
 
+  // KeyProcess 调用JNI方法发送keycode和mask
   public static boolean onKey(int[] event) {
     if (event != null && event.length == 2) return onKey(event[0], event[1]);
     return false;

--- a/app/src/main/java/com/osfans/trime/Rime.java
+++ b/app/src/main/java/com/osfans/trime/Rime.java
@@ -224,9 +224,17 @@ public class Rime {
     System.loadLibrary("rime_jni");
   }
 
+  /*
+  Android SDK包含了如下6个修饰键的状态，其中function键会被trime消费掉，因此只处理5个键
+  Android和librime对按键命名并不一致。读取可能有误。librime按键命名见如下链接，
+  https://github.com/rime/librime/blob/master/src/rime/key_table.cc
+   */
   public static int META_SHIFT_ON = get_modifier_by_name("Shift");
   public static int META_CTRL_ON = get_modifier_by_name("Control");
   public static int META_ALT_ON = get_modifier_by_name("Alt");
+  public static int META_SYM_ON = get_modifier_by_name("Super");
+  public static int META_META_ON = get_modifier_by_name("Meta");
+
   public static int META_RELEASE_ON = get_modifier_by_name("Release");
   private static boolean showSwitches = true;
   private static boolean showSwitchArrow = false;

--- a/app/src/main/java/com/osfans/trime/ime/core/EditorInstance.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/EditorInstance.kt
@@ -131,7 +131,9 @@ class EditorInstance(private val ims: InputMethodService) {
     fun meta(
         ctrl: Boolean = false,
         alt: Boolean = false,
-        shift: Boolean = false
+        shift: Boolean = false,
+        meta: Boolean = false,
+        sym: Boolean = false,
     ): Int {
         var metaState = 0
         if (ctrl) {
@@ -143,6 +145,13 @@ class EditorInstance(private val ims: InputMethodService) {
         if (shift) {
             metaState = metaState or KeyEvent.META_SHIFT_ON or KeyEvent.META_SHIFT_LEFT_ON
         }
+        if (meta) {
+            metaState = metaState or KeyEvent.META_META_ON or KeyEvent.META_META_LEFT_ON
+        }
+        if (sym) {
+            metaState = metaState or KeyEvent.META_SYM_ON
+        }
+
         return metaState
     }
 
@@ -214,16 +223,14 @@ class EditorInstance(private val ims: InputMethodService) {
         if (metaState and KeyEvent.META_SHIFT_ON != 0) {
             sendDownKeyEvent(eventTime, KeyEvent.KEYCODE_SHIFT_LEFT, 0)
         }
-        /*
-        var sendKeyDownUp = true
-        if (metaState == 0 && mAsciiMode) {
-            // 使用ASCII键盘输入英文字符时，直接上屏，跳过复杂的调用，从表面上解决issue #301 知乎输入英语后输入法失去焦点的问题
-            val keyText = toCharString(keyEventCode)
-            if (keyText.isNotEmpty()) {
-                ic.commitText(keyText, 1)
-                sendKeyDownUp = false
-            }
-        } */
+        if (metaState and KeyEvent.META_META_ON != 0) {
+            sendDownKeyEvent(eventTime, KeyEvent.KEYCODE_META_LEFT, 0)
+        }
+
+        if (metaState and KeyEvent.META_SYM_ON != 0) {
+            sendDownKeyEvent(eventTime, KeyEvent.KEYCODE_SYM, 0)
+        }
+
         for (n in 0 until count) {
             sendDownKeyEvent(eventTime, keyEventCode, metaState)
             sendUpKeyEvent(eventTime, keyEventCode, metaState)
@@ -237,6 +244,15 @@ class EditorInstance(private val ims: InputMethodService) {
         if (metaState and KeyEvent.META_CTRL_ON != 0) {
             sendUpKeyEvent(eventTime, KeyEvent.KEYCODE_CTRL_LEFT, 0)
         }
+
+        if (metaState and KeyEvent.META_META_ON != 0) {
+            sendUpKeyEvent(eventTime, KeyEvent.KEYCODE_META_LEFT, 0)
+        }
+
+        if (metaState and KeyEvent.META_SYM_ON != 0) {
+            sendUpKeyEvent(eventTime, KeyEvent.KEYCODE_SYM, 0)
+        }
+
         ic.endBatchEdit()
         return true
     }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -806,7 +806,7 @@ public class Trime extends LifecycleInputMethodService {
    * a sentence.
    */
   private void dispatchCapsStateToInputView() {
-    if ((isAutoCaps || Rime.isAsciiMode())
+    if ((isAutoCaps && Rime.isAsciiMode())
         && (mainKeyboardView != null && !mainKeyboardView.isCapsOn())) {
       mainKeyboardView.setShifted(false, activeEditorInstance.getCursorCapsMode() != 0);
     }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -845,7 +845,7 @@ public class Trime extends LifecycleInputMethodService {
     final int keyCode = event.getKeyCode();
     if (keyCode == KeyEvent.KEYCODE_MENU) return false; // 不處理 Menu 鍵
     if (keyCode >= Key.getSymbolStart()) return false; // 只處理安卓標準按鍵
-    if (event.getRepeatCount() == 0 && KeyEvent.isModifierKey(keyCode)) {
+    if (event.getRepeatCount() == 0 && Key.isTrimeModifierKey(keyCode)) {
       boolean ret =
           onRimeKey(
               Event.getRimeEvent(

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -857,14 +857,14 @@ public class Trime extends LifecycleInputMethodService {
 
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
-    Timber.i("onKeyDown = %s", event);
+    Timber.i("\t<TrimeInput>\tonKeyDown()\tkeycode=%d, event=%s", keyCode, event.toString());
     if (composeEvent(event) && onKeyEvent(event)) return true;
     return super.onKeyDown(keyCode, event);
   }
 
   @Override
   public boolean onKeyUp(int keyCode, KeyEvent event) {
-    Timber.i("onKeyUp = %s", event);
+    Timber.i("\t<TrimeInput>\tonKeyUp()\tkeycode=%d, event=%s", keyCode, event.toString());
     if (composeEvent(event) && textInputManager.getNeedSendUpRimeKey()) {
       textInputManager.onRelease(keyCode);
       return true;
@@ -878,8 +878,9 @@ public class Trime extends LifecycleInputMethodService {
    * @param event {@link KeyEvent 按鍵事件}
    * @return 是否成功處理
    */
+  // KeyEvent 处理实体键盘事件
   private boolean onKeyEvent(@NonNull KeyEvent event) {
-    Timber.i("onKeyEvent = %s", event);
+    Timber.i("\t<TrimeInput>\tonKeyEvent()\tRealKeyboard event=%s", event.toString());
     int keyCode = event.getKeyCode();
     textInputManager.setNeedSendUpRimeKey(Rime.isComposing());
     if (!isComposing()) {
@@ -947,17 +948,27 @@ public class Trime extends LifecycleInputMethodService {
     }
   }
 
+  // 处理键盘事件(Android keycode)
   public boolean handleKey(int keyEventCode, int metaState) { // 軟鍵盤
     textInputManager.setNeedSendUpRimeKey(false);
     if (onRimeKey(Event.getRimeEvent(keyEventCode, metaState))) {
+      // 如果输入法消费了按键事件，则需要释放按键
       textInputManager.setNeedSendUpRimeKey(true);
-      Timber.i("Rime onKey");
+      Timber.d(
+          "\t<TrimeInput>\thandleKey()\trimeProcess, keycode=%d, metaState=%d",
+          keyEventCode, metaState);
     } else if (performEnter(keyEventCode) || handleBack(keyEventCode)) {
-      Timber.i("Trime onKey");
+      // 处理返回键（隐藏软键盘）和回车键（换行）
+      // todo 确认是否有必要单独处理回车键？是否需要把back和escape全部占用？
+      Timber.d("\t<TrimeInput>\thandleKey()\tEnterOrHide, keycode=%d", keyEventCode);
     } else if (ShortcutUtils.INSTANCE.openCategory(keyEventCode)) {
-      Timber.i("Open category");
+      // 打开系统默认应用
+      Timber.d("\t<TrimeInput>\thandleKey()\topenCategory keycode=%d", keyEventCode);
     } else {
       textInputManager.setNeedSendUpRimeKey(true);
+      Timber.d(
+          "\t<TrimeInput>\thandleKey()\treturn FALSE, keycode=%d, metaState=%d",
+          keyEventCode, metaState);
       return false;
     }
     return true;

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -518,6 +518,7 @@ public class Trime extends LifecycleInputMethodService {
   public void resetKeyboard() {
     if (mainKeyboardView != null) {
       mainKeyboardView.setShowHint(!Rime.getOption("_hide_key_hint"));
+      mainKeyboardView.setShowSymbol(!Rime.getOption("_hide_key_symbol"));
       mainKeyboardView.reset(this); // 實體鍵盤無軟鍵盤
     }
   }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
@@ -237,6 +237,8 @@ public class Event {
     return keyCode;
   }
 
+  // TODO 把软键盘预设android_keys的keycode(index)->keyname(string)—>rimeKeycode的过程改为直接返回int
+  // https://github.com/rime/librime/blob/99e269c8eb251deddbad9b0d2c4d965b228f8006/src/rime/key_table.cc
   private static int getRimeCode(int code) {
     int i = 0;
     if (code >= 0 && code < Key.androidKeys.size()) {
@@ -250,6 +252,7 @@ public class Event {
     return (mask & modifier) > 0;
   }
 
+  // KeyboardEvent 从软键盘的按键keycode（可能含有mask）和mask，分离出rimekeycode和mask构成的数组
   public static int[] getRimeEvent(int code, int mask) {
     int i = getRimeCode(code);
     int m = 0;

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
@@ -182,7 +182,7 @@ public class Event {
   @NonNull
   private String adjustCase(String s) {
     if (TextUtils.isEmpty(s)) return "";
-    if (s.length() == 1 && mKeyboard != null && mKeyboard.isShifted())
+    if (s.length() == 1 && mKeyboard != null && mKeyboard.needUpCase())
       s = s.toUpperCase(Locale.getDefault());
     else if (s.length() == 1
         && mKeyboard != null
@@ -200,7 +200,7 @@ public class Event {
     String s = "";
     if (!TextUtils.isEmpty(text)) s = text;
     else if (mKeyboard != null
-        && mKeyboard.isShifted()
+        && mKeyboard.needUpCase()
         && mask == 0
         && code >= KeyEvent.KEYCODE_A
         && code <= KeyEvent.KEYCODE_Z) s = label;
@@ -284,8 +284,20 @@ public class Event {
     if (hasModifier(mask, KeyEvent.META_SHIFT_ON)) m |= Rime.META_SHIFT_ON;
     if (hasModifier(mask, KeyEvent.META_CTRL_ON)) m |= Rime.META_CTRL_ON;
     if (hasModifier(mask, KeyEvent.META_ALT_ON)) m |= Rime.META_ALT_ON;
+    if (hasModifier(mask, KeyEvent.META_SYM_ON)) m |= Rime.META_SYM_ON;
+    if (hasModifier(mask, KeyEvent.META_META_ON)) m |= Rime.META_META_ON;
     if (mask == Rime.META_RELEASE_ON) m |= Rime.META_RELEASE_ON;
     return new int[] {i, m};
+  }
+
+  public boolean isMeta() {
+    int c = getCode();
+    return (c == KeyEvent.KEYCODE_META_LEFT || c == KeyEvent.KEYCODE_META_RIGHT);
+  }
+
+  public boolean isAlt() {
+    int c = getCode();
+    return (c == KeyEvent.KEYCODE_ALT_LEFT || c == KeyEvent.KEYCODE_ALT_RIGHT);
   }
 
   private static final Map<String, Integer> masks =
@@ -294,6 +306,8 @@ public class Event {
           put("Shift", KeyEvent.META_SHIFT_ON);
           put("Control", KeyEvent.META_CTRL_ON);
           put("Alt", KeyEvent.META_ALT_ON);
+          put("Meta", KeyEvent.META_META_ON);
+          put("SYM", KeyEvent.META_SYM_ON);
         }
       };
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
@@ -457,6 +457,7 @@ public class Key {
     return (c == KeyEvent.KEYCODE_SHIFT_LEFT || c == KeyEvent.KEYCODE_SHIFT_RIGHT);
   }
 
+  // shift键在点击时是否触发锁定
   public boolean isShiftLock() {
     switch (getClick().getShiftLock()) {
       case "long":

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
@@ -96,6 +96,7 @@ public class Key {
   private boolean on;
   private String popupCharacters;
   private int popupResId;
+  private String labelSymbol;
 
   /**
    * Create an empty key with no attributes.
@@ -136,6 +137,7 @@ public class Key {
     s = YamlUtils.INSTANCE.getString(mk, "ascii", "");
     if (!TextUtils.isEmpty(s)) ascii = new Event(mKeyboard, s);
     label = YamlUtils.INSTANCE.getString(mk, "label", "");
+    labelSymbol = YamlUtils.INSTANCE.getString(mk, "label_symbol", "");
     hint = YamlUtils.INSTANCE.getString(mk, "hint", "");
     if (mk.containsKey("send_bindings")) {
       send_bindings = YamlUtils.INSTANCE.getBoolean(mk, "send_bindings", true);
@@ -535,6 +537,10 @@ public class Key {
   }
 
   public String getSymbolLabel() {
-    return getLongClick().getLabel();
+    if (labelSymbol.isEmpty()) {
+      Event longClick = getLongClick();
+      if (longClick != null) return longClick.getLabel();
+    }
+    return labelSymbol;
   }
 }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -76,6 +76,8 @@ public class Keyboard {
   /** Keyboard mode, or zero, if none. */
   private int mAsciiMode;
 
+  private boolean resetAsciiMode;
+
   // Variables for pre-computing nearest keys.
   private String mLabelTransform;
   private int mCellWidth;
@@ -195,6 +197,7 @@ public class Keyboard {
     mAsciiMode = YamlUtils.INSTANCE.getInt(keyboardConfig, "ascii_mode", 1);
     if (mAsciiMode == 0)
       mAsciiKeyboard = YamlUtils.INSTANCE.getString(keyboardConfig, "ascii_keyboard", "");
+    resetAsciiMode = YamlUtils.INSTANCE.getBoolean(keyboardConfig, "reset_ascii_mode", false);
     mLock = YamlUtils.INSTANCE.getBoolean(keyboardConfig, "lock", false);
     int columns = YamlUtils.INSTANCE.getInt(keyboardConfig, "columns", 30);
     int defaultWidth =
@@ -586,6 +589,10 @@ public class Keyboard {
 
   public boolean getAsciiMode() {
     return mAsciiMode != 0;
+  }
+
+  public boolean isResetAsciiMode() {
+    return resetAsciiMode;
   }
 
   public String getAsciiKeyboard() {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSwitcher.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSwitcher.kt
@@ -89,5 +89,9 @@ class KeyboardSwitcher {
         currentId = if (id.isValidId()) id else 0
     }
 
+    public fun getCurrentKeyboardName(): String {
+        return keyboardNames.get(currentId)
+    }
+
     private fun Int.isValidId() = this in keyboards.indices
 }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -232,7 +232,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
    */
   private boolean mHeadsetRequiredToHearPasswordsAnnounced;
 
-  private boolean mShowHint = true;
+  private boolean mShowHint = true, mShowSymbol = true;
 
   private Method findStateDrawableIndex;
   private Method getStateDrawable;
@@ -276,6 +276,10 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
 
   public void setShowHint(final boolean value) {
     mShowHint = value;
+  }
+
+  public void setShowSymbol(final boolean value) {
+    mShowSymbol = value;
   }
 
   public void reset(final Context context) {
@@ -808,20 +812,22 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
                 + top
                 + key.getKey_text_offset_y(),
             paint);
-        if (mShowHint) {
-          if (key.getLongClick() != null) {
+        if (mShowSymbol) {
+          String labelSymbol = key.getSymbolLabel();
+          if (!TextUtils.isEmpty(labelSymbol)) {
             mPaintSymbol.setTextSize(
                 key.getSymbol_text_size() != null && key.getSymbol_text_size() > 0
                     ? key.getSymbol_text_size()
                     : mSymbolSize);
             mPaintSymbol.setShadowLayer(mShadowRadius, 0, 0, mShadowColor);
             canvas.drawText(
-                key.getSymbolLabel(),
+                labelSymbol,
                 left + key.getKey_symbol_offset_x(),
                 symbolBase + key.getKey_symbol_offset_y(),
                 mPaintSymbol);
           }
-
+        }
+        if (mShowHint) {
           if (!TextUtils.isEmpty(hint)) {
             mPaintSymbol.setShadowLayer(mShadowRadius, 0, 0, mShadowColor);
             canvas.drawText(

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -934,6 +934,8 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
         final int[] codes = new int[MAX_NEARBY_KEYS];
         Arrays.fill(codes, NOT_A_KEY);
         getKeyIndices(x, y, codes);
+        Timber.d("\t<TrimeInput>\tdetectAndSendKey()\ttype=" + type + ", key.getEvent");
+        //      可以在这里把 mKeyboard.getModifer() 获取的修饰键状态写入event里
         mKeyboardActionListener.onEvent(key.getEvent(type));
         releaseKey(code);
         resetShifted();

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -230,6 +230,12 @@ class TextInputManager private constructor() :
             it.switchToKeyboard(keyboardType)
         }
         Rime.get(trime)
+
+        // style/reset_ascii_mode指定了弹出键盘时是否重置ASCII状态。
+        // 键盘的reset_ascii_mode指定了重置时是否重置到keyboard的ascii_mode描述的状态。
+        if (shouldResetAsciiMode && keyboardSwitcher.currentKeyboard.isResetAsciiMode) {
+            tempAsciiMode = keyboardSwitcher.currentKeyboard.asciiMode
+        }
         tempAsciiMode?.let { Rime.setOption("ascii_mode", it) }
         isComposable = isComposable && !Rime.isEmpty()
         if (!trime.onEvaluateInputViewShown()) {

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -137,6 +137,7 @@ class TextInputManager private constructor() :
         mainKeyboardView = uiBinding.main.mainKeyboardView.also {
             it.setOnKeyboardActionListener(this)
             it.setShowHint(!Rime.getOption("_hide_key_hint"))
+            it.setShowSymbol(!Rime.getOption("_hide_key_symbol"))
             it.reset(trime)
         }
         // Initialize candidate bar
@@ -250,6 +251,7 @@ class TextInputManager private constructor() :
             }
             "_liquid_keyboard" -> trime.selectLiquidKeyboard(0)
             "_hide_key_hint" -> if (mainKeyboardView != null) mainKeyboardView!!.setShowHint(!value)
+            "_hide_key_symbol" -> if (mainKeyboardView != null) mainKeyboardView!!.setShowSymbol(!value)
             else -> if (option.startsWith("_keyboard_") &&
                 option.length > 10 && value
             ) {

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -293,6 +293,7 @@ class TextInputManager private constructor() :
         }
     }
 
+    // KeyboardEvent 处理软键盘事件
     override fun onEvent(event: Event?) {
         event ?: return
         if (!event.commit.isNullOrEmpty()) {
@@ -364,7 +365,7 @@ class TextInputManager private constructor() :
             }
             KeyEvent.KEYCODE_PROG_RED -> trime.showColorDialog() // Color schemes
             KeyEvent.KEYCODE_MENU -> trime.showOptionsDialog()
-            else -> onKey(event.code, event.mask)
+            else -> onKey(event.code, event.mask or trime.keyboardSwitcher.currentKeyboard.modifer)
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
@@ -18,6 +18,7 @@ import com.blankj.utilcode.util.IntentUtils
 import com.osfans.trime.Rime
 import com.osfans.trime.ime.core.Preferences
 import com.osfans.trime.ime.core.Trime
+import timber.log.Timber
 import java.text.FieldPosition
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -127,6 +128,7 @@ object ShortcutUtils {
     fun openCategory(keyCode: Int): Boolean {
         val category = applicationLaunchKeyCategories[keyCode]
         return if (category != null) {
+            Timber.d("\t<TrimeInput>\topenCategory()\tkeycode=%d, app=%s", keyCode, category)
             val intent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, category)
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_HISTORY
             ActivityUtils.startActivity(intent)

--- a/app/src/main/java/com/osfans/trime/util/StringUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/StringUtils.kt
@@ -62,6 +62,7 @@ object StringUtils {
         return true
     }
 
+    // KeyCode Android keycode -> 可录入的按键字符
     // 考虑到可能存在魔改机型的keycode有差异，而KeyEvent.keyCodeToString(keyCode)无法从keyCode获得按键字符，故重写这个从keyCode获取Char的方法。
     @JvmStatic
     fun toCharString(keyCode: Int): String {


### PR DESCRIPTION
## Pull request
1. 目前在处理按键事件时，没有读取修饰键的状态。对此情况进行了简易修复 Fixes #685
2. 增加皮肤开关参数`_hide_key_symbol`，按键显示的文字由两个开关单独控制：`_hide_key_symbol`控制上方的符号是否隐藏，`_hide_key_hint`控制下方的助记符号。
3. 增加皮肤参数`label_symbol`，当按键有此参数时，按键符号位置优先显示此参数指定的文本；否则读取longpress对应的label
4. 增加按键的新写法，可以无需使用预设按键，直接把commit参数写在按键参数中
参考：
```
      - {click: f, swipe_up: {commit: "%"}}
```
5. 增加keyboard的皮肤keyboard的参数 reset_ascii_mode。
 style/reset_ascii_mode指定了弹出键盘时是否重置ASCII状态。 键盘的reset_ascii_mode指定了重置时是否重置到keyboard的ascii_mode描述的状态。
6. 修复部分App首字母被错误设置shift状态的问题
7. 增加了单独的Alt/meta/sys修饰键的支持。暂时和Ctrl键一样，点击后不能显示已经选中这个修饰键（问题比较复杂，近期不能解决，故此pr不做处理）


#### Issue tracker
Fixes will automatically close the related issue



#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
8. GitHub action ci pass
9. At least one contributor reviews and votes
10. Can be merged clean without conflicts
11. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
