### PR TITLE
优化liquidkeyboard —— 自动隐藏、按键换行

### DIFF
--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -684,7 +684,7 @@ liquid_keyboard:
   single_width: 60    #single类型的按键宽度
   vertical_gap: 1     #纵向按键间隙
   margin_x: 0.5         #左右按键间隙的1/2
-  keyboards: [emoji, math, ascii, cn, history, clipboard, draft, list, tabs, exit, ids , jp, table, symbol, pinyin, grease, rusa, korea, lation, yinbiao, unit,  exit]  #tab列表
+  keyboards: [emoji, math, ascii, cn, history, clipboard, draft, tabs, exit, list, ids , table, symbol, unit, new, jp, pinyin, grease, rusa, korea, lation, yinbiao,  exit]  #tab列表
   exit:
     name: 返回
     type: NO_KEY
@@ -692,6 +692,9 @@ liquid_keyboard:
   tabs:
     name: 更多
     type: TABS
+  new:
+    name: 新行 #此类型不显示在候选栏中，但是打开“更多”TAB时，下一个按键会换行
+    type: NEW_ROW
   history:
     name: 常用
     type: HISTORY
@@ -723,8 +726,9 @@ liquid_keyboard:
       - ‘
       - ···
       - ……
-      - { click: "——" }
+      - { click: "-" }
       - { click: "——", label: "破折" }
+      - { click: "" } # 内容为空可以强制令键盘从此处新起一行
       - （
       - ）
       - 【

