### PR TITLE
调整App设置中“关于“页面的内容

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,9 @@ android {
         versionCode 20220701
         versionName "3.2.7"
         setProperty("archivesBaseName", "trime-$versionName")
+        resValue "string", "trime_url", getGitUrl()
+        buildConfigField 'String', 'BUILD_INFO' , '"Build by '+getGitUser()+ ', in ' + getBuildTime() + ' UTC, branch ' + getGitBranch() + '"'
+        buildConfigField 'String', 'BUILD_VERSION' , '"'+"$versionName" + '-'+ gitGitVersionCode() +'-g'+ getGitVersion()+ '-' + getBuildDate()  + '"'
     }
 
     signingConfigs {
@@ -101,4 +104,37 @@ dependencies {
 }
 repositories {
     mavenCentral()
+}
+
+def getBuildDate() {
+    return new Date().format("yyyyMMdd", TimeZone.getTimeZone("UTC"))
+}
+
+def getBuildTime() {
+    return new Date().format("yyyy-MM-dd HH:mm", TimeZone.getTimeZone("UTC"))
+}
+
+def getGitBranch(){
+    ' git symbolic-ref --short -q HEAD'.execute().text.trim()
+}
+
+def getGitVersion() {
+    return 'git rev-parse --short HEAD'.execute().text.trim()
+}
+
+def gitGitVersionCode() {
+    try {
+        return 'git rev-list HEAD --first-parent --count'.execute().text.trim().toInteger()
+    }
+    catch (ignored) {
+        return 1
+    }
+}
+
+def getGitUser() {
+    return 'git config user.name'.execute().text.trim()
+}
+
+def getGitUrl() {
+    return 'git remote get-url  origin'.execute().text.trim().replaceFirst("\\.git\$","")
 }

--- a/app/src/main/java/com/osfans/trime/settings/AboutActivity.kt
+++ b/app/src/main/java/com/osfans/trime/settings/AboutActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import com.osfans.trime.BuildConfig
 import com.osfans.trime.R
 import com.osfans.trime.core.Rime
 import com.osfans.trime.databinding.AboutActivityBinding
@@ -71,7 +72,10 @@ class AboutActivity : AppCompatActivity() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.about_preference, rootKey)
             findPreference<Preference>("about__changelog")
-                ?.writeLibraryVersionToSummary(Rime.get_trime_version())
+                ?.writeLibraryVersionToSummary(BuildConfig.BUILD_VERSION)
+
+            findPreference<Preference>("about__buildinfo")
+                ?.writeLibraryVersionToSummary(BuildConfig.BUILD_INFO)
 
             findPreference<Preference>("about__librime_version")
                 ?.writeLibraryVersionToSummary(Rime.get_librime_version())

--- a/app/src/main/java/com/osfans/trime/util/AppVersionUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/AppVersionUtils.kt
@@ -28,7 +28,9 @@ object AppVersionUtils {
         }
         this.summary = versionCode
         val intent = this.intent
-        intent.data = Uri.withAppendedPath(intent.data, "commits/$commitHash")
-        this.intent = intent
+        if (intent != null) {
+            intent.data = Uri.withAppendedPath(intent.data, "commits/$commitHash")
+            this.intent = intent
+        }
     }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -36,7 +36,7 @@
     <string name="about__opencc_version">OpenCC版本</string>
     <string name="about__changelog">更新日志</string>
     <string name="about__licensing_title">许可证</string>
-    <string name="pref_credits">鸣谢</string>
+    <string name="pref_credits">贡献代码</string>
     <string name="about__product_prime">微软平台PRIME输入法</string>
     <string name="about__privacy_policy">隐私策略</string>
     <string name="settings__configuration_title">输入配置</string>
@@ -197,4 +197,5 @@
     <string name="keyboard__swipe_enabled">允许触发按键的滑动手势</string>
     <string name="keyboard__key_swipe_velocity">触发按键滑动手势的速度（距离/速度满足其一即可）</string>
     <string name="keyboard__key_swipe_velocity_hi">连续击键时触发滑动手势的速度</string>
