### PR TITLE
键盘跟随系统自动切换暗黑、明亮模式

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -150,6 +150,7 @@ preset_color_schemes:
   default:
     name: "标准配色！"  #方案名称
     author: 风花絮 #作者信息
+    dark_scheme: steam
     back_color: *color2 #候选区背景状态栏
     candidate_separator_color: *color2 #候选分割背景
     candidate_text_color: *color1 #候选文本
@@ -676,6 +677,7 @@ preset_color_schemes:
   steam:
     name: "Steam"
     author: "Patricivs <ipatrickmac@me.com>"
+    light_scheme: default
     text_color: 0xff528ccd
     back_color: 0xff171614
     border_color: 0xff383635
@@ -1011,7 +1013,7 @@ preset_keyboards:
       - {click: BackSpace, width: 15, key_back_color: bbs, key_text_color: tbs}
 
       - {click: Keyboard_number, long_click: Menu, width: 12.5, key_back_color: bgn, key_text_color: tgn}
-      - {click: Keyboard_bqrw, long_click: Theme_settings, width: 12.5, key_text_size: "18", key_back_color: bgn, key_text_color: tgn}
+      - {click: Keyboard_bqrw, long_click: Theme_settings, swipe_down: Color_switch, swipe_up: Color_switch, width: 12.5, key_text_size: "18", key_back_color: bgn, key_text_color: tgn}
       - {click: ',', label: '，', long_click: '<>{Left}', key_back_color: bh4, key_text_color: th4}
       - {click: space, long_click: Mode_switch, swipe_left: "Left", swipe_right: "Right", swipe_up: Schema_switchcn, width: 30, key_back_color: bkg, key_text_color: tkg}
       - {click: '.', label: '。', long_click: liquid_keyboard_clipboard, key_back_color: bh4, key_text_color: th4}


### PR DESCRIPTION
## Pull request
1. 在主题中preset_color_schemes的各个小节中，增加dark_scheme参数即可把此配色视为明亮模式的配色，并且当系统切换为暗黑模式后，当弹出键盘时，自动切换配色方案为dark_scheme指定的配色。包含light_scheme参数时，反之。
2. 同文风已经内置了一组light/dark配色方案，即stream/default
3. 当配色没有指定dark_scheme、light_scheme参数时，几乎没有性能损失。


#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
4. GitHub action ci pass
5. At least one contributor reviews and votes
6. Can be merged clean without conflicts
7. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