--- a/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
@@ -4,6 +4,9 @@ import java.util.HashMap
 import java.util.Locale
 
 enum class SymbolKeyboardType {
+    // 不占据tab位，仅当在“更多”面板，即“TABS”中显示时，产生换行效果
+    NEW_ROW,
+
     // 只占据tab位，不含keys（如返回键
     NO_KEY,
 
@@ -27,7 +30,10 @@ enum class SymbolKeyboardType {
     //  按键使用固定宽度。如不设置宽度，则自动换行
     SHORT,
 
-    //  按键长度不固定
+    //  按键长度不固定，与展开候选的样式相同；与
+    VAR,
+
+    //  长度较长，与草稿箱、剪贴板的样式相同，使用小号字体多行展示
     LONG,
 
     //  需要展开显示的多行内容（不省略内容）
@@ -57,8 +63,14 @@ enum class SymbolKeyboardType {
             return type ?: SINGLE
         }
 
-        fun needKeys(type: SymbolKeyboardType): Boolean {
+        // 是否在liquidKeyboard键盘区域展示按键
+        fun hasKeys(type: SymbolKeyboardType): Boolean {
             return type > HISTORY
+        }
+
+        // 是否呈现在liquidKeyboard键盘区域的tabs列表中
+        fun hasKey(type: SymbolKeyboardType): Boolean {
+            return type >= CLIPBOARD
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.java
@@ -94,7 +94,6 @@ public class SimpleAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
       final ItemViewHolder itemViewHold = ((ItemViewHolder) viewHolder);
 
       if (textFont != null) itemViewHold.mTitle.setTypeface(textFont);
-      itemViewHold.mTitle.setText(searchHistoryBean.getText());
 
       itemViewHold.mTitle.setText(searchHistoryBean.getLabel());
       if (textSize > 0) itemViewHold.mTitle.setTextSize(textSize);
@@ -104,19 +103,27 @@ public class SimpleAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         FlexboxLayoutManager.LayoutParams flexboxLp =
             (FlexboxLayoutManager.LayoutParams) itemViewHold.listItemLayout.getLayoutParams();
 
-        if (keyWidth > 0) flexboxLp.setWidth(keyWidth);
-        if (keyHeight > 0) flexboxLp.setHeight(keyHeight);
-        itemViewHold.mTitle.setTextColor(textColor);
+        if (searchHistoryBean.getLabel().isEmpty()) {
+          flexboxLp.setWrapBefore(true);
+          flexboxLp.setWidth(0);
+          flexboxLp.setHeight(0);
+          flexboxLp.setMargins(0, 0, 0, 0);
+        } else {
 
-        int marginTop = flexboxLp.getMarginTop();
-        int marginX = flexboxLp.getMarginLeft();
-        if (keyMarginTop > 0) marginTop = keyMarginTop;
-        if (keyMarginX > 0) marginX = keyMarginX;
+          if (keyWidth > 0) flexboxLp.setWidth(keyWidth);
+          if (keyHeight > 0) flexboxLp.setHeight(keyHeight);
+          itemViewHold.mTitle.setTextColor(textColor);
 
-        flexboxLp.setMargins(marginX, marginTop, marginX, flexboxLp.getMarginBottom());
+          int marginTop = flexboxLp.getMarginTop();
+          int marginX = flexboxLp.getMarginLeft();
+          if (keyMarginTop > 0) marginTop = keyMarginTop;
+          if (keyMarginX > 0) marginX = keyMarginX;
 
-        if (background != null) {
-          itemViewHold.listItemLayout.setBackground(background);
+          flexboxLp.setMargins(marginX, marginTop, marginX, flexboxLp.getMarginBottom());
+
+          if (background != null) {
+            itemViewHold.listItemLayout.setBackground(background);
+          }
         }
       }
 

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
@@ -27,7 +27,9 @@ public class TabManager {
     if (tabSwitchData.size() > 0) return tabSwitchData;
 
     for (TabTag tag : tabTags) {
-      tabSwitchData.add(new SimpleKeyBean(tag.text));
+      if (SymbolKeyboardType.Companion.hasKey(tag.type))
+        tabSwitchData.add(new SimpleKeyBean(tag.text));
+      else tabSwitchData.add(new SimpleKeyBean(""));
     }
     return tabSwitchData;
   }
@@ -62,7 +64,7 @@ public class TabManager {
   public void addTab(@NonNull String name, SymbolKeyboardType type, List<SimpleKeyBean> keyBeans) {
     if (name.trim().length() < 1) return;
 
-    if (SymbolKeyboardType.Companion.needKeys(type)) {
+    if (SymbolKeyboardType.Companion.hasKeys(type)) {
       for (int i = 0; i < tabTags.size(); i++) {
         TabTag tag = tabTags.get(i);
         if (tag.text.equals(name)) {
@@ -90,7 +92,7 @@ public class TabManager {
 
   // 解析config的数据
   public void addTab(String name, SymbolKeyboardType type, Object obj) {
-    if (SymbolKeyboardType.Companion.needKeys(type)) {
+    if (SymbolKeyboardType.Companion.hasKeys(type)) {
       if (obj instanceof String) {
         addTab(name, type, (String) obj);
       } else if (obj instanceof List<?>) {

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -178,6 +178,7 @@ class TextInputManager private constructor() :
 
     override fun onStartInputView(instance: EditorInstance, restarting: Boolean) {
         super.onStartInputView(instance, restarting)
+        Trime.getService().selectLiquidKeyboard(-1)
         isComposable = false
         performEnterAsLineBreak = false
         var tempAsciiMode = if (shouldResetAsciiMode) false else null


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
1. 弹出软键盘时，隐藏liquidKeyboard
2. 为liquidKeyboard内的按键列表增加换行功能，实现了类似分组的效果，方便查找和对齐。默认皮肤已经修改并添加注释。其中
  - simple类型的列表，如果label内容指定为空，或者没有指定label但是click内容为空，则下一个按键会换行。
  - tabs类型的列表，即默认皮肤中liquidkeyboard里的“更多”，在显示tab列表时，如果列表没有对应的按键分组，则自动隐藏并让下一个按键自动换行。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
4. Manual build and test pass
5. GitHub action ci pass
6. At least one contributor reviews and votes
7. Can be merged clean without conflicts
8. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
