### PR TITLE
连接实体键盘时显示迷你键盘

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -922,7 +922,7 @@ public class Trime extends LifecycleInputMethodService {
   private boolean composeEvent(@NonNull KeyEvent event) {
     final int keyCode = event.getKeyCode();
     if (keyCode == KeyEvent.KEYCODE_MENU) return false; // 不處理 Menu 鍵
-    if (Keycode.Companion.isStdKey(keyCode)) return false; // 只處理安卓標準按鍵
+    if (Keycode.Companion.hasSymbolLabel(keyCode)) return false; // 只處理安卓標準按鍵
     if (event.getRepeatCount() == 0 && Key.isTrimeModifierKey(keyCode)) {
       boolean ret =
           onRimeKey(


### PR DESCRIPTION
## Pull request

#### Feature
1. 在主题中增加名称为mini的键盘
2. 在外观选项中增加对应开关
3. 当连接实体键盘，且有默认mini的主题、开关打开时，原先弹出的default键盘会变成弹出mini键盘。


#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
5. Manual build and test pass
6. GitHub action ci pass
7. At least one contributor reviews and votes
8. Can be merged clean without conflicts
9. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