+    <string name="about__buildinfo">编译信息</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -37,7 +37,7 @@
     <string name="about__opencc_version">OpenCC版本</string>
     <string name="about__changelog">更新日誌</string>
     <string name="about__licensing_title">許可證</string>
-    <string name="pref_credits">鳴謝</string>
+    <string name="pref_credits">貢獻代碼</string>
     <string name="about__product_prime">Win10 PRIME輸入法平臺</string>
     <string name="about__privacy_policy">隱私權政策</string>
     <string name="settings__configuration_title">輸入配置</string>
@@ -198,4 +198,5 @@
     <string name="keyboard__swipe_enabled">允許觸發按鍵的滑動手勢</string>
     <string name="keyboard__key_swipe_velocity">觸發按鍵滑動手勢的速度（距離/速度滿足其一即可）</string>
     <string name="keyboard__key_swipe_velocity_hi">連續擊鍵時觸發滑動手勢的速度</string>
+    <string name="about__buildinfo">編譯信息</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="about__opencc_version">OpenCC Version</string>
     <string name="about__changelog">Change Log</string>
     <string name="about__licensing_title">License</string>
-    <string name="pref_credits">Credits</string>
+    <string name="pref_credits">Contribute</string>
     <string name="about__product_prime">Win10 PRIME Platform</string>
     <string name="about__privacy_policy">Privacy Policy</string>
     <string name="settings__configuration_title">Configurations</string>
@@ -199,4 +199,5 @@
      <string name="keyboard__swipe_enabled">Allow swipe gestures to trigger keys</string>
      <string name="keyboard__key_swipe_velocity">The speed of triggering the button swipe gesture (the distance/velocity is sufficient)</string>
      <string name="keyboard__key_swipe_velocity_hi">The velocity of the swipe gesture on consecutive keystrokes</string>
+    <string name="about__buildinfo">Build info</string>
 </resources>

--- a/app/src/main/res/xml/about_preference.xml
+++ b/app/src/main/res/xml/about_preference.xml
@@ -10,7 +10,12 @@
             app:title="@string/about__changelog"
             app:iconSpaceReserved="false">
             <intent android:action="android.intent.action.VIEW"
-                android:data="https://github.com/osfans/trime" />
+                android:data="@string/trime_url" />
+        </Preference>
+
+        <Preference app:key="about__buildinfo"
+            app:title="@string/about__buildinfo"
+            app:iconSpaceReserved="false"> />
         </Preference>
 
         <Preference app:key="about__librime_version"
@@ -66,7 +71,7 @@
         <Preference android:key="pref_credits" android:title="@string/pref_credits"
             app:iconSpaceReserved="false">
             <intent android:action="android.intent.action.VIEW"
-                android:data="https://github.com/osfans/trime#%E9%B3%B4%E8%AC%9Dcredits" />
+                android:data="https://github.com/osfans/trime" />
         </Preference>
 
         <Preference app:key="about__product_prime"


### PR DESCRIPTION
## Pull request

#### Issue tracker
见 #755

已经完成：  
1. 同文的版本改为由gradle脚本生成，而不是现在的jni，从而避免系统显示的App版本信息与设置界面有差异
2. 修改changelog的链接为编译人所在的当前仓库的当前commit
3. 增加编译信息栏位
4. 移除“鸣谢” 栏位，感觉目前链接意义不大，改为指向仓库本身，用“贡献代码”命名

考虑到可能有争议，暂未做issue提及的如下变更，讨论后再处置：
1. 移动“寻求帮助”的内容到“关于” 内
2. 考虑到有人制作内置方案但是不修改代码的修改版，增加“定制版QQ群”的栏位，当存在此信息时，显示在“用户社区”的顶部；不存在时自动隐藏。

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
7. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
