### PR TITLE
修复候选不对齐问题#698，增加候选和注释y向偏移#741

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabView.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabView.java
@@ -57,6 +57,7 @@ public class TabView extends View {
   private final boolean shouldShowComment = true;
   private boolean isCommentOnTop;
   private boolean shouldCandidateUseCursor;
+  private int candidateOffsetY, commentOffsetY;
   // private final Rect[] tabGeometries = new Rect[MAX_CANDIDATE_COUNT + 2];
 
   public void reset(Context context) {
@@ -78,6 +79,8 @@ public class TabView extends View {
     candidateViewHeight = config.getPixel("candidate_view_height");
 
     candidateFont = config.getFont("candidate_font");
+    candidateOffsetY = config.getFont("candidate_offset_y");
+    commentOffsetY = config.getFont("comment_offset_y");
 
     candidatePaint.setTextSize(candidateTextSize);
     candidatePaint.setTypeface(candidateFont);

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
@@ -77,6 +77,7 @@ public class Candidate extends View {
   private int candidateViewHeight, commentHeight, candidateSpacing, candidatePadding;
   private boolean shouldShowComment = true, isCommentOnTop, candidateUseCursor;
   private int commentOffsetY, candidateOffsetY;
+  private int cmtcnt;
 
   public void reset(Context context) {
     Config config = Config.get(context);
@@ -216,6 +217,7 @@ public class Candidate extends View {
     if (candidates == null) return;
     super.onDraw(canvas);
 
+    /*
     int cmtcnt = 0;
     for (ComputedCandidate computedCandidate : computedCandidates) {
       if (computedCandidate instanceof ComputedCandidate.Word) {
@@ -224,6 +226,7 @@ public class Candidate extends View {
           cmtcnt++;
       }
     }
+     */
     for (ComputedCandidate computedCandidate : computedCandidates) {
       int i = computedCandidates.indexOf(computedCandidate);
       // Draw highlight
@@ -251,10 +254,11 @@ public class Candidate extends View {
               if (!isCommentOnTop) {
                 float commentWidth = graphicUtils.measureText(commentPaint, comment, commentFont);
                 commentX = computedCandidate.getGeometry().right - commentWidth / 2;
-                commentY += computedCandidates.get(0).getGeometry().bottom - commentHeight ;
-                commentY -= commentOffsetY;
+                //commentY += computedCandidates.get(0).getGeometry().bottom - commentHeight + candidateOffsetY ;
+                //commentY -= commentOffsetY;
                 wordX -= commentWidth / 2.0f;
                 wordY -= commentHeight / 2.0f;
+                commentY = wordY;
               }
               commentPaint.setColor(isHighlighted(i) ? hilitedCommentTextColor : commentTextColor);
               graphicUtils.drawText(canvas, comment, commentX, commentY, commentPaint, commentFont);
@@ -342,6 +346,16 @@ public class Candidate extends View {
               PAGE_DOWN_BUTTON, new Rect(x, 0, (int) ((int) x + right), getMeasuredHeight())));
       x += (int) right;
     }
+
+    cmtcnt = 0;
+    for (ComputedCandidate computedCandidate : computedCandidates) {
+      if (computedCandidate instanceof ComputedCandidate.Word) {
+        String cmt = ((ComputedCandidate.Word) computedCandidate).getComment();
+        if (cmt != null && !cmt.isEmpty())
+          cmtcnt++;
+      }
+    }
+
     LayoutParams params = getLayoutParams();
     params.width = x;
     params.height =


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #698 
![QQ截图20220514123410](https://user-images.githubusercontent.com/4023160/168410900-798caeac-78b7-4573-b073-08f54c687ed0.png)
![QQ截图20220514123422](https://user-images.githubusercontent.com/4023160/168410936-ed78be96-f52d-48f4-9c35-abe17fdc8446.png)
![QQ截图20220514123433](https://user-images.githubusercontent.com/4023160/168410939-e9b347f7-dc27-4af0-b761-4746d7de93be.png)
![QQ截图20220514123448](https://user-images.githubusercontent.com/4023160/168410941-d1b6e600-8bbc-4159-967b-0b7ffb06ddea.png)
![QQ截图20220514123458](https://user-images.githubusercontent.com/4023160/168410949-50aed315-8021-4bb0-894e-8c19006bbafb.png)
![QQ截图20220514123508](https://user-images.githubusercontent.com/4023160/168410955-722010c9-df1c-46f6-8358-a44b7b4bdc43.png)



#### Feature
Describe feature of pull request
#741 
增加两个参数，以便在特定candidate_background图片的时候可以更好的适配 candidate 和 comment的位置（y)
        comment_offset_y
        candidate_offset_y
效果
offset 都为0:
![before](https://user-images.githubusercontent.com/4023160/167903384-69884b9c-9ac7-41e6-b47b-fe6e752118ba.jpg)
offset 调整后：
![after](https://user-images.githubusercontent.com/4023160/167903423-1207f85c-2917-4a7a-a0b9-7a146e953c2b.jpg)


#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [ ] `./gradlew spotlessCheck`
- [ ] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
