### PR TITLE
皮肤和按键优化

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -171,6 +171,7 @@ class AppPrefs(
             const val SWITCH_ARROW_ENABLED = "keyboard__show_switch_arrow"
             const val FULLSCREEN_MODE = "keyboard__fullscreen_mode"
 
+            const val HOOK_FAST_INPUT = "keyboard__hook_fast_input"
             const val HOOK_CANDIDATE = "keyboard__hook_candidate"
             const val HOOK_CTRL_A = "keyboard__hook_ctrl_a"
             const val HOOK_CTRL_CV = "keyboard__hook_ctrl_cv"
@@ -188,7 +189,12 @@ class AppPrefs(
             const val SPEAK_KEY_PRESS_ENABLED = "keyboard__speak_key_press"
             const val SPEAK_COMMIT_ENABLED = "keyboard__speak_commit"
 
+            const val SWIPE_ENABLED = "keyboard__swipe_enabled"
             const val SWIPE_TRAVEL = "keyboard__key_swipe_travel"
+            const val SWIPE_TRAVEL_HI = "keyboard__key_swipe_travel_hi"
+            const val SWIPE_VELOCITY = "keyboard__key_swipe_velocity"
+            const val SWIPE_VELOCITY_HI = "keyboard__key_swipe_velocity_hi"
+            const val SWIPE_TIME_HI = "keyboard__key_swipe_time_hi"
             const val LONG_PRESS_TIMEOUT = "keyboard__key_long_press_timeout"
             const val REPEAT_INTERVAL = "keyboard__key_repeat_interval"
         }
@@ -214,19 +220,22 @@ class AppPrefs(
             get() = prefs.getPref(SWITCH_ARROW_ENABLED, true)
             private set
 
-        var hockCandidate: Boolean = false
+        var hookFastInput: Boolean = false
+            get() = prefs.getPref(HOOK_FAST_INPUT, false)
+            private set
+        var hookCandidate: Boolean = false
             get() = prefs.getPref(HOOK_CANDIDATE, false)
             private set
-        var hockCtrlA: Boolean = false
+        var hookCtrlA: Boolean = false
             get() = prefs.getPref(HOOK_CTRL_A, false)
             private set
-        var hockCtrlCV: Boolean = false
+        var hookCtrlCV: Boolean = false
             get() = prefs.getPref(HOOK_CTRL_CV, false)
             private set
-        var hockCtrlLR: Boolean = false
+        var hookCtrlLR: Boolean = false
             get() = prefs.getPref(HOOK_CTRL_LR, false)
             private set
-        var hockCtrlZY: Boolean = false
+        var hookCtrlZY: Boolean = false
             get() = prefs.getPref(HOOK_CTRL_ZY, false)
             private set
 
@@ -248,8 +257,23 @@ class AppPrefs(
         var vibrationAmplitude: Int = 0
             get() = prefs.getPref(VIBRATION_AMPLITUDE, -1)
             private set
+        var swipeEnabled: Boolean = false
+            get() = prefs.getPref(SWIPE_ENABLED, true)
+            private set
         var swipeTravel: Int = 0
             get() = prefs.getPref(SWIPE_TRAVEL, 80)
+            private set
+        var swipeTravelHi: Int = 0
+            get() = prefs.getPref(SWIPE_TRAVEL_HI, 200)
+            private set
+        var swipeVelocity: Int = 0
+            get() = prefs.getPref(SWIPE_VELOCITY, 800)
+            private set
+        var swipeVelocityHi: Int = 0
+            get() = prefs.getPref(SWIPE_VELOCITY_HI, 25000)
+            private set
+        var swipeTimeHi: Int = 0
+            get() = prefs.getPref(SWIPE_TIME_HI, 80)
             private set
         var longPressTimeout: Int = 0
             get() = prefs.getPref(LONG_PRESS_TIMEOUT, 20)

--- a/app/src/main/java/com/osfans/trime/data/Config.java
+++ b/app/src/main/java/com/osfans/trime/data/Config.java
@@ -385,7 +385,7 @@ public class Config {
       presetColorSchemes =
           (Map<String, Map<String, String>>) globalThemeConfig.get("preset_color_schemes");
       presetKeyboards = (Map<String, Map<String, ?>>) globalThemeConfig.get("preset_keyboards");
-      liquidKeyboard = (Map<String, ?>) globalThemeConfig.get("liquid_keyboard");
+      liquidKeyboard = globalThemeConfig.get("liquid_keyboard");
       initLiquidKeyboard();
       Timber.d("init() initLiquidKeyboard done");
       Rime.setShowSwitches(appPrefs.getKeyboard().getSwitchesEnabled());

--- a/app/src/main/java/com/osfans/trime/data/Config.java
+++ b/app/src/main/java/com/osfans/trime/data/Config.java
@@ -36,8 +36,9 @@ import android.util.TypedValue;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.osfans.trime.core.Rime;
+import com.osfans.trime.ime.enums.Keycode;
+import com.osfans.trime.ime.enums.PositionType;
 import com.osfans.trime.ime.enums.SymbolKeyboardType;
-import com.osfans.trime.ime.enums.WindowsPositionType;
 import com.osfans.trime.ime.keyboard.Key;
 import com.osfans.trime.ime.keyboard.Sound;
 import com.osfans.trime.ime.symbol.TabManager;
@@ -376,9 +377,8 @@ public class Config {
       mDefaultStyle = (Map<?, ?>) globalThemeConfig.get("style");
       fallbackColors = (Map<?, ?>) globalThemeConfig.get("fallback_colors");
       final Map<String, ?> androidKeySettings = globalThemeConfig.get("android_keys");
-      Key.androidKeys = (List<String>) androidKeySettings.get("name");
       Key.presetKeys = (Map<String, Map<String, String>>) globalThemeConfig.get("preset_keys");
-      Key.setSymbolStart(Key.androidKeys.contains("A") ? Key.androidKeys.indexOf("A") : 284);
+      Key.setSymbolStart(Keycode.A.ordinal());
       Key.setSymbols((String) androidKeySettings.get("symbols"));
       if (TextUtils.isEmpty(Key.getSymbols()))
         Key.setSymbols("ABCDEFGHIJKLMNOPQRSTUVWXYZ!\"$%&:<>?^_{|}~");
@@ -934,8 +934,8 @@ public class Config {
     return drawableObject(o);
   }
 
-  public WindowsPositionType getWinPos() {
-    return WindowsPositionType.Companion.fromString(getString("layout/position"));
+  public PositionType getWinPos() {
+    return PositionType.Companion.fromString(getString("layout/position"));
   }
 
   public int getLongTimeout() {

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1077,7 +1077,7 @@ public class Trime extends LifecycleInputMethodService {
     if (Event.hasModifier(mask, KeyEvent.META_CTRL_ON)) {
 
       if (VERSION.SDK_INT >= VERSION_CODES.M) {
-        if (getPrefs().getKeyboard().getHockCtrlZY()) {
+        if (getPrefs().getKeyboard().getHookCtrlZY()) {
           switch (code) {
             case KeyEvent.KEYCODE_Y:
               return ic.performContextMenuAction(android.R.id.redo);
@@ -1088,11 +1088,11 @@ public class Trime extends LifecycleInputMethodService {
       }
       switch (code) {
         case KeyEvent.KEYCODE_A:
-          if (getPrefs().getKeyboard().getHockCtrlA())
+          if (getPrefs().getKeyboard().getHookCtrlA())
             return ic.performContextMenuAction(android.R.id.selectAll);
           return false;
         case KeyEvent.KEYCODE_X:
-          if (getPrefs().getKeyboard().getHockCtrlCV()) {
+          if (getPrefs().getKeyboard().getHookCtrlCV()) {
             ExtractedTextRequest etr = new ExtractedTextRequest();
             etr.token = 0;
             ExtractedText et = ic.getExtractedText(etr, 0);
@@ -1104,7 +1104,7 @@ public class Trime extends LifecycleInputMethodService {
           Timber.i("hookKeyboard cut fail");
           return false;
         case KeyEvent.KEYCODE_C:
-          if (getPrefs().getKeyboard().getHockCtrlCV()) {
+          if (getPrefs().getKeyboard().getHookCtrlCV()) {
             ExtractedTextRequest etr = new ExtractedTextRequest();
             etr.token = 0;
             ExtractedText et = ic.getExtractedText(etr, 0);
@@ -1116,7 +1116,7 @@ public class Trime extends LifecycleInputMethodService {
           Timber.i("hookKeyboard copy fail");
           return false;
         case KeyEvent.KEYCODE_V:
-          if (getPrefs().getKeyboard().getHockCtrlCV()) {
+          if (getPrefs().getKeyboard().getHookCtrlCV()) {
             ExtractedTextRequest etr = new ExtractedTextRequest();
             etr.token = 0;
             ExtractedText et = ic.getExtractedText(etr, 0);
@@ -1132,7 +1132,7 @@ public class Trime extends LifecycleInputMethodService {
           }
           return false;
         case KeyEvent.KEYCODE_DPAD_RIGHT:
-          if (getPrefs().getKeyboard().getHockCtrlLR()) {
+          if (getPrefs().getKeyboard().getHookCtrlLR()) {
             ExtractedTextRequest etr = new ExtractedTextRequest();
             etr.token = 0;
             ExtractedText et = ic.getExtractedText(etr, 0);
@@ -1145,7 +1145,7 @@ public class Trime extends LifecycleInputMethodService {
             break;
           }
         case KeyEvent.KEYCODE_DPAD_LEFT:
-          if (getPrefs().getKeyboard().getHockCtrlLR()) {
+          if (getPrefs().getKeyboard().getHookCtrlLR()) {
             ExtractedTextRequest etr = new ExtractedTextRequest();
             etr.token = 0;
             ExtractedText et = ic.getExtractedText(etr, 0);

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -68,7 +68,7 @@ import com.osfans.trime.data.db.draft.DraftDao;
 import com.osfans.trime.databinding.CompositionRootBinding;
 import com.osfans.trime.databinding.InputRootBinding;
 import com.osfans.trime.ime.broadcast.IntentReceiver;
-import com.osfans.trime.ime.enums.WindowsPositionType;
+import com.osfans.trime.ime.enums.PositionType;
 import com.osfans.trime.ime.keyboard.Event;
 import com.osfans.trime.ime.keyboard.InputFeedbackManager;
 import com.osfans.trime.ime.keyboard.Key;
@@ -151,7 +151,7 @@ public class Trime extends LifecycleInputMethodService {
   private boolean isCursorUpdated = false; // 光標是否移動
   private int minPopupSize; // 上悬浮窗的候选词的最小词长
   private int minPopupCheckSize; // 第一屏候选词数量少于设定值，则候选词上悬浮窗。（也就是说，第一屏存在长词）此选项大于1时，min_length等参数失效
-  private WindowsPositionType popupWindowPos; // 悬浮窗口彈出位置
+  private PositionType popupWindowPos; // 悬浮窗口彈出位置
   private PopupWindow mPopupWindow;
   private RectF mPopupRectF = new RectF();
   private final Handler mPopupHandler = new Handler(Looper.getMainLooper());
@@ -314,14 +314,14 @@ public class Trime extends LifecycleInputMethodService {
 
   private boolean isWinFixed() {
     return VERSION.SDK_INT <= VERSION_CODES.LOLLIPOP
-        || (popupWindowPos != WindowsPositionType.LEFT
-            && popupWindowPos != WindowsPositionType.RIGHT
-            && popupWindowPos != WindowsPositionType.LEFT_UP
-            && popupWindowPos != WindowsPositionType.RIGHT_UP);
+        || (popupWindowPos != PositionType.LEFT
+            && popupWindowPos != PositionType.RIGHT
+            && popupWindowPos != PositionType.LEFT_UP
+            && popupWindowPos != PositionType.RIGHT_UP);
   }
 
   public void updatePopupWindow(final int offsetX, final int offsetY) {
-    popupWindowPos = WindowsPositionType.DRAG;
+    popupWindowPos = PositionType.DRAG;
     popupWindowX = offsetX;
     popupWindowY = offsetY;
     Timber.i("updatePopupWindow: winX = %s, winY = %s", popupWindowX, popupWindowY);

--- a/app/src/main/java/com/osfans/trime/ime/enums/KeyEventType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/KeyEventType.kt
@@ -2,5 +2,6 @@ package com.osfans.trime.ime.enums
 
 /** 按键事件枚举  */
 enum class KeyEventType {
-    CLICK, LONG_CLICK, SWIPE_LEFT, SWIPE_RIGHT, SWIPE_UP, SWIPE_DOWN, COMBO
+    // 长按按键展开列表时，正上方为长按对应按键，排序如上，不展示combo及之前的按键，展示extra
+    COMPOSING, HAS_MENU, PAGING, COMBO, CLICK, SWIPE_UP, LONG_CLICK, SWIPE_DOWN, SWIPE_LEFT, SWIPE_RIGHT,
 }

--- a/app/src/main/java/com/osfans/trime/ime/enums/KeyEventType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/KeyEventType.kt
@@ -2,6 +2,17 @@ package com.osfans.trime.ime.enums
 
 /** 按键事件枚举  */
 enum class KeyEventType {
+
     // 长按按键展开列表时，正上方为长按对应按键，排序如上，不展示combo及之前的按键，展示extra
-    COMPOSING, HAS_MENU, PAGING, COMBO, CLICK, SWIPE_UP, LONG_CLICK, SWIPE_DOWN, SWIPE_LEFT, SWIPE_RIGHT,
+    COMPOSING, HAS_MENU, PAGING, COMBO, ASCII, CLICK, SWIPE_UP, LONG_CLICK, SWIPE_DOWN, SWIPE_LEFT, SWIPE_RIGHT, EXTRA;
+
+    companion object {
+        @JvmStatic
+        fun valueOf(ordinal: Int): KeyEventType {
+            if (ordinal < 0 || ordinal >= values().size) {
+                return EXTRA
+            }
+            return values()[ordinal]
+        }
+    }
 }

--- a/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
@@ -8,7 +8,7 @@ enum class Keycode {
     // 1. 数字开头的keyName添加了下划线(在init阶段已经修复)，受到影响的按键有： 0-12，3D_MODE
     // 2. 按键0恢复为UNKNOWN, VoidSymbol改为最末位的按键
 
-    UNKNOWN, SOFT_LEFT, SOFT_RIGHT, HOME, BACK, CALL, ENDCALL,
+    VoidSymbol, SOFT_LEFT, SOFT_RIGHT, HOME, BACK, CALL, ENDCALL,
     _0, _1, _2, _3, _4, _5, _6, _7, _8, _9,
     asterisk, numbersign, Up, Down, Left, Right, KP_Begin,
     VOLUME_UP, VOLUME_DOWN, POWER, CAMERA, Clear,
@@ -54,7 +54,7 @@ enum class Keycode {
     ALL_APPS, REFRESH, THUMBS_UP, THUMBS_DOWN, PROFILE_SWITCH,
     A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
     exclam, quotedbl, dollar, percent, ampersand, colon, less, greater, question, asciicircum, underscore, braceleft, bar, braceright, asciitilde,
-    VoidSymbol;
+    ;
 
     companion object {
 
@@ -96,20 +96,20 @@ enum class Keycode {
         @JvmStatic
         fun fromString(s: String): Keycode {
             val type = convertMap[s]
-            return type ?: UNKNOWN
+            return type ?: VoidSymbol
         }
 
         @JvmStatic
         fun valueOf(ordinal: Int): Keycode {
             if (ordinal < 0 || ordinal >= values().size) {
-                return UNKNOWN
+                return VoidSymbol
             }
             return values()[ordinal]
         }
 
         @JvmStatic
         fun keyNameOf(ordinal: Int): String {
-            return valueOf(ordinal).toString().replaceFirst("^_", "")
+            return valueOf(ordinal).toString().replaceFirst("^_".toRegex(), "")
         }
 
         @JvmStatic
@@ -122,12 +122,14 @@ enum class Keycode {
             val sends = IntArray(2)
             if (TextUtils.isEmpty(s)) return sends
             val codes: String
-            if (!s.contains("+")) codes = s else {
-                val ss = s.split("\\+").toTypedArray()
+            if (s.contains("+")) {
+                val ss = s.split("+").toTypedArray()
                 val n = ss.size
                 for (i in 0 until n - 1) if (masks.containsKey(ss[i])) sends[1] =
                     addMask(sends[1], ss[i])
                 codes = ss[n - 1]
+            } else {
+                codes = s
             }
             sends[0] = fromString(codes).ordinal
             return sends

--- a/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
@@ -1,0 +1,136 @@
+package com.osfans.trime.ime.enums
+
+import android.text.TextUtils
+import android.view.KeyEvent
+
+enum class Keycode {
+    // 与原trime.yaml主题android_key/name小节相比，差异如下：
+    // 1. 数字开头的keyName添加了下划线(在init阶段已经修复)，受到影响的按键有： 0-12，3D_MODE
+    // 2. 按键0恢复为UNKNOWN, VoidSymbol改为最末位的按键
+
+    UNKNOWN, SOFT_LEFT, SOFT_RIGHT, HOME, BACK, CALL, ENDCALL,
+    _0, _1, _2, _3, _4, _5, _6, _7, _8, _9,
+    asterisk, numbersign, Up, Down, Left, Right, KP_Begin,
+    VOLUME_UP, VOLUME_DOWN, POWER, CAMERA, Clear,
+    a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z,
+    comma, period, Alt_L, Alt_R, Shift_L, Shift_R, Tab, space,
+    SYM, EXPLORER, ENVELOPE, Return, BackSpace,
+    grave, minus, equal, bracketleft, bracketright, backslash, semicolon, apostrophe, slash, at,
+    NUM, HEADSETHOOK, FOCUS, plus, Menu, NOTIFICATION, Find,
+    MEDIA_PLAY_PAUSE, MEDIA_STOP, MEDIA_NEXT, MEDIA_PREVIOUS, MEDIA_REWIND, MEDIA_FAST_FORWARD, MUTE,
+    Page_Up, Page_Down, PICTSYMBOLS, Mode_switch,
+    BUTTON_A, BUTTON_B, BUTTON_C, BUTTON_X, BUTTON_Y, BUTTON_Z,
+    BUTTON_L1, BUTTON_R1, BUTTON_L2, BUTTON_R2,
+    BUTTON_THUMBL, BUTTON_THUMBR, BUTTON_START, BUTTON_SELECT, BUTTON_MODE,
+    Escape, Delete, Control_L, Control_R, Caps_Lock, Scroll_Lock, Meta_L, Meta_R,
+    function, Sys_Req, Pause, Home, End, Insert, Next,
+    MEDIA_PLAY, MEDIA_PAUSE, MEDIA_CLOSE, MEDIA_EJECT, MEDIA_RECORD,
+    F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+    Num_Lock, KP_0, KP_1, KP_2, KP_3, KP_4, KP_5, KP_6, KP_7, KP_8, KP_9,
+    KP_Divide, KP_Multiply, KP_Subtract, KP_Add, KP_Decimal, KP_Separator, KP_Enter, KP_Equal,
+    parenleft, parenright,
+    VOLUME_MUTE, INFO, CHANNEL_UP, CHANNEL_DOWN, ZOOM_IN, ZOOM_OUT,
+    TV, WINDOW, GUIDE, DVR, BOOKMARK, CAPTIONS, SETTINGS,
+    TV_POWER, TV_INPUT, STB_POWER, STB_INPUT, AVR_POWER, AVR_INPUT,
+    PROG_RED, PROG_GREEN, PROG_YELLOW, PROG_BLUE, APP_SWITCH,
+    BUTTON_1, BUTTON_2, BUTTON_3, BUTTON_4, BUTTON_5, BUTTON_6, BUTTON_7, BUTTON_8,
+    BUTTON_9, BUTTON_10, BUTTON_11, BUTTON_12, BUTTON_13, BUTTON_14, BUTTON_15, BUTTON_16,
+    LANGUAGE_SWITCH, MANNER_MODE, _3D_MODE, CONTACTS, CALENDAR, MUSIC, CALCULATOR,
+    Zenkaku_Hankaku, Eisu_toggle, Muhenkan, Henkan, Hiragana_Katakana, yen, RO, Kana_Lock,
+    ASSIST, BRIGHTNESS_DOWN, BRIGHTNESS_UP, MEDIA_AUDIO_TRACK,
+    SLEEP, WAKEUP, PAIRING, MEDIA_TOP_MENU, _11, _12, LAST_CHANNEL, TV_DATA_SERVICE, VOICE_ASSIST,
+    TV_RADIO_SERVICE, TV_TELETEXT, TV_NUMBER_ENTRY, TV_TERRESTRIAL_ANALOG, TV_TERRESTRIAL_DIGITAL,
+    TV_SATELLITE, TV_SATELLITE_BS, TV_SATELLITE_CS, TV_SATELLITE_SERVICE, TV_NETWORK, TV_ANTENNA_CABLE,
+    TV_INPUT_HDMI_1, TV_INPUT_HDMI_2, TV_INPUT_HDMI_3, TV_INPUT_HDMI_4,
+    TV_INPUT_COMPOSITE_1, TV_INPUT_COMPOSITE_2, TV_INPUT_COMPONENT_1, TV_INPUT_COMPONENT_2, TV_INPUT_VGA_1,
+    TV_AUDIO_DESCRIPTION, TV_AUDIO_DESCRIPTION_MIX_UP, TV_AUDIO_DESCRIPTION_MIX_DOWN,
+    TV_ZOOM_MODE, TV_CONTENTS_MENU, TV_MEDIA_CONTEXT_MENU, TV_TIMER_PROGRAMMING,
+    Help, NAVIGATE_PREVIOUS, NAVIGATE_NEXT, NAVIGATE_IN, NAVIGATE_OUT,
+    STEM_PRIMARY, STEM_1, STEM_2, STEM_3,
+    Pointer_UpLeft, Pointer_DownLeft, Pointer_UpRight, Pointer_DownRight,
+    MEDIA_SKIP_FORWARD, MEDIA_SKIP_BACKWARD, MEDIA_STEP_FORWARD, MEDIA_STEP_BACKWARD,
+    SOFT_SLEEP, CUT, COPY, PASTE,
+    SYSTEM_NAVIGATION_UP, SYSTEM_NAVIGATION_DOWN, SYSTEM_NAVIGATION_LEFT, SYSTEM_NAVIGATION_RIGHT,
+    ALL_APPS, REFRESH, THUMBS_UP, THUMBS_DOWN, PROFILE_SWITCH,
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+    exclam, quotedbl, dollar, percent, ampersand, colon, less, greater, question, asciicircum, underscore, braceleft, bar, braceright, asciitilde,
+    VoidSymbol;
+
+    companion object {
+
+        private val convertMap: HashMap<String, Keycode> = hashMapOf()
+
+        init {
+            for (type in Keycode.values()) {
+                convertMap[type.toString()] = type
+            }
+
+            convertMap["3D_MODE"] = Keycode._3D_MODE
+            convertMap["0"] = Keycode._0
+            convertMap["1"] = Keycode._1
+            convertMap["2"] = Keycode._2
+            convertMap["3"] = Keycode._3
+            convertMap["4"] = Keycode._4
+            convertMap["5"] = Keycode._5
+            convertMap["6"] = Keycode._6
+            convertMap["7"] = Keycode._7
+            convertMap["8"] = Keycode._8
+            convertMap["9"] = Keycode._9
+            convertMap["8"] = Keycode._8
+            convertMap["9"] = Keycode._9
+        }
+
+        private val masks = hashMapOf(
+            "Shift" to KeyEvent.META_SHIFT_ON,
+            "Control" to KeyEvent.META_CTRL_ON,
+            "Alt" to KeyEvent.META_ALT_ON,
+            "Meta" to KeyEvent.META_META_ON,
+            "SYM" to KeyEvent.META_SYM_ON,
+        )
+
+        fun addMask(mask: Int, s: String): Int {
+            val m = masks[s] ?: 0
+            return m or mask
+        }
+
+        @JvmStatic
+        fun fromString(s: String): Keycode {
+            val type = convertMap[s]
+            return type ?: UNKNOWN
+        }
+
+        @JvmStatic
+        fun valueOf(ordinal: Int): Keycode {
+            if (ordinal < 0 || ordinal >= values().size) {
+                return UNKNOWN
+            }
+            return values()[ordinal]
+        }
+
+        @JvmStatic
+        fun keyNameOf(ordinal: Int): String {
+            return valueOf(ordinal).toString().replaceFirst("^_", "")
+        }
+
+        @JvmStatic
+        fun keyCodeOf(name: String): Int {
+            return fromString(name).ordinal
+        }
+
+        @JvmStatic
+        fun parseSend(s: String): IntArray {
+            val sends = IntArray(2)
+            if (TextUtils.isEmpty(s)) return sends
+            val codes: String
+            if (!s.contains("+")) codes = s else {
+                val ss = s.split("\\+").toTypedArray()
+                val n = ss.size
+                for (i in 0 until n - 1) if (masks.containsKey(ss[i])) sends[1] =
+                    addMask(sends[1], ss[i])
+                codes = ss[n - 1]
+            }
+            sends[0] = fromString(codes).ordinal
+            return sends
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/enums/PositionType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/PositionType.kt
@@ -20,11 +20,21 @@ package com.osfans.trime.ime.enums
 import java.util.HashMap
 import java.util.Locale
 
-enum class WindowsPositionType {
-    LEFT, LEFT_UP, RIGHT, RIGHT_UP, DRAG, FIXED, BOTTOM_LEFT, BOTTOM_RIGHT, TOP_LEFT, TOP_RIGHT;
+/**
+ * 悬浮窗。候选栏文字，按键文字，按键气泡文字的定位方式
+ */
+enum class PositionType {
+    // 跟随光标
+    LEFT, LEFT_UP, RIGHT, RIGHT_UP,
+    // 固定位置
+    DRAG, FIXED,
+    // 相对位置
+    BOTTOM_LEFT, BOTTOM_RIGHT, TOP_LEFT, TOP_RIGHT,
+    // 暂未实现的相对位置
+    TOP_CENTER, BOTTOM_CENTER, CENTER;
 
     companion object {
-        private val convertMap: HashMap<String, WindowsPositionType> = hashMapOf()
+        private val convertMap: HashMap<String, PositionType> = hashMapOf()
 
         init {
             for (type in values()) {
@@ -33,9 +43,27 @@ enum class WindowsPositionType {
         }
 
         @JvmStatic
-        fun fromString(code: String): WindowsPositionType {
+        fun fromString(code: String): PositionType {
             val type = convertMap[code.uppercase(Locale.getDefault())]
             return type ?: FIXED
+        }
+
+        @JvmStatic
+        fun fromString(code: String, default: PositionType): PositionType {
+            val type = convertMap[code.uppercase(Locale.getDefault())]
+            return type ?: default
+        }
+
+        /**
+         * 解析候选栏文字，按键文字，按键气泡文字的定位方式
+         */
+        @JvmStatic
+        fun parseKeyPosition(code: String): PositionType {
+            val type = convertMap[code.uppercase(Locale.getDefault())]
+            if (type != null)
+                if (type > FIXED)
+                    return type
+            return type ?: CENTER
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
@@ -64,7 +64,7 @@ public class Event {
       int[] sends = Keycode.parseSend(label); // send
       code = sends[0];
       mask = sends[1];
-      if (code >= 0) return;
+      if (code > 0 || mask > 0) return;
       if (parseAction(label)) return;
       s = label; // key
       label = null;
@@ -238,7 +238,7 @@ public class Event {
     int keyCode = -1;
     if (TextUtils.isEmpty(s)) { // 空鍵
       keyCode = 0;
-    } else if (Keycode.fromString(s) != Keycode.UNKNOWN) { // 字母數字
+    } else if (Keycode.fromString(s) != Keycode.VoidSymbol) { // 字母數字
       keyCode = Keycode.keyCodeOf(s);
     } else if (Key.getSymbols().contains(s)) { // 可見符號
       keyCode = Key.getSymbolStart() + Key.getSymbols().indexOf(s);
@@ -262,6 +262,9 @@ public class Event {
     if (hasModifier(mask, KeyEvent.META_SYM_ON)) m |= Rime.META_SYM_ON;
     if (hasModifier(mask, KeyEvent.META_META_ON)) m |= Rime.META_META_ON;
     if (mask == Rime.META_RELEASE_ON) m |= Rime.META_RELEASE_ON;
+    Timber.d(
+        "<Event> getRimeEvent()\tcode=%d, mask=%d, name=%s\toutput key=%d, meta=%d",
+        code, mask, Keycode.keyNameOf(code), i, m);
     return new int[] {i, m};
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
@@ -28,7 +28,6 @@ import com.osfans.trime.core.Rime;
 import com.osfans.trime.data.Config;
 import com.osfans.trime.ime.enums.KeyEventType;
 import com.osfans.trime.util.ConfigGetter;
-import java.util.List;
 import java.util.Map;
 import timber.log.Timber;
 
@@ -55,7 +54,6 @@ public class Key {
         KEY_STATE_PRESSED, // 4
         KEY_STATE_NORMAL // 5
       };
-  public static List<String> androidKeys;
   public static Map<String, Map<String, String>> presetKeys;
   private static final int EVENT_NUM = KeyEventType.values().length;
   public Event[] events = new Event[EVENT_NUM];
@@ -157,10 +155,6 @@ public class Key {
     key_symbol_color = Config.getColor(context, mk, "key_symbol_color");
     hilited_key_symbol_color = Config.getColor(context, mk, "hilited_key_symbol_color");
     round_corner = ConfigGetter.getFloat(mk, "round_corner", 0);
-  }
-
-  public static List<String> getAndroidKeys() {
-    return androidKeys;
   }
 
   public static Map<String, Map<String, String>> getPresetKeys() {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -329,96 +329,100 @@ public class Keyboard {
       mTotalWidth = 0;
     }
 
-    for (Map<String, Object> mk : lm) {
-      int gap = mDefaultHorizontalGap;
-      int w = (int) (ConfigGetter.getDouble(mk, "width", 0) * mDisplayWidth / 100);
-      if (w == 0 && mk.containsKey("click")) w = defaultWidth;
-      w -= gap;
-      if (column >= maxColumns || x + w > mDisplayWidth) {
-        x = gap / 2;
-        y += mDefaultVerticalGap + rowHeight;
-        column = 0;
-        row++;
-        if (mKeys.size() > 0) mKeys.get(mKeys.size() - 1).edgeFlags |= Keyboard.EDGE_RIGHT;
-      }
-      if (column == 0) {
-        if (keyboardHeight > 0) {
-          rowHeight = newHeight[row];
-        } else {
-          int heightK = ConfigGetter.getPixel(mk, "height", 0);
-          rowHeight = (heightK > 0) ? heightK : defaultHeight;
+    try {
+      for (Map<String, Object> mk : lm) {
+        int gap = mDefaultHorizontalGap;
+        int w = (int) (ConfigGetter.getDouble(mk, "width", 0) * mDisplayWidth / 100);
+        if (w == 0 && mk.containsKey("click")) w = defaultWidth;
+        w -= gap;
+        if (column >= maxColumns || x + w > mDisplayWidth) {
+          x = gap / 2;
+          y += mDefaultVerticalGap + rowHeight;
+          column = 0;
+          row++;
+          if (mKeys.size() > 0) mKeys.get(mKeys.size() - 1).edgeFlags |= Keyboard.EDGE_RIGHT;
+        }
+        if (column == 0) {
+          if (keyboardHeight > 0) {
+            rowHeight = newHeight[row];
+          } else {
+            int heightK = ConfigGetter.getPixel(mk, "height", 0);
+            rowHeight = (heightK > 0) ? heightK : defaultHeight;
+          }
+        }
+        if (!mk.containsKey("click")) { // 無按鍵事件
+          x += w + gap;
+          continue; // 縮進
+        }
+
+        final int defaultKeyTextOffsetX =
+            ConfigGetter.getPixel(
+                keyboardConfig, "key_text_offset_x", config.getFloat("key_text_offset_x"));
+        final int defaultKeyTextOffsetY =
+            ConfigGetter.getPixel(
+                keyboardConfig, "key_text_offset_y", config.getFloat("key_text_offset_y"));
+        final int defaultKeySymbolOffsetX =
+            ConfigGetter.getPixel(
+                keyboardConfig, "key_symbol_offset_x", config.getFloat("key_symbol_offset_x"));
+        final int defaultKeySymbolOffsetY =
+            ConfigGetter.getPixel(
+                keyboardConfig, "key_symbol_offset_y", config.getFloat("key_symbol_offset_y"));
+        final int defaultKeyHintOffsetX =
+            ConfigGetter.getPixel(
+                keyboardConfig, "key_hint_offset_x", config.getFloat("key_hint_offset_x"));
+        final int defaultKeyHintOffsetY =
+            ConfigGetter.getPixel(
+                keyboardConfig, "key_hint_offset_y", config.getFloat("key_hint_offset_y"));
+        final int defaultKeyPressOffsetX =
+            ConfigGetter.getInt(
+                keyboardConfig, "key_press_offset_x", config.getInt("key_press_offset_x"));
+        final int defaultKeyPressOffsetY =
+            ConfigGetter.getInt(
+                keyboardConfig, "key_press_offset_y", config.getInt("key_press_offset_y"));
+
+        final Key key = new Key(context, this, mk);
+        key.setKey_text_offset_x(
+            ConfigGetter.getPixel(mk, "key_text_offset_x", defaultKeyTextOffsetX));
+        key.setKey_text_offset_y(
+            ConfigGetter.getPixel(mk, "key_text_offset_y", defaultKeyTextOffsetY));
+        key.setKey_symbol_offset_x(
+            ConfigGetter.getPixel(mk, "key_symbol_offset_x", defaultKeySymbolOffsetX));
+        key.setKey_symbol_offset_y(
+            ConfigGetter.getPixel(mk, "key_symbol_offset_y", defaultKeySymbolOffsetY));
+        key.setKey_hint_offset_x(
+            ConfigGetter.getPixel(mk, "key_hint_offset_x", defaultKeyHintOffsetX));
+        key.setKey_hint_offset_y(
+            ConfigGetter.getPixel(mk, "key_hint_offset_y", defaultKeyHintOffsetY));
+        key.setKey_press_offset_x(
+            ConfigGetter.getInt(mk, "key_press_offset_x", defaultKeyPressOffsetX));
+        key.setKey_press_offset_y(
+            ConfigGetter.getInt(mk, "key_press_offset_y", defaultKeyPressOffsetY));
+
+        key.setX(x);
+        key.setY(y);
+        int right_gap = Math.abs(mDisplayWidth - x - w - gap / 2);
+        // 右側不留白
+        key.setWidth((right_gap <= mDisplayWidth / 100) ? mDisplayWidth - x - gap / 2 : w);
+        key.setHeight(rowHeight);
+        key.setGap(gap);
+        key.setRow(row);
+        key.setColumn(column);
+        column++;
+        x += key.getWidth() + key.getGap();
+        mKeys.add(key);
+        if (x > mTotalWidth) {
+          mTotalWidth = x;
         }
       }
-      if (!mk.containsKey("click")) { // 無按鍵事件
-        x += w + gap;
-        continue; // 縮進
+      if (mKeys.size() > 0) mKeys.get(mKeys.size() - 1).edgeFlags |= Keyboard.EDGE_RIGHT;
+      mTotalHeight = y + rowHeight + mDefaultVerticalGap;
+      for (Key key : mKeys) {
+        if (key.getColumn() == 0) key.edgeFlags |= Keyboard.EDGE_LEFT;
+        if (key.getRow() == 0) key.edgeFlags |= Keyboard.EDGE_TOP;
+        if (key.getRow() == row) key.edgeFlags |= Keyboard.EDGE_BOTTOM;
       }
-
-      final int defaultKeyTextOffsetX =
-          ConfigGetter.getPixel(
-              keyboardConfig, "key_text_offset_x", config.getFloat("key_text_offset_x"));
-      final int defaultKeyTextOffsetY =
-          ConfigGetter.getPixel(
-              keyboardConfig, "key_text_offset_y", config.getFloat("key_text_offset_y"));
-      final int defaultKeySymbolOffsetX =
-          ConfigGetter.getPixel(
-              keyboardConfig, "key_symbol_offset_x", config.getFloat("key_symbol_offset_x"));
-      final int defaultKeySymbolOffsetY =
-          ConfigGetter.getPixel(
-              keyboardConfig, "key_symbol_offset_y", config.getFloat("key_symbol_offset_y"));
-      final int defaultKeyHintOffsetX =
-          ConfigGetter.getPixel(
-              keyboardConfig, "key_hint_offset_x", config.getFloat("key_hint_offset_x"));
-      final int defaultKeyHintOffsetY =
-          ConfigGetter.getPixel(
-              keyboardConfig, "key_hint_offset_y", config.getFloat("key_hint_offset_y"));
-      final int defaultKeyPressOffsetX =
-          ConfigGetter.getInt(
-              keyboardConfig, "key_press_offset_x", config.getInt("key_press_offset_x"));
-      final int defaultKeyPressOffsetY =
-          ConfigGetter.getInt(
-              keyboardConfig, "key_press_offset_y", config.getInt("key_press_offset_y"));
-
-      final Key key = new Key(context, this, mk);
-      key.setKey_text_offset_x(
-          ConfigGetter.getPixel(mk, "key_text_offset_x", defaultKeyTextOffsetX));
-      key.setKey_text_offset_y(
-          ConfigGetter.getPixel(mk, "key_text_offset_y", defaultKeyTextOffsetY));
-      key.setKey_symbol_offset_x(
-          ConfigGetter.getPixel(mk, "key_symbol_offset_x", defaultKeySymbolOffsetX));
-      key.setKey_symbol_offset_y(
-          ConfigGetter.getPixel(mk, "key_symbol_offset_y", defaultKeySymbolOffsetY));
-      key.setKey_hint_offset_x(
-          ConfigGetter.getPixel(mk, "key_hint_offset_x", defaultKeyHintOffsetX));
-      key.setKey_hint_offset_y(
-          ConfigGetter.getPixel(mk, "key_hint_offset_y", defaultKeyHintOffsetY));
-      key.setKey_press_offset_x(
-          ConfigGetter.getInt(mk, "key_press_offset_x", defaultKeyPressOffsetX));
-      key.setKey_press_offset_y(
-          ConfigGetter.getInt(mk, "key_press_offset_y", defaultKeyPressOffsetY));
-
-      key.setX(x);
-      key.setY(y);
-      int right_gap = Math.abs(mDisplayWidth - x - w - gap / 2);
-      // 右側不留白
-      key.setWidth((right_gap <= mDisplayWidth / 100) ? mDisplayWidth - x - gap / 2 : w);
-      key.setHeight(rowHeight);
-      key.setGap(gap);
-      key.setRow(row);
-      key.setColumn(column);
-      column++;
-      x += key.getWidth() + key.getGap();
-      mKeys.add(key);
-      if (x > mTotalWidth) {
-        mTotalWidth = x;
-      }
-    }
-    if (mKeys.size() > 0) mKeys.get(mKeys.size() - 1).edgeFlags |= Keyboard.EDGE_RIGHT;
-    mTotalHeight = y + rowHeight + mDefaultVerticalGap;
-    for (Key key : mKeys) {
-      if (key.getColumn() == 0) key.edgeFlags |= Keyboard.EDGE_LEFT;
-      if (key.getRow() == 0) key.edgeFlags |= Keyboard.EDGE_TOP;
-      if (key.getRow() == row) key.edgeFlags |= Keyboard.EDGE_BOTTOM;
+    } catch (Exception e) {
+      e.printStackTrace();
     }
   }
 
@@ -450,10 +454,6 @@ public class Keyboard {
       this.mMetaKey = key;
     else if (c == KeyEvent.KEYCODE_ALT_LEFT || c == KeyEvent.KEYCODE_ALT_RIGHT) this.mAltKey = key;
     else if (c == KeyEvent.KEYCODE_SYM) this.mSymKey = key;
-  }
-
-  public List<Key> getmComposingKeys() {
-    return mComposingKeys;
   }
 
   public List<Key> getKeys() {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/RimeKeycode.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/RimeKeycode.java
@@ -4,6 +4,7 @@ import com.osfans.trime.core.Rime;
 import com.osfans.trime.ime.enums.Keycode;
 import java.util.HashMap;
 import java.util.Map;
+import timber.log.Timber;
 
 public class RimeKeycode {
   private Map<Integer, Integer> rimeKeycode;
@@ -30,6 +31,8 @@ public class RimeKeycode {
     if (code >= 0 && code < Keycode.values().length) {
       String s = Keycode.keyNameOf(code);
       i = Rime.get_keycode_by_name(s);
+    } else {
+      Timber.w("code=%s", code);
     }
     return i;
   }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/RimeKeycode.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/RimeKeycode.java
@@ -1,0 +1,36 @@
+package com.osfans.trime.ime.keyboard;
+
+import com.osfans.trime.core.Rime;
+import com.osfans.trime.ime.enums.Keycode;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RimeKeycode {
+  private Map<Integer, Integer> rimeKeycode;
+  private static RimeKeycode self;
+
+  private RimeKeycode() {
+    rimeKeycode = new HashMap<>();
+  }
+
+  public static RimeKeycode get() {
+    if (self == null) self = new RimeKeycode();
+    return self;
+  }
+
+  public int getRimeCode(int code) {
+    if (!rimeKeycode.containsKey(code)) rimeKeycode.put(code, rimeCode(code));
+    return rimeKeycode.get(code);
+  }
+
+  // TODO 把软键盘预设android_keys的keycode(index)->keyname(string)—>rimeKeycode的过程改为直接返回int
+  // https://github.com/rime/librime/blob/99e269c8eb251deddbad9b0d2c4d965b228f8006/src/rime/key_table.cc
+  public static int rimeCode(int code) {
+    int i = 0;
+    if (code >= 0 && code < Keycode.values().length) {
+      String s = Keycode.keyNameOf(code);
+      i = Rime.get_keycode_by_name(s);
+    }
+    return i;
+  }
+}

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -209,6 +209,9 @@ public class LiquidKeyboard {
     Timber.d("Tab.select(%s) beans.size=%s", i, simpleKeyBeans.size());
     simpleAdapter = new SimpleAdapter(context, simpleKeyBeans);
 
+    Timber.d(
+        "configStylet() single_width=%s, keyHeight=%s, margin_x=%s, margin_top=%s",
+        single_width, keyHeight, margin_x, margin_top);
     simpleAdapter.configStyle(single_width, keyHeight, margin_x, margin_top);
     //            simpleAdapter.configKey(single_width,height,margin_x,margin_top);
     keyboardView.setAdapter(simpleAdapter);

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -153,8 +153,10 @@ public class LiquidKeyboard {
     }
     Timber.i("config keyHeight=" + keyHeight + " marginTop=" + margin_top);
 
-    if (isLand) single_width = config.getLiquidPixel("single_width_land");
-    if (single_width <= 0) single_width = config.getLiquidPixel("single_width");
+    if (isLand) {
+      single_width = config.getLiquidPixel("single_width_land");
+      if (single_width <= 0) single_width = config.getLiquidPixel("single_width");
+    } else single_width = config.getLiquidPixel("single_width");
     if (single_width <= 0)
       single_width = context.getResources().getDimensionPixelSize(R.dimen.simple_key_single_width);
 

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -444,7 +444,7 @@ class TextInputManager private constructor() :
                 Rime.toggleOption(index)
                 trime.updateComposing()
             }
-        } else if (prefs.keyboard.hockCandidate || index > 9) {
+        } else if (prefs.keyboard.hookCandidate || index > 9) {
             if (Rime.selectCandidate(index)) {
                 activeEditorInstance.commitRimeText()
             }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -154,7 +154,7 @@
     <string name="about__used_libraries">第三方开源库</string>
     <string name="about__used_library_dialog_title">同文输入法 | 开源软件库</string>
     <string name="pref__system_default">系统默认</string>
-    <string name="keyboard__key_swipe_travel_title">触发滑动手势的最短距离</string>
+    <string name="keyboard__key_swipe_travel_title">触发按键滑动手势的距离</string>
     <string name="keyboard__hook_candidate">点击候选词</string>
     <string name="trime_app_slogan">击响中文之韵</string>
     <string name="external_storage_access_required">同文输入法需要存储权限以部署或读取方案和配置，点击“确定”前往授权。</string>
@@ -190,4 +190,11 @@
     <string name="pref_keyboard__hook_summary">事件不发送给被编辑的 App 及 librime</string>
     <string name="keyboard__hook_candidate_on">直接上屏候选词</string>
     <string name="keyboard__hook_candidate_off">发送数字键模拟键盘输入</string>
+    <string name="keyboard__key_swipe_travel_hi_title">连续击键时触发滑动手势的距离</string>
+    <string name="keyboard__key_swipe_time_hi_title">判定为连续击键的时间间隔</string>
+    <string name="keyboard__hook_fast_input">拦截字母键的快速输入</string>
+    <string name="keyboard__hook_fast_input_summary">合并多次按键输入为一次，从而缩减出候选的时间，但交互的反馈感会变差(暂未实现此功能)</string>
+    <string name="keyboard__swipe_enabled">允许触发按键的滑动手势</string>
+    <string name="keyboard__key_swipe_velocity">触发按键滑动手势的速度（距离/速度满足其一即可）</string>
+    <string name="keyboard__key_swipe_velocity_hi">连续击键时触发滑动手势的速度</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -191,4 +191,11 @@
     <string name="pref_keyboard__hook_summary">事件不發送給被編輯的 App 及 librime</string>
     <string name="keyboard__hook_candidate_on">直接上屏候選詞</string>
     <string name="keyboard__hook_candidate_off">發送數字鍵模擬鍵盤錄入</string>
+<string name="keyboard__key_swipe_travel_hi_title">連續擊鍵時觸發滑動手勢的距離</string>
+    <string name="keyboard__key_swipe_time_hi_title">判定為連續擊鍵的時間間隔</string>
+    <string name="keyboard__hook_fast_input">攔截字母鍵的快速輸入</string>
+    <string name="keyboard__hook_fast_input_summary">合併多次按鍵輸入為一次，從而縮減出候選的時間，但交互的反饋感會變差(暫未實現此功能)</string>
+    <string name="keyboard__swipe_enabled">允許觸發按鍵的滑動手勢</string>
+    <string name="keyboard__key_swipe_velocity">觸發按鍵滑動手勢的速度（距離/速度滿足其一即可）</string>
+    <string name="keyboard__key_swipe_velocity_hi">連續擊鍵時觸發滑動手勢的速度</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,4 +192,11 @@
     <string name="pref_keyboard__hook_summary">Not handled by the App being edited or librime</string>
     <string name="keyboard__hook_candidate_on">Commit directly</string>
     <string name="keyboard__hook_candidate_off">Send number key to librime</string>
+<string name="keyboard__key_swipe_travel_hi_title">The distance to trigger the swipe gesture</string>
+     <string name="keyboard__key_swipe_time_hi_title">Determine the time interval for consecutive keystrokes</string>
+     <string name="keyboard__hook_fast_input">Time interval as fast input </string>
+     <string name="keyboard__hook_fast_input_summary">Merge multiple key inputs into one, thereby reducing the time for candidates, but the interactive feedback will become worse (It will be comming soon)</string>
+     <string name="keyboard__swipe_enabled">Allow swipe gestures to trigger keys</string>
+     <string name="keyboard__key_swipe_velocity">The speed of triggering the button swipe gesture (the distance/velocity is sufficient)</string>
+     <string name="keyboard__key_swipe_velocity_hi">The velocity of the swipe gesture on consecutive keystrokes</string>
 </resources>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -53,16 +53,21 @@
     <PreferenceCategory
         app:iconSpaceReserved="false"
         app:key="settings__keyboard_hook"
-        app:title="@string/pref_keyboard__hook"
         app:summary="@string/pref_keyboard__hook_summary"
-        >
+        app:title="@string/pref_keyboard__hook">
 
-        <SwitchPreferenceCompat android:key="keyboard__hook_candidate"
-            app:iconSpaceReserved="false"
-            android:title="@string/keyboard__hook_candidate"
-            android:summaryOn="@string/keyboard__hook_candidate_on"
+        <SwitchPreferenceCompat
+            android:key="keyboard__hook_fast_input"
+            android:summary="@string/keyboard__hook_fast_input_summary"
+            android:title="@string/keyboard__hook_fast_input"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            android:key="keyboard__hook_candidate"
             android:summaryOff="@string/keyboard__hook_candidate_off"
-            />
+            android:summaryOn="@string/keyboard__hook_candidate_on"
+            android:title="@string/keyboard__hook_candidate"
+            app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
             android:key="keyboard__hook_ctrl_lr"
@@ -83,97 +88,149 @@
             android:title="@string/keyboard__hook_ctrl_zy"
             app:iconSpaceReserved="false" />
 
-          </PreferenceCategory>
+    </PreferenceCategory>
 
-    <PreferenceCategory app:iconSpaceReserved="false"
-        app:title="@string/pref_keyboard__effect"
-        app:key="settings__keyboard_effects" >
-        <SwitchPreferenceCompat android:key="keyboard__key_sound"
-            app:iconSpaceReserved="false"
-            android:title="@string/keyboard__key_sound_title"/>
-        <Preference android:key="keyboard__key_sound_package"
-            app:iconSpaceReserved="false"
-            android:title="@string/keyboard__key_sound_package_title" />
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:key="settings__keyboard_effects"
+        app:title="@string/pref_keyboard__effect">
+        <SwitchPreferenceCompat
+            android:key="keyboard__key_sound"
+            android:title="@string/keyboard__key_sound_title"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="keyboard__key_sound_package"
+            android:title="@string/keyboard__key_sound_package_title"
+            app:iconSpaceReserved="false" />
         <com.osfans.trime.settings.components.DialogSeekBarPreference
-            app:allowDividerAbove="false"
+            android:defaultValue="-1"
+            android:dependency="keyboard__key_sound"
             android:key="keyboard__key_sound_volume"
-            app:iconSpaceReserved="false"
             android:title="@string/keyboard__key_sound_volume_title"
-            app:min="0"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
             app:max="100"
+            app:min="0"
             app:seekBarIncrement="1"
-            android:defaultValue="-1"
             app:systemDefaultValue="-1"
             app:systemDefaultValueText="@string/pref__system_default"
-            app:unit="%"
-            android:dependency="keyboard__key_sound"/>
-        <SwitchPreferenceCompat android:key="keyboard__key_vibration"
-            app:iconSpaceReserved="false"
-            android:title="@string/keyboard__key_vibration_title"/>
+            app:unit="%" />
+        <SwitchPreferenceCompat
+            android:key="keyboard__key_vibration"
+            android:title="@string/keyboard__key_vibration_title"
+            app:iconSpaceReserved="false" />
         <com.osfans.trime.settings.components.DialogSeekBarPreference
-            app:allowDividerAbove="false"
+            android:defaultValue="-1"
+            android:dependency="keyboard__key_vibration"
             android:key="keyboard__key_vibration_duration"
-            app:iconSpaceReserved="false"
             android:title="@string/keyboard__key_vibration_duration_title"
-            app:min="0"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
             app:max="100"
+            app:min="0"
             app:seekBarIncrement="1"
-            android:defaultValue="-1"
             app:systemDefaultValue="-1"
             app:systemDefaultValueText="@string/pref__system_default"
-            app:unit="@string/unit__time_ms"
-            android:dependency="keyboard__key_vibration"/>
+            app:unit="@string/unit__time_ms" />
         <com.osfans.trime.settings.components.DialogSeekBarPreference
-            app:allowDividerAbove="false"
+            android:defaultValue="-1"
+            android:dependency="keyboard__key_vibration"
             android:key="keyboard__key_vibration_amplitude"
-            app:iconSpaceReserved="false"
             android:title="@string/keyboard__key_vibration_amplitude_title"
-            app:min="0"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
             app:max="255"
+            app:min="0"
             app:seekBarIncrement="1"
-            android:defaultValue="-1"
             app:systemDefaultValue="-1"
             app:systemDefaultValueText="@string/pref__system_default"
-            app:unit=""
-            android:dependency="keyboard__key_vibration"/>
+            app:unit="" />
         <!--        <SwitchPreference android:key="key_vibrate_default_amplitude" android:title="@string/key_vibrate_default_amplitude"/>-->
-        <SwitchPreferenceCompat android:key="keyboard__speak_key_press"
-            app:iconSpaceReserved="false"
-            android:title="@string/keyboard__speak_key_press_title"/>
-        <SwitchPreferenceCompat android:key="keyboard__speak_commit"
-            app:iconSpaceReserved="false"
-            android:title="@string/keyboard__speak_key_commit_title"/>
+        <SwitchPreferenceCompat
+            android:key="keyboard__speak_key_press"
+            android:title="@string/keyboard__speak_key_press_title"
+            app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
+            android:key="keyboard__speak_commit"
+            android:title="@string/keyboard__speak_key_commit_title"
+            app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
+            android:key="keyboard__swipe_enabled"
+            android:title="@string/keyboard__swipe_enabled"
+            android:defaultValue="true"
+            app:iconSpaceReserved="false" />
         <com.osfans.trime.settings.components.DialogSeekBarPreference
-            app:allowDividerAbove="false"
-            android:key="keyboard__key_swipe_travel"
-            app:iconSpaceReserved="false"
-            android:title="@string/keyboard__key_swipe_travel_title"
-            app:min="0"
-            app:max="400"
-            app:seekBarIncrement="10"
             android:defaultValue="80"
-            app:unit=""/>
-        <com.osfans.trime.settings.components.DialogSeekBarPreference
+            android:key="keyboard__key_swipe_travel"
+            android:title="@string/keyboard__key_swipe_travel_title"
             app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
+            app:max="400"
+            app:min="0"
+            app:seekBarIncrement="10"
+            app:unit="" />
+        <com.osfans.trime.settings.components.DialogSeekBarPreference
+            android:defaultValue="800"
+            android:key="keyboard__key_swipe_velocity"
+            android:title="@string/keyboard__key_swipe_velocity"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
+            app:max="30000"
+            app:min="0"
+            app:seekBarIncrement="100"
+            app:unit="" />
+        <com.osfans.trime.settings.components.DialogSeekBarPreference
+            android:defaultValue="240"
+            android:key="keyboard__key_swipe_travel_hi"
+            android:title="@string/keyboard__key_swipe_travel_hi_title"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
+            app:max="600"
+            app:min="0"
+            app:seekBarIncrement="10"
+            app:unit="" />
+        <com.osfans.trime.settings.components.DialogSeekBarPreference
+            android:defaultValue="25000"
+            android:key="keyboard__key_swipe_velocity_hi"
+            android:title="@string/keyboard__key_swipe_velocity_hi"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
+            app:max="30000"
+            app:min="0"
+            app:seekBarIncrement="100"
+            app:unit="" />
+        <com.osfans.trime.settings.components.DialogSeekBarPreference
+            android:defaultValue="50"
+            android:key="keyboard__key_swipe_time_hi"
+            android:title="@string/keyboard__key_swipe_time_hi_title"
             android:widgetLayout="@layout/seek_bar_dialog"
-            android:key="keyboard__key_long_press_timeout"
-            app:iconSpaceReserved="false"
-            android:title="@string/keyboard__long_press_timeout_title"
-            app:min="10"
-            app:max="60"
-            app:seekBarIncrement="10"
-            android:defaultValue="20"
-            app:unit="@string/unit__time_ms"/>
-        <com.osfans.trime.settings.components.DialogSeekBarPreference
             app:allowDividerAbove="false"
-            android:key="keyboard__key_repeat_interval"
             app:iconSpaceReserved="false"
-            android:title="@string/keyboard__key_repeat_interval_title"
-            app:min="10"
-            app:max="100"
+            app:max="500"
+            app:min="0"
             app:seekBarIncrement="10"
+            app:unit="@string/unit__time_ms" />
+        <com.osfans.trime.settings.components.DialogSeekBarPreference
+            android:defaultValue="20"
+            android:key="keyboard__key_long_press_timeout"
+            android:title="@string/keyboard__long_press_timeout_title"
+            android:widgetLayout="@layout/seek_bar_dialog"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
+            app:max="60"
+            app:min="10"
+            app:seekBarIncrement="10"
+            app:unit="@string/unit__time_ms" />
+        <com.osfans.trime.settings.components.DialogSeekBarPreference
             android:defaultValue="40"
-            app:unit="@string/unit__time_ms"/>
+            android:key="keyboard__key_repeat_interval"
+            android:title="@string/keyboard__key_repeat_interval_title"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
+            app:max="100"
+            app:min="10"
+            app:seekBarIncrement="10"
+            app:unit="@string/unit__time_ms" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
## Pull request
1. 移除对皮肤中android_keys/name的解析，改为内置的枚举类。原因：皮肤中android_keys/name的内容实际上是不可随意修改的，排序遵循Android keycode，而内容与librime关联，在皮肤中配置、读取徒增开销，令key类臃肿
2. 增加keyEventType的类型，并调整原有排序。把原有的field中的Event ascii/composing/has_menu/paging改为events数组中keyEventType为COMPOSING, HAS_MENU, PAGING, COMBO, ASCII的event。
3. 缓存keycode，减少jni调用Rime.get_keycode_by_name()
4. 修复更新主题后，liquidKeyboard的按键宽度没有正确刷新的问题。
5. 优化按键滑动。在设置界面增加了关闭滑动的开关，以及其他滑动触发条件的参数。特别的，设计了“连续击键”时使用的另一套触发参数，目的在于连续输入编码时避免误触滑动


#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
6. Manual build and test pass
7. GitHub action ci pass
8. At least one contributor reviews and votes
9. Can be merged clean without conflicts
10. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
