### PR TITLE
在主题的preset_keyboards中设置keyboard_height

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -137,6 +137,8 @@ public class Keyboard {
     mKeys = new ArrayList<>();
     mComposingKeys = new ArrayList<>();
   }
+
+  // todo 把按下按键弹出的内容改为单独设计的view，而不是keyboard
   /**
    * Creates a blank keyboard from the given resource file and populates it with the specified
    * characters in left-to-right, top-to-bottom fashion, using the specified number of columns.
@@ -236,6 +238,15 @@ public class Keyboard {
     int[] newHeight = new int[0];
 
     if (keyboardHeight > 0) {
+      int mkeyboardHeight = YamlUtils.INSTANCE.getPixel(keyboardConfig, "keyboard_height", 0);
+      if (land) {
+        int mkeyBoardHeightLand =
+            YamlUtils.INSTANCE.getPixel(keyboardConfig, "keyboard_height_land", 0);
+        if (mkeyBoardHeightLand > 0) mkeyboardHeight = mkeyBoardHeightLand;
+      }
+
+      if (mkeyboardHeight > 0) keyboardHeight = mkeyboardHeight;
+
       int rawSumHeight = 0;
       List<Integer> rawHeight = new ArrayList<>();
       for (Map<String, Object> mk : lm) {


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
#709 中锁定了键盘高度，但是部分用户需要不同键盘有不同高度，
此pr通过在preset_keyboards中指定单个键盘的高度，进行了修复。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
