### PR TITLE
在设置界面设置候选词数量

### DIFF
--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -693,7 +693,7 @@ liquid_keyboard:
   single_width: 60    #single类型的按键宽度
   vertical_gap: 1     #纵向按键间隙
   margin_x: 0.5         #左右按键间隙的1/2
-  keyboards: [emoji, math, ascii, cn, history, clipboard, draft, tabs, exit, list, ids , table, symbol, unit, new, jp, pinyin, grease, rusa, korea, lation, yinbiao,  exit]  #tab列表
+  keyboards: [emoji, math, ascii, cn, history, clipboard, draft, tabs, exit, candidate, list, ids , table, symbol, unit, new, jp, pinyin, grease, rusa, korea, lation, yinbiao,  exit]  #tab列表
   exit:
     name: 返回
     type: NO_KEY
@@ -704,6 +704,9 @@ liquid_keyboard:
   new:
     name: 新行 #此类型不显示在候选栏中，但是打开“更多”TAB时，下一个按键会换行
     type: NEW_ROW
+  candidate:
+    name: 候选
+    type: CANDIDATE
   history:
     name: 常用
     type: HISTORY

--- a/app/src/main/java/com/osfans/trime/core/Rime.java
+++ b/app/src/main/java/com/osfans/trime/core/Rime.java
@@ -367,8 +367,12 @@ public class Rime {
   }
 
   public static void getContexts() {
+    Timber.i("\t<TrimeInput>\tgetContexts() get_context");
+    // get_context() 是耗时操作
     get_context(mContext);
+    Timber.i("\t<TrimeInput>\tgetContexts() getStatus");
     getStatus();
+    Timber.i("\t<TrimeInput>\tgetContexts() finish");
   }
 
   public static boolean isVoidKeycode(int keycode) {
@@ -385,6 +389,7 @@ public class Rime {
     Timber.i(
         "\t<TrimeInput>\tonkey()\tkeycode=%s, mask=%s, process_key result=%s", keycode, mask, b);
     getContexts();
+    Timber.i("\t<TrimeInput>\tonkey()\tfinish");
     return b;
   }
 

--- a/app/src/main/java/com/osfans/trime/core/Rime.java
+++ b/app/src/main/java/com/osfans/trime/core/Rime.java
@@ -366,11 +366,9 @@ public class Rime {
     return get_commit(mCommit);
   }
 
-  @SuppressWarnings("UnusedReturnValue")
-  private static boolean getContexts() {
-    boolean b = get_context(mContext);
+  public static void getContexts() {
+    get_context(mContext);
     getStatus();
-    return b;
   }
 
   public static boolean isVoidKeycode(int keycode) {
@@ -413,6 +411,11 @@ public class Rime {
   public static RimeCandidate[] getCandidates() {
     if (!isComposing() && showSwitches) return mSchema.getCandidates();
     return mContext.getCandidates();
+  }
+
+  public static RimeCandidate[] getCandidatesWithoutSwitch() {
+    if (isComposing()) return mContext.getCandidates();
+    return null;
   }
 
   public static String[] getSelectLabels() {

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -232,7 +232,7 @@ class AppPrefs(
             get() = prefs.getPref(HOOK_CANDIDATE, false)
             private set
         var hookCandidateCommit: Boolean = false
-            get() = prefs.getPref(HOOK_CANDIDATE_COMMIT, true)
+            get() = prefs.getPref(HOOK_CANDIDATE_COMMIT, false)
             private set
         var hookCtrlA: Boolean = false
             get() = prefs.getPref(HOOK_CTRL_A, false)

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -170,6 +170,7 @@ class AppPrefs(
             const val SWITCHES_ENABLED = "keyboard__show_switches"
             const val SWITCH_ARROW_ENABLED = "keyboard__show_switch_arrow"
             const val FULLSCREEN_MODE = "keyboard__fullscreen_mode"
+            const val CANDIDATE_PAGE_SIZE = "keyboard__candidate_page_size"
 
             const val HOOK_FAST_INPUT = "keyboard__hook_fast_input"
             const val HOOK_CANDIDATE = "keyboard__hook_candidate"
@@ -218,6 +219,9 @@ class AppPrefs(
             private set
         var switchArrowEnabled: Boolean = false
             get() = prefs.getPref(SWITCH_ARROW_ENABLED, true)
+            private set
+        var candidatePageSize: String = "0"
+            get() = prefs.getPref(CANDIDATE_PAGE_SIZE, "0")
             private set
 
         var hookFastInput: Boolean = false

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -174,6 +174,7 @@ class AppPrefs(
 
             const val HOOK_FAST_INPUT = "keyboard__hook_fast_input"
             const val HOOK_CANDIDATE = "keyboard__hook_candidate"
+            const val HOOK_CANDIDATE_COMMIT = "keyboard__hook_candidate_commit"
             const val HOOK_CTRL_A = "keyboard__hook_ctrl_a"
             const val HOOK_CTRL_CV = "keyboard__hook_ctrl_cv"
             const val HOOK_CTRL_LR = "keyboard__hook_ctrl_lr"
@@ -229,6 +230,9 @@ class AppPrefs(
             private set
         var hookCandidate: Boolean = false
             get() = prefs.getPref(HOOK_CANDIDATE, false)
+            private set
+        var hookCandidateCommit: Boolean = false
+            get() = prefs.getPref(HOOK_CANDIDATE_COMMIT, true)
             private set
         var hookCtrlA: Boolean = false
             get() = prefs.getPref(HOOK_CTRL_A, false)

--- a/app/src/main/java/com/osfans/trime/ime/core/EditorInstance.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/EditorInstance.kt
@@ -60,6 +60,7 @@ class EditorInstance(private val ims: InputMethodService) {
         if (ret) {
             commitText(Rime.getCommitText())
         }
+        Timber.i("\t<TrimeInput>\tcommitRimeText()\tupdateComposing")
         (ims as Trime).updateComposing()
         return ret
     }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -69,6 +69,7 @@ import com.osfans.trime.databinding.InputRootBinding;
 import com.osfans.trime.ime.broadcast.IntentReceiver;
 import com.osfans.trime.ime.enums.Keycode;
 import com.osfans.trime.ime.enums.PositionType;
+import com.osfans.trime.ime.enums.SymbolKeyboardType;
 import com.osfans.trime.ime.keyboard.Event;
 import com.osfans.trime.ime.keyboard.InputFeedbackManager;
 import com.osfans.trime.ime.keyboard.Key;
@@ -454,7 +455,12 @@ public class Trime extends LifecycleInputMethodService {
   // 按键需要通过tab name来打开liquidKeyboard的指定tab
   public void selectLiquidKeyboard(@NonNull String name) {
     if (name.matches("\\d+")) selectLiquidKeyboard(Integer.parseInt(name));
+    else if (name.matches("[A-Z]+")) selectLiquidKeyboard(SymbolKeyboardType.valueOf(name));
     else selectLiquidKeyboard(TabManager.getTagIndex(name));
+  }
+
+  public void selectLiquidKeyboard(SymbolKeyboardType type) {
+    selectLiquidKeyboard(TabManager.getTagIndex(type));
   }
 
   public void pasteByChar() {
@@ -1197,6 +1203,7 @@ public class Trime extends LifecycleInputMethodService {
       } else {
         mCandidate.setText(0);
       }
+      mCandidate.setExpectWidth(mainKeyboardView.getWidth());
       // 刷新候选词后，如果候选词超出屏幕宽度，滚动候选栏
       mTabRoot.move(mCandidate.getHighlightLeft(), mCandidate.getHighlightRight());
     }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -442,7 +442,6 @@ public class Trime extends LifecycleInputMethodService {
         liquidKeyboard.setLand(orientation == Configuration.ORIENTATION_LANDSCAPE);
         liquidKeyboard.calcPadding(mainInputView.getWidth());
         symbolKeyboardType = liquidKeyboard.select(tabIndex);
-        updateComposing();
         tabView.updateTabWidth();
         if (inputRootBinding != null) {
           mTabRoot.setBackground(mCandidateRoot.getBackground());
@@ -451,8 +450,8 @@ public class Trime extends LifecycleInputMethodService {
       } else {
         symbolKeyboardType = SymbolKeyboardType.NO_KEY;
         symbolInputView.setVisibility(View.GONE);
-        updateComposing();
       }
+      updateComposing();
     }
     if (mainInputView != null)
       mainInputView.setVisibility(tabIndex >= 0 ? View.GONE : View.VISIBLE);

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1466,4 +1466,14 @@ public class Trime extends LifecycleInputMethodService {
       }
     }
   }
+
+  private boolean candidateExPage = false;
+
+  public boolean hasCandidateExPage() {
+    return candidateExPage;
+  }
+
+  public void setCandidateExPage(boolean candidateExPage) {
+    this.candidateExPage = candidateExPage;
+  }
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -914,6 +914,7 @@ public class Trime extends LifecycleInputMethodService {
 
   public boolean onRimeKey(int[] event) {
     updateRimeOption();
+    // todo 改为异步处理按键事件、刷新UI
     final boolean ret = Rime.onKey(event);
     activeEditorInstance.commitRimeText();
     return ret;

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1223,6 +1223,15 @@ public class Trime extends LifecycleInputMethodService {
     if (mainKeyboardView != null) mainKeyboardView.invalidateComposingKeys();
     if (!onEvaluateInputViewShown())
       setCandidatesViewShown(textInputManager.isComposable()); // 實體鍵盤打字時顯示候選欄
+
+    if (symbolKeyboardType == SymbolKeyboardType.CANDIDATE) {
+      if (isComposing()) {
+        liquidKeyboard.updateCandidates();
+      } else {
+        selectLiquidKeyboard(-1);
+      }
+    }
+
     return startNum;
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
@@ -19,6 +19,9 @@ enum class SymbolKeyboardType {
     //  文本框编辑历史，即“草稿箱”
     DRAFT,
 
+    // 候选词
+    CANDIDATE,
+
     //  近期上屏符号历史（需要区分来源并提示？）
     HISTORY,
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -1276,9 +1276,13 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
   }
 
   public void invalidateComposingKeys() {
-    final List<Key> keys = mKeyboard.getComposingKeys();
-    if (keys != null && keys.size() > 5) invalidateAllKeys();
-    else invalidateKeys(keys);
+    if (mKeyboard != null) {
+      final List<Key> keys = mKeyboard.getComposingKeys();
+      if (keys != null && keys.size() > 5) invalidateAllKeys();
+      else invalidateKeys(keys);
+    } else {
+      Timber.e("invalidateComposingKeys() mKeyboard==null");
+    }
   }
 
   private boolean openPopupIfRequired(final MotionEvent me) {

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
@@ -31,11 +31,10 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
   private AppPrefs prefs;
 
   private int keyMarginX, keyMarginTop;
-  private Integer textColor;
-  private float textSize;
-  private Typeface textFont;
+  private Integer textColor, textColor2, commentColor;
+  private float textSize, commentSize;
+  private Typeface textFont, commentFont;
   private Drawable background;
-
   private PositionType textPosition, commentPosition;
   private static int COMMENT_UNKNOW = 0, COMMENT_TOP = 1, COMMENT_DOWN = 2, COMMENT_RIGHT = 3;
   private static int comment_position;
@@ -53,12 +52,8 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
   public int updateCandidates() {
 
     candidates = Rime.getCandidatesWithoutSwitch();
-    //    highlightIndex = Rime.getCandHighlightIndex() - startNum;
     if (candidates == null) {
       candidates = new Rime.RimeCandidate[0];
-    }
-    synchronized (candidates) {
-      candidates.notify();
     }
     return candidates.length;
   }
@@ -74,8 +69,10 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
     //  边框尺寸、圆角、字号直接读取主题通用参数。配色优先读取 liquidKeyboard 专用参数。
     Config config = Config.get(myContext);
-    textColor = config.getLiquidColor("long_text_color");
-    if (textColor == null) textColor = config.getLiquidColor("key_text_color");
+
+    textColor = config.getColor("candidate_text_color");
+    textColor2 = config.getColor("hilited_candidate_text_color");
+    commentColor = config.getColor("comment_text_color");
 
     hide_comment = Rime.getOption("_hide_comment");
     if (hide_comment) {
@@ -87,12 +84,15 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
       }
     }
     textSize = config.getFloat("candidate_text_size");
+    commentSize = config.getFloat("comment_text_size");
 
+    //  点击前后必须使用相同类型的背景，或者全部为背景图，或者都为背景色
     background =
         config.getDrawable(
-            "long_text_back_color", "key_border", "key_long_text_border", "round_corner", null);
+            "key_back_color", "key_border", "key_border_color", "round_corner", null);
 
-    textFont = config.getFont("long_text_font");
+    textFont = config.getFont("candidate_font");
+    commentFont = config.getFont("comment_font");
   }
 
   @NonNull
@@ -117,14 +117,13 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
   private static class ItemViewHolder extends RecyclerView.ViewHolder {
     public ItemViewHolder(View view) {
       super(view);
-
       listItemLayout = view.findViewById(R.id.listitem_layout);
-      textView1 = view.findViewById(R.id.text1);
-      textView2 = view.findViewById(R.id.text2);
+      textView = view.findViewById(R.id.text);
+      commentView = view.findViewById(R.id.comment);
     }
 
     ConstraintLayout listItemLayout;
-    TextView textView1, textView2;
+    TextView textView, commentView;
   }
 
   @SuppressLint("ClickableViewAccessibility")
@@ -134,26 +133,29 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     if (viewHolder instanceof ItemViewHolder) {
       final ItemViewHolder itemViewHold = ((ItemViewHolder) viewHolder);
 
-      if (textFont != null) itemViewHold.textView1.setTypeface(textFont);
+      if (textFont != null) itemViewHold.textView.setTypeface(textFont);
+      if (commentFont != null) itemViewHold.commentView.setTypeface(commentFont);
 
       String text = candidates[index].text;
       String comment = "";
       if (!hide_comment && candidates[index].comment != null) comment = candidates[index].comment;
 
-      if (text.length() > 300) itemViewHold.textView1.setText(text.substring(0, 300));
-      else itemViewHold.textView1.setText(text);
+      if (text.length() > 300) itemViewHold.textView.setText(text.substring(0, 300));
+      else itemViewHold.textView.setText(text);
 
-      if (comment.length() > 300) itemViewHold.textView2.setText(comment.substring(0, 300));
-      else itemViewHold.textView2.setText(comment);
+      if (comment.length() > 300) itemViewHold.commentView.setText(comment.substring(0, 300));
+      else itemViewHold.commentView.setText(comment);
 
-      if (textSize > 0) itemViewHold.textView1.setTextSize(textSize);
+      if (textSize > 0) itemViewHold.textView.setTextSize(textSize);
+      if (commentSize > 0) itemViewHold.commentView.setTextSize(commentSize);
 
       ViewGroup.LayoutParams lp = itemViewHold.listItemLayout.getLayoutParams();
       if (lp instanceof FlexboxLayoutManager.LayoutParams) {
         FlexboxLayoutManager.LayoutParams flexboxLp =
             (FlexboxLayoutManager.LayoutParams) itemViewHold.listItemLayout.getLayoutParams();
 
-        itemViewHold.textView1.setTextColor(textColor);
+        itemViewHold.textView.setTextColor(textColor);
+        itemViewHold.commentView.setTextColor(commentColor);
 
         int marginTop = flexboxLp.getMarginTop();
         int marginX = flexboxLp.getMarginLeft();
@@ -162,39 +164,31 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
         flexboxLp.setMargins(marginX, marginTop, marginX, flexboxLp.getMarginBottom());
         flexboxLp.setFlexGrow(1);
-
-        // TODO 设置剪贴板列表样式
-        // copy SimpleAdapter 会造成高度始终为 3 行无法自适应的效果。
-
       }
-      if (background != null)
-        itemViewHold.listItemLayout.setBackground(
-            Config.get(myContext)
-                .getDrawable(
-                    "long_text_back_color",
-                    "key_border",
-                    "key_long_text_border",
-                    "round_corner",
-                    null));
+
+      // 如果直接使用background，会造成滚动时部分内容的背景填充错误的问题
+      if (background != null) itemViewHold.listItemLayout.setBackground(background);
 
       // 如果设置了回调，则设置点击事件
       if (mOnItemClickListener != null) {
         itemViewHold.listItemLayout.setOnClickListener(
             view -> {
-              int position = itemViewHold.getLayoutPosition(); // 在增加数据或者减少数据时候，position和index就不一样了
+              int position = itemViewHold.getLayoutPosition();
               mOnItemClickListener.onItemClick(itemViewHold.listItemLayout, position);
             });
       }
 
-      // TODO 剪贴板列表点击时产生背景变色效果
+      // 点击时产生背景变色效果
       itemViewHold.listItemLayout.setOnTouchListener(
           (view, motionEvent) -> {
             int action = motionEvent.getAction();
             switch (action) {
               case MotionEvent.ACTION_DOWN:
-
+                itemViewHold.textView.setTextColor(textColor2);
+                break;
               case MotionEvent.ACTION_UP:
               case MotionEvent.ACTION_CANCEL:
+                itemViewHold.textView.setTextColor(textColor);
                 break;
             }
             return false;

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
@@ -39,6 +39,7 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
   private PositionType textPosition, commentPosition;
   private static int COMMENT_UNKNOW = 0, COMMENT_TOP = 1, COMMENT_DOWN = 2, COMMENT_RIGHT = 3;
   private static int comment_position;
+  private static boolean hide_comment;
 
   public CandidateAdapter(Context context) {
     myContext = context;
@@ -76,11 +77,15 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     textColor = config.getLiquidColor("long_text_color");
     if (textColor == null) textColor = config.getLiquidColor("key_text_color");
 
-    comment_position = config.getInt("comment_position");
-    if (comment_position == COMMENT_UNKNOW) {
-      comment_position = config.getBoolean("comment_on_top") ? COMMENT_TOP : COMMENT_RIGHT;
+    hide_comment = Rime.getOption("_hide_comment");
+    if (hide_comment) {
+      comment_position = COMMENT_RIGHT;
+    } else {
+      comment_position = config.getInt("comment_position");
+      if (comment_position == COMMENT_UNKNOW) {
+        comment_position = config.getBoolean("comment_on_top") ? COMMENT_TOP : COMMENT_RIGHT;
+      }
     }
-
     textSize = config.getFloat("candidate_text_size");
 
     background =
@@ -132,8 +137,8 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
       if (textFont != null) itemViewHold.textView1.setTypeface(textFont);
 
       String text = candidates[index].text;
-      String comment = candidates[index].comment;
-      if (comment == null) comment = "";
+      String comment = "";
+      if (!hide_comment && candidates[index].comment != null) comment = candidates[index].comment;
 
       if (text.length() > 300) itemViewHold.textView1.setText(text.substring(0, 300));
       else itemViewHold.textView1.setText(text);

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
@@ -38,6 +38,8 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
   private Drawable background;
 
   private PositionType textPosition, commentPosition;
+  private static int COMMENT_UNKNOW = 0, COMMENT_TOP = 1, COMMENT_DOWN = 2, COMMENT_RIGHT = 3;
+  private static int comment_position;
 
   public CandidateAdapter(Context context) {
     myContext = context;
@@ -45,6 +47,7 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     prefs = AppPrefs.defaultInstance();
     candidates = new Rime.RimeCandidate[0];
     textInputManager = TextInputManager.Companion.getInstance();
+    comment_position = 0;
   }
 
   public int updateCandidates() {
@@ -74,6 +77,11 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     textColor = config.getLiquidColor("long_text_color");
     if (textColor == null) textColor = config.getLiquidColor("key_text_color");
 
+    comment_position = config.getInt("comment_position");
+    if (comment_position == COMMENT_UNKNOW) {
+      comment_position = config.getBoolean("comment_on_top") ? COMMENT_TOP : COMMENT_RIGHT;
+    }
+
     textSize = config.getFloat("candidate_text_size");
 
     background =
@@ -86,7 +94,19 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
   @NonNull
   @Override
   public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-    View view = LayoutInflater.from(myContext).inflate(R.layout.liquid_key_item, parent, false);
+    View view;
+    if (comment_position == COMMENT_DOWN) {
+      view = LayoutInflater.from(myContext).inflate(R.layout.liquid_key_item, parent, false);
+    } else if (comment_position == COMMENT_TOP) {
+      view =
+          LayoutInflater.from(myContext)
+              .inflate(R.layout.liquid_key_item_comment_top, parent, false);
+    } else {
+
+      view =
+          LayoutInflater.from(myContext)
+              .inflate(R.layout.liquid_key_item_comment_right, parent, false);
+    }
     return new ItemViewHolder(view);
   }
 
@@ -137,12 +157,12 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         if (keyMarginX > 0) marginX = keyMarginX;
 
         flexboxLp.setMargins(marginX, marginTop, marginX, flexboxLp.getMarginBottom());
+        flexboxLp.setFlexGrow(1);
 
         // TODO 设置剪贴板列表样式
         // copy SimpleAdapter 会造成高度始终为 3 行无法自适应的效果。
 
       }
-
       if (background != null)
         itemViewHold.listItemLayout.setBackground(
             Config.get(myContext)

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
@@ -20,7 +20,6 @@ import com.osfans.trime.data.Config;
 import com.osfans.trime.ime.core.Trime;
 import com.osfans.trime.ime.enums.PositionType;
 import com.osfans.trime.ime.text.TextInputManager;
-import timber.log.Timber;
 
 public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
   private final Context myContext;
@@ -174,15 +173,11 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                     null));
 
       // 如果设置了回调，则设置点击事件
-      {
+      if (mOnItemClickListener != null) {
         itemViewHold.listItemLayout.setOnClickListener(
             view -> {
-              int position = itemViewHold.getLayoutPosition();
-              Timber.d("Click " + position + "/" + getItemCount());
-              textInputManager.onCandidatePressed(index);
-              updateCandidates();
-              if (candidates.length < 1) Trime.getService().selectLiquidKeyboard(-1);
-              else notifyDataSetChanged();
+              int position = itemViewHold.getLayoutPosition(); // 在增加数据或者减少数据时候，position和index就不一样了
+              mOnItemClickListener.onItemClick(itemViewHold.listItemLayout, position);
             });
       }
 
@@ -208,4 +203,8 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
   }
 
   private OnItemClickListener mOnItemClickListener;
+
+  public void setOnItemClickListener(OnItemClickListener mOnItemClickListener) {
+    this.mOnItemClickListener = mOnItemClickListener;
+  }
 }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
@@ -1,0 +1,191 @@
+package com.osfans.trime.ime.symbol;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.android.flexbox.FlexboxLayoutManager;
+import com.osfans.trime.R;
+import com.osfans.trime.core.Rime;
+import com.osfans.trime.data.AppPrefs;
+import com.osfans.trime.data.Config;
+import com.osfans.trime.ime.core.Trime;
+import com.osfans.trime.ime.enums.PositionType;
+import com.osfans.trime.ime.text.TextInputManager;
+import timber.log.Timber;
+
+public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+  private final Context myContext;
+  private final TextInputManager textInputManager;
+
+  // 候选词
+  private Rime.RimeCandidate[] candidates;
+  private Trime trime;
+  private AppPrefs prefs;
+
+  private int keyMarginX, keyMarginTop;
+  private Integer textColor;
+  private float textSize;
+  private Typeface textFont;
+  private Drawable background;
+
+  private PositionType textPosition, commentPosition;
+
+  public CandidateAdapter(Context context) {
+    myContext = context;
+    trime = Trime.getService();
+    prefs = AppPrefs.defaultInstance();
+    candidates = new Rime.RimeCandidate[0];
+    textInputManager = TextInputManager.Companion.getInstance();
+  }
+
+  public int updateCandidates() {
+
+    candidates = Rime.getCandidatesWithoutSwitch();
+    //    highlightIndex = Rime.getCandHighlightIndex() - startNum;
+    if (candidates == null) {
+      candidates = new Rime.RimeCandidate[0];
+    }
+    synchronized (candidates) {
+      candidates.notify();
+    }
+    return candidates.length;
+  }
+
+  @Override
+  public int getItemCount() {
+    return candidates.length;
+  }
+
+  public void configStyle(int keyMarginX, int keyMarginTop) {
+    this.keyMarginX = keyMarginX;
+    this.keyMarginTop = keyMarginTop;
+
+    //  边框尺寸、圆角、字号直接读取主题通用参数。配色优先读取 liquidKeyboard 专用参数。
+    Config config = Config.get(myContext);
+    textColor = config.getLiquidColor("long_text_color");
+    if (textColor == null) textColor = config.getLiquidColor("key_text_color");
+
+    textSize = config.getFloat("candidate_text_size");
+
+    background =
+        config.getDrawable(
+            "long_text_back_color", "key_border", "key_long_text_border", "round_corner", null);
+
+    textFont = config.getFont("long_text_font");
+  }
+
+  @NonNull
+  @Override
+  public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+    View view = LayoutInflater.from(myContext).inflate(R.layout.liquid_key_item, parent, false);
+    return new ItemViewHolder(view);
+  }
+
+  private static class ItemViewHolder extends RecyclerView.ViewHolder {
+    public ItemViewHolder(View view) {
+      super(view);
+
+      listItemLayout = view.findViewById(R.id.listitem_layout);
+      textView1 = view.findViewById(R.id.text1);
+      textView2 = view.findViewById(R.id.text2);
+    }
+
+    ConstraintLayout listItemLayout;
+    TextView textView1, textView2;
+  }
+
+  @SuppressLint("ClickableViewAccessibility")
+  @Override
+  public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int index) {
+
+    if (viewHolder instanceof ItemViewHolder) {
+      final ItemViewHolder itemViewHold = ((ItemViewHolder) viewHolder);
+
+      if (textFont != null) itemViewHold.textView1.setTypeface(textFont);
+
+      String text = candidates[index].text;
+      String comment = candidates[index].comment;
+      if (comment == null) comment = "";
+
+      if (text.length() > 300) itemViewHold.textView1.setText(text.substring(0, 300));
+      else itemViewHold.textView1.setText(text);
+
+      if (comment.length() > 300) itemViewHold.textView2.setText(comment.substring(0, 300));
+      else itemViewHold.textView2.setText(comment);
+
+      if (textSize > 0) itemViewHold.textView1.setTextSize(textSize);
+
+      ViewGroup.LayoutParams lp = itemViewHold.listItemLayout.getLayoutParams();
+      if (lp instanceof FlexboxLayoutManager.LayoutParams) {
+        FlexboxLayoutManager.LayoutParams flexboxLp =
+            (FlexboxLayoutManager.LayoutParams) itemViewHold.listItemLayout.getLayoutParams();
+
+        itemViewHold.textView1.setTextColor(textColor);
+
+        int marginTop = flexboxLp.getMarginTop();
+        int marginX = flexboxLp.getMarginLeft();
+        if (keyMarginTop > 0) marginTop = keyMarginTop;
+        if (keyMarginX > 0) marginX = keyMarginX;
+
+        flexboxLp.setMargins(marginX, marginTop, marginX, flexboxLp.getMarginBottom());
+
+        // TODO 设置剪贴板列表样式
+        // copy SimpleAdapter 会造成高度始终为 3 行无法自适应的效果。
+
+      }
+
+      if (background != null)
+        itemViewHold.listItemLayout.setBackground(
+            Config.get(myContext)
+                .getDrawable(
+                    "long_text_back_color",
+                    "key_border",
+                    "key_long_text_border",
+                    "round_corner",
+                    null));
+
+      // 如果设置了回调，则设置点击事件
+      {
+        itemViewHold.listItemLayout.setOnClickListener(
+            view -> {
+              int position = itemViewHold.getLayoutPosition();
+              Timber.d("Click " + position + "/" + getItemCount());
+              textInputManager.onCandidatePressed(index);
+              updateCandidates();
+              if (candidates.length < 1) Trime.getService().selectLiquidKeyboard(-1);
+              else notifyDataSetChanged();
+            });
+      }
+
+      // TODO 剪贴板列表点击时产生背景变色效果
+      itemViewHold.listItemLayout.setOnTouchListener(
+          (view, motionEvent) -> {
+            int action = motionEvent.getAction();
+            switch (action) {
+              case MotionEvent.ACTION_DOWN:
+
+              case MotionEvent.ACTION_UP:
+              case MotionEvent.ACTION_CANCEL:
+                break;
+            }
+            return false;
+          });
+    }
+  }
+
+  /** 添加 OnItemClickListener 回调 * */
+  public interface OnItemClickListener {
+    void onItemClick(View view, int position);
+  }
+
+  private OnItemClickListener mOnItemClickListener;
+}

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -31,6 +31,7 @@ public class LiquidKeyboard {
   private ClipboardAdapter mClipboardAdapter;
   private DraftAdapter mDraftAdapter;
   private SimpleAdapter simpleAdapter;
+  private CandidateAdapter candidateAdapter;
   private List<SimpleKeyBean> clipboardBeanList, draftBeanList;
   private final List<SimpleKeyBean> simpleKeyBeans;
   private List<SimpleKeyBean> historyBeans;
@@ -91,6 +92,10 @@ public class LiquidKeyboard {
       case DRAFT:
         TabManager.get().select(i);
         initDraftData();
+        break;
+      case CANDIDATE:
+        TabManager.get().select(i);
+        initCandidate();
         break;
       case HISTORY:
       case TABS:
@@ -326,5 +331,34 @@ public class LiquidKeyboard {
             ic.commitText(draftBeanList.get(position).getText(), 1);
           }
         });
+  }
+
+  public void initCandidate() {
+    keyboardView.removeAllViews();
+    simpleAdapter = null;
+    mClipboardAdapter = null;
+    mDraftAdapter = null;
+
+    if (candidateAdapter == null) candidateAdapter = new CandidateAdapter(context);
+
+    // 设置布局管理器
+    FlexboxLayoutManager flexboxLayoutManager = new FlexboxLayoutManager(context);
+    // flexDirection 属性决定主轴的方向（即项目的排列方向）。类似 LinearLayout 的 vertical 和 horizontal。
+    flexboxLayoutManager.setFlexDirection(FlexDirection.ROW); // 主轴为水平方向，起点在左端。
+    // flexWrap 默认情况下 Flex 跟 LinearLayout 一样，都是不带换行排列的，但是flexWrap属性可以支持换行排列。
+    flexboxLayoutManager.setFlexWrap(FlexWrap.WRAP); // 按正常方向换行
+    // justifyContent 属性定义了项目在主轴上的对齐方式。
+    flexboxLayoutManager.setJustifyContent(JustifyContent.FLEX_START); // 交叉轴的起点对齐。
+    keyboardView.setLayoutManager(flexboxLayoutManager);
+
+    draft_max_size = Config.get(context).getDraftLimit();
+
+    draftBeanList = DraftDao.get().getAllSimpleBean(draft_max_size);
+    candidateAdapter.configStyle(margin_x, margin_top);
+
+    keyboardView.setAdapter(candidateAdapter);
+    keyboardView.setSelected(true);
+
+    candidateAdapter.updateCandidates();
   }
 }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -16,6 +16,7 @@ import com.osfans.trime.data.db.clipboard.ClipboardDao;
 import com.osfans.trime.data.db.draft.DraftDao;
 import com.osfans.trime.ime.core.Trime;
 import com.osfans.trime.ime.enums.SymbolKeyboardType;
+import com.osfans.trime.ime.text.TextInputManager;
 import com.osfans.trime.util.ConfigGetter;
 import java.io.File;
 import java.util.ArrayList;
@@ -358,7 +359,17 @@ public class LiquidKeyboard {
 
     keyboardView.setAdapter(candidateAdapter);
     keyboardView.setSelected(true);
-
     candidateAdapter.updateCandidates();
+
+    candidateAdapter.setOnItemClickListener(
+        (view, position) -> {
+          TextInputManager.Companion.getInstance().onCandidatePressed(position);
+          candidateAdapter.updateCandidates();
+          if (candidateAdapter.getItemCount() < 1) Trime.getService().selectLiquidKeyboard(-1);
+          else {
+            candidateAdapter.notifyDataSetChanged();
+            keyboardView.scrollToPosition(0);
+          }
+        });
   }
 }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -81,7 +81,7 @@ public class LiquidKeyboard {
     if (mDraftAdapter != null) mDraftAdapter.notifyItemInserted(0);
   }
 
-  public void select(int i) {
+  public SymbolKeyboardType select(int i) {
     TabTag tag = TabManager.getTag(i);
     calcPadding(tag.type);
     keyboardType = tag.type;
@@ -104,6 +104,7 @@ public class LiquidKeyboard {
       default:
         initFixData(i);
     }
+    return keyboardType;
   }
 
   // 设置liquidKeyboard共用的布局参数

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -10,6 +10,7 @@ import com.google.android.flexbox.FlexWrap;
 import com.google.android.flexbox.FlexboxLayoutManager;
 import com.google.android.flexbox.JustifyContent;
 import com.osfans.trime.R;
+import com.osfans.trime.core.Rime;
 import com.osfans.trime.data.Config;
 import com.osfans.trime.data.db.DbBean;
 import com.osfans.trime.data.db.clipboard.ClipboardDao;
@@ -365,12 +366,15 @@ public class LiquidKeyboard {
     candidateAdapter.setOnItemClickListener(
         (view, position) -> {
           TextInputManager.Companion.getInstance().onCandidatePressed(position);
-          candidateAdapter.updateCandidates();
-          if (candidateAdapter.getItemCount() < 1) Trime.getService().selectLiquidKeyboard(-1);
-          else {
-            candidateAdapter.notifyDataSetChanged();
-            keyboardView.scrollToPosition(0);
-          }
+          if (Rime.isComposing()) {
+            updateCandidates();
+          } else Trime.getService().selectLiquidKeyboard(-1);
         });
+  }
+
+  public void updateCandidates() {
+    candidateAdapter.updateCandidates();
+    candidateAdapter.notifyDataSetChanged();
+    keyboardView.scrollToPosition(0);
   }
 }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
@@ -53,6 +53,17 @@ public class TabManager {
     return 0;
   }
 
+  public static int getTagIndex(SymbolKeyboardType type) {
+    if (type == null) return 0;
+    for (int i = 0; i < self.tabTags.size(); i++) {
+      TabTag tag = self.tabTags.get(i);
+      if (tag.type.equals(type)) {
+        return i;
+      }
+    }
+    return 0;
+  }
+
   private TabManager() {
     selected = 0;
     tabTags = new ArrayList<>();

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
@@ -36,6 +36,7 @@ import androidx.annotation.Nullable;
 import com.osfans.trime.core.Rime;
 import com.osfans.trime.data.AppPrefs;
 import com.osfans.trime.data.Config;
+import com.osfans.trime.ime.core.Trime;
 import com.osfans.trime.util.GraphicUtils;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -275,6 +276,7 @@ public class Candidate extends View {
   }
 
   private void updateCandidateWidth() {
+    boolean hasExButton = false;
     Integer pageEx =
         Integer.parseInt(AppPrefs.defaultInstance().getKeyboard().getCandidatePageSize()) - 10000;
     int pageBottonWidth =
@@ -300,6 +302,7 @@ public class Candidate extends View {
                   PAGE_EX_BUTTON,
                   new Rect(x, 0, ((int) x + pageBottonWidth), getMeasuredHeight())));
           x += pageBottonWidth;
+          hasExButton = true;
           break;
         }
       }
@@ -324,6 +327,7 @@ public class Candidate extends View {
             new ComputedCandidate.Symbol(
                 PAGE_EX_BUTTON, new Rect(x, 0, ((int) x + pageBottonWidth), getMeasuredHeight())));
         x += pageBottonWidth;
+        hasExButton = true;
         break;
       }
 
@@ -353,6 +357,8 @@ public class Candidate extends View {
             ? candidateViewHeight + commentHeight
             : candidateViewHeight;
     setLayoutParams(params);
+
+    Trime.getService().setCandidateExPage(hasExButton);
   }
 
   @Override

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
@@ -306,12 +306,12 @@ public class Candidate extends View {
           break;
         }
       }
-
+      String comment = null, text = candidates[n].text;
       float candidateWidth =
-          graphicUtils.measureText(candidatePaint, candidates[n].text, candidateFont)
-              + 2 * candidatePadding;
+          graphicUtils.measureText(candidatePaint, text, candidateFont) + 2 * candidatePadding;
+
       if (shouldShowComment) {
-        String comment = candidates[n].comment;
+        comment = candidates[n].comment;
         if (!TextUtils.isEmpty(comment)) {
           float commentWidth = graphicUtils.measureText(commentPaint, comment, commentFont);
           candidateWidth =
@@ -333,9 +333,7 @@ public class Candidate extends View {
 
       computedCandidates.add(
           new ComputedCandidate.Word(
-              candidates[n].text,
-              candidates[n].comment,
-              new Rect(x, 0, (int) (x + candidateWidth), getMeasuredHeight())));
+              text, comment, new Rect(x, 0, (int) (x + candidateWidth), getMeasuredHeight())));
       x += candidateWidth + candidateSpacing;
     }
     if (Rime.hasLeft()) {

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
@@ -275,14 +275,17 @@ public class Candidate extends View {
   }
 
   private void updateCandidateWidth() {
-    boolean usePageExButton =
-        AppPrefs.defaultInstance().getKeyboard().getCandidatePageSize().equals("10000");
+    Integer pageEx =
+        Integer.parseInt(AppPrefs.defaultInstance().getKeyboard().getCandidatePageSize()) - 10000;
     int pageBottonWidth =
         (int)
             (candidateSpacing
                 + graphicUtils.measureText(symbolPaint, PAGE_DOWN_BUTTON, symbolFont)
                 + 2 * candidatePadding);
-    int minWidth = expectWidth - pageBottonWidth * 2;
+    int minWidth;
+    if (pageEx > 2) minWidth = (int) (expectWidth * (pageEx / 10f + 1) - pageBottonWidth);
+    else if (pageEx == 2) minWidth = (expectWidth - pageBottonWidth * 2);
+    else minWidth = expectWidth - pageBottonWidth;
 
     computedCandidates.clear();
     updateCandidates();
@@ -290,8 +293,8 @@ public class Candidate extends View {
     for (int i = 0; i < numCandidates; i++) {
       int n = i + startNum;
 
-      if (usePageExButton) {
-        if (x > minWidth) {
+      if (pageEx >= 0) {
+        if (x >= minWidth) {
           computedCandidates.add(
               new ComputedCandidate.Symbol(
                   PAGE_EX_BUTTON,
@@ -314,6 +317,16 @@ public class Candidate extends View {
                   : candidateWidth + commentWidth;
         }
       }
+
+      // 自动填满候选栏，并保障展开候选按钮显示出来
+      if (pageEx == 0 && x + candidateWidth + candidateSpacing > minWidth) {
+        computedCandidates.add(
+            new ComputedCandidate.Symbol(
+                PAGE_EX_BUTTON, new Rect(x, 0, ((int) x + pageBottonWidth), getMeasuredHeight())));
+        x += pageBottonWidth;
+        break;
+      }
+
       computedCandidates.add(
           new ComputedCandidate.Word(
               candidates[n].text,

--- a/app/src/main/java/com/osfans/trime/ime/text/Composition.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Composition.java
@@ -512,7 +512,26 @@ public class Composition extends AppCompatTextView {
     if (!TextUtils.isEmpty(sep)) ss.append(sep);
   }
 
-  public int setWindow(int length, int min_check) {
+  /**
+   * 设置悬浮窗文本
+   *
+   * @param charLength 候选词长度大于设定，才会显示到悬浮窗中
+   * @param minCheck 检查至少多少个候选词。当首选词长度不足时，继续检查后方候选词
+   * @param maxPopup 最多在悬浮窗显示多少个候选词
+   * @return 悬浮窗显示的候选词数量
+   */
+  public int setWindow(int charLength, int minCheck, int maxPopup) {
+    return setWindow(charLength, minCheck);
+  }
+
+  /**
+   * 设置悬浮窗文本
+   *
+   * @param stringMinLength 候选词长度大于设定，才会显示到悬浮窗中
+   * @param candidateMinCheck 检查至少多少个候选词。当首选词长度不足时，继续检查后方候选词
+   * @return 悬浮窗显示的候选词数量
+   */
+  public int setWindow(int stringMinLength, int candidateMinCheck) {
     if (getVisibility() != View.VISIBLE) return 0;
     StackTraceElement[] stacks = new Throwable().getStackTrace();
     Timber.d(
@@ -534,9 +553,11 @@ public class Composition extends AppCompatTextView {
     for (Map<String, ?> m : windows_comps) {
       if (m.containsKey("composition")) appendComposition(m);
       else if (m.containsKey("candidate")) {
-        start_num = calcStartNum(length, min_check);
-        Timber.d("start_num = %s, min_length = %s, min_check = %s", start_num, length, min_check);
-        appendCandidates(m, length, start_num);
+        start_num = calcStartNum(stringMinLength, candidateMinCheck);
+        Timber.d(
+            "start_num = %s, min_length = %s, min_check = %s",
+            start_num, stringMinLength, candidateMinCheck);
+        appendCandidates(m, stringMinLength, start_num);
       } else if (m.containsKey("click")) appendButton(m);
       else if (m.containsKey("move")) appendMove(m);
     }

--- a/app/src/main/java/com/osfans/trime/ime/text/Composition.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Composition.java
@@ -64,7 +64,7 @@ public class Composition extends AppCompatTextView {
   private int max_entries = Candidate.getMaxCandidateCount();
   private boolean candidate_use_cursor, show_comment;
   private int highlightIndex;
-  private List<Map<String, Object>> components;
+  private List<Map<String, Object>> windows_comps;
   private SpannableStringBuilder ss;
   private final int span = 0;
   private String movable;
@@ -212,7 +212,7 @@ public class Composition extends AppCompatTextView {
 
   public void reset(Context context) {
     final Config config = Config.get(context);
-    components = (List<Map<String, Object>>) config.getValue("window");
+    windows_comps = (List<Map<String, Object>>) config.getValue("window");
     if (config.hasKey("layout/max_entries")) max_entries = config.getInt("layout/max_entries");
     candidate_use_cursor = config.getBoolean("candidate_use_cursor");
     text_size = config.getPixel("text_size");
@@ -331,9 +331,11 @@ public class Composition extends AppCompatTextView {
    * @return j
    */
   private int calcStartNum(int min_length, int min_check) {
+    Timber.d("setWindow calcStartNum() getCandidates");
     final Rime.RimeCandidate[] candidates = Rime.getCandidates();
     if (candidates == null) return 0;
 
+    Timber.d("setWindow calcStartNum() getCandidates finish, size=" + candidates.length);
     int j = min_check > max_entries ? (max_entries - 1) : (min_check - 1);
     if (j >= candidates.length) j = candidates.length - 1;
     for (; j >= 0; j--) {
@@ -512,6 +514,15 @@ public class Composition extends AppCompatTextView {
 
   public int setWindow(int length, int min_check) {
     if (getVisibility() != View.VISIBLE) return 0;
+    StackTraceElement[] stacks = new Throwable().getStackTrace();
+    Timber.d(
+        "setWindow Rime.getComposition()"
+            + ", [1]"
+            + stacks[1].toString()
+            + ", [2]"
+            + stacks[2].toString()
+            + ", [3]"
+            + stacks[3].toString());
     Rime.RimeComposition r = Rime.getComposition();
     if (r == null) return 0;
     String s = r.getText();
@@ -519,7 +530,8 @@ public class Composition extends AppCompatTextView {
     setSingleLine(true); // 設置單行
     ss = new SpannableStringBuilder();
     int start_num = 0;
-    for (Map<String, ?> m : components) {
+
+    for (Map<String, ?> m : windows_comps) {
       if (m.containsKey("composition")) appendComposition(m);
       else if (m.containsKey("candidate")) {
         start_num = calcStartNum(length, min_check);

--- a/app/src/main/java/com/osfans/trime/ime/text/Composition.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Composition.java
@@ -19,7 +19,6 @@
 package com.osfans.trime.ime.text;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -146,7 +145,6 @@ public class Composition extends AppCompatTextView {
     }
   }
 
-  @TargetApi(21)
   public static class LetterSpacingSpan extends UnderlineSpan {
     private final float letterSpacing;
 

--- a/app/src/main/java/com/osfans/trime/ime/text/ScrollView.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/ScrollView.java
@@ -10,6 +10,7 @@ import android.view.animation.TranslateAnimation;
 import android.widget.HorizontalScrollView;
 import androidx.annotation.NonNull;
 import com.osfans.trime.core.Rime;
+import com.osfans.trime.ime.core.Trime;
 import timber.log.Timber;
 
 public class ScrollView extends HorizontalScrollView {
@@ -20,15 +21,16 @@ public class ScrollView extends HorizontalScrollView {
   private boolean isMoving = false;
   private int left;
 
-  private Runnable pageDownAction, pageUpAction;
+  private Runnable pageDownAction, pageUpAction, pageExAction;
 
   public ScrollView(Context context, AttributeSet attrs) {
     super(context, attrs);
   }
 
-  public void setPageStr(Runnable pageDownAction, Runnable pageUpAction) {
+  public void setPageStr(Runnable pageDownAction, Runnable pageUpAction, Runnable pageExAction) {
     this.pageDownAction = pageDownAction;
     this.pageUpAction = pageUpAction;
+    this.pageExAction = pageExAction;
   }
 
   /**
@@ -94,6 +96,9 @@ public class ScrollView extends HorizontalScrollView {
           if (pageUpAction != null) pageUpAction.run();
           if (inner.getWidth() > this.getWidth())
             scrollTo(this.getWidth() - inner.getWidth() + 400, 0);
+        } else if (inner.getWidth() - inner.getRight() > 100
+            && Trime.getService().hasCandidateExPage()) {
+          if (pageExAction != null) pageExAction.run();
         } else if (inner.getWidth() - inner.getRight() > 100 && Rime.hasRight()) {
           if (pageDownAction != null) pageDownAction.run();
           if (inner.getWidth() > this.getWidth()) {

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -14,6 +14,7 @@ import com.osfans.trime.ime.core.EditorInstance
 import com.osfans.trime.ime.core.Speech
 import com.osfans.trime.ime.core.Trime
 import com.osfans.trime.ime.enums.Keycode
+import com.osfans.trime.ime.enums.SymbolKeyboardType
 import com.osfans.trime.ime.keyboard.Event
 import com.osfans.trime.ime.keyboard.Keyboard.printModifierKeyState
 import com.osfans.trime.ime.keyboard.KeyboardSwitcher
@@ -446,9 +447,11 @@ class TextInputManager private constructor() :
             }
         } else if (prefs.keyboard.hookCandidate || index > 9) {
             if (Rime.selectCandidate(index)) {
-                if (prefs.keyboard.hookCandidateCommit)
-                    trime.handleKey(KeyEvent.KEYCODE_SPACE, 0)
-                else
+                if (prefs.keyboard.hookCandidateCommit) {
+                    // todo 找到切换高亮候选词的API，并把此处改为模拟移动候选后发送空格
+                    // 如果使用了lua处理候选上屏，模拟数字键、空格键是非常有必要的
+                    activeEditorInstance.commitRimeText()
+                } else
                     activeEditorInstance.commitRimeText()
             }
         } else if (index == 9) {
@@ -462,6 +465,7 @@ class TextInputManager private constructor() :
         when (arrow) {
             Candidate.PAGE_UP_BUTTON -> onKey(KeyEvent.KEYCODE_PAGE_UP, 0)
             Candidate.PAGE_DOWN_BUTTON -> onKey(KeyEvent.KEYCODE_PAGE_DOWN, 0)
+            Candidate.PAGE_EX_BUTTON -> Trime.getService().selectLiquidKeyboard(SymbolKeyboardType.CANDIDATE)
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -146,7 +146,8 @@ class TextInputManager private constructor() :
         candidateRoot = uiBinding.main.candidateView.candidateRoot.also {
             it.setPageStr(
                 Runnable { trime.handleKey(KeyEvent.KEYCODE_PAGE_DOWN, 0) },
-                Runnable { trime.handleKey(KeyEvent.KEYCODE_PAGE_UP, 0) }
+                Runnable { trime.handleKey(KeyEvent.KEYCODE_PAGE_UP, 0) },
+                Runnable { trime.selectLiquidKeyboard(SymbolKeyboardType.CANDIDATE) }
             )
             it.visibility = if (Rime.getOption("_hide_candidate")) View.GONE else View.VISIBLE
         }

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -446,7 +446,10 @@ class TextInputManager private constructor() :
             }
         } else if (prefs.keyboard.hookCandidate || index > 9) {
             if (Rime.selectCandidate(index)) {
-                activeEditorInstance.commitRimeText()
+                if (prefs.keyboard.hookCandidateCommit)
+                    trime.handleKey(KeyEvent.KEYCODE_SPACE, 0)
+                else
+                    activeEditorInstance.commitRimeText()
             }
         } else if (index == 9) {
             trime.handleKey(KeyEvent.KEYCODE_0, 0)

--- a/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/settings/fragments/KeyboardFragment.kt
@@ -45,6 +45,9 @@ class KeyboardFragment :
             "keyboard__show_switches" -> {
                 Rime.setShowSwitches(prefs.keyboard.switchesEnabled)
             }
+            "keyboard__candidate_page_size" -> {
+                Rime.applySchemaChange()
+            }
         }
     }
     override fun onPreferenceTreeClick(preference: Preference?): Boolean {

--- a/app/src/main/res/layout/liquid_key_item.xml
+++ b/app/src/main/res/layout/liquid_key_item.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/listitem_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="2dp"
+    android:layout_marginTop="6dp"
+    android:layout_marginRight="2dp"
+    android:padding="5dp"
+    tools:ignore="MissingDefaultResource">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:ellipsize="end"
+        android:maxLines="3"
+        android:textColor="#333333"
+        android:textSize="14sp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        app:layout_constraintLeft_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="parent"
+        android:ellipsize="end"
+        android:maxLines="3"
+        android:textColor="#333333"
+        android:textSize="14sp" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/liquid_key_item.xml
+++ b/app/src/main/res/layout/liquid_key_item.xml
@@ -12,7 +12,7 @@
     tools:ignore="MissingDefaultResource">
 
     <TextView
-        android:id="@+id/text1"
+        android:id="@+id/text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
@@ -26,7 +26,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/text2"
+        android:id="@+id/comment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
@@ -37,5 +37,5 @@
         android:textSize="12sp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text1" />
+        app:layout_constraintTop_toBottomOf="@id/text" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/liquid_key_item_comment_right.xml
+++ b/app/src/main/res/layout/liquid_key_item_comment_right.xml
@@ -22,7 +22,6 @@
         android:textColor="#333333"
         android:textSize="14sp"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
@@ -35,7 +34,6 @@
         android:text="Comment"
         android:textColor="#333333"
         android:textSize="12sp"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text1" />
+        app:layout_constraintLeft_toRightOf="@id/text1"
+        app:layout_constraintBottom_toBottomOf="@id/text1" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/liquid_key_item_comment_right.xml
+++ b/app/src/main/res/layout/liquid_key_item_comment_right.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/listitem_layout"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -12,20 +12,22 @@
     tools:ignore="MissingDefaultResource">
 
     <TextView
-        android:id="@+id/text1"
+        android:id="@+id/text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        app:layout_goneMarginRight="0dp"
         android:ellipsize="end"
         android:maxLines="3"
         android:text="Candidate"
         android:textColor="#333333"
         android:textSize="14sp"
-        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/comment"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/text2"
+        android:id="@+id/comment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
@@ -34,6 +36,8 @@
         android:text="Comment"
         android:textColor="#333333"
         android:textSize="12sp"
-        app:layout_constraintLeft_toRightOf="@id/text1"
-        app:layout_constraintBottom_toBottomOf="@id/text1" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toEndOf="@id/text"
+        app:layout_constraintBottom_toBottomOf="@id/text" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/liquid_key_item_comment_top.xml
+++ b/app/src/main/res/layout/liquid_key_item_comment_top.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:tools="http://schemas.android.com/tools"
+xmlns:app="http://schemas.android.com/apk/res-auto"
+android:id="@+id/listitem_layout"
+android:layout_width="wrap_content"
+android:layout_height="wrap_content"
+android:layout_marginLeft="2dp"
+android:layout_marginTop="6dp"
+android:layout_marginRight="2dp"
+android:padding="5dp"
+tools:ignore="MissingDefaultResource">
+
+<TextView
+    android:id="@+id/text2"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:ellipsize="end"
+    android:maxLines="3"
+    android:text="Candidate"
+    android:textColor="#333333"
+    android:textSize="14sp"
+    app:layout_constraintRight_toRightOf="parent"
+    app:layout_constraintLeft_toLeftOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
+<TextView
+    android:id="@+id/text1"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:ellipsize="end"
+    android:maxLines="3"
+    android:text="Comment"
+    android:textColor="#333333"
+    android:textSize="12sp"
+    app:layout_constraintRight_toRightOf="parent"
+    app:layout_constraintLeft_toLeftOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/text2" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/liquid_key_item_comment_top.xml
+++ b/app/src/main/res/layout/liquid_key_item_comment_top.xml
@@ -12,7 +12,7 @@ android:padding="5dp"
 tools:ignore="MissingDefaultResource">
 
 <TextView
-    android:id="@+id/text2"
+    android:id="@+id/comment"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
@@ -26,7 +26,7 @@ tools:ignore="MissingDefaultResource">
     app:layout_constraintTop_toTopOf="parent" />
 
 <TextView
-    android:id="@+id/text1"
+    android:id="@+id/text"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
@@ -37,5 +37,5 @@ tools:ignore="MissingDefaultResource">
     android:textSize="12sp"
     app:layout_constraintRight_toRightOf="parent"
     app:layout_constraintLeft_toLeftOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/text2" />
+    app:layout_constraintTop_toBottomOf="@id/comment" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -129,7 +129,7 @@
         <item name="1000">1000</item>
         <item name="-1">全部</item>
     </string-array>
-    <string name="keyboard__show_switche_arrow_title">候选栏上的开关显示箭头符号(→)</string>
+    <string name="keyboard__show_switche_arrow_title">为开关显示箭头符号(→)</string>
     <string name="keyboard__fullscreen_mode_title">横屏时全屏编辑</string>
     <string name="deploy_finish">部署完成</string>
     <string-array name="keyboard__fullscreen_mode_entries">
@@ -155,7 +155,7 @@
     <string name="pref__system_default">系统默认</string>
     <string name="keyboard__key_swipe_travel_title">触发按键滑动手势的距离</string>
     <string name="keyboard__hook_candidate">点击候选词</string>
-    <string name="keyboard__hook_candidate_commit">点击候选词后，模拟空格键完成上屏</string>
+    <string name="keyboard__hook_candidate_commit">点击候选词后，模拟空格键完成上屏(暂未实现)</string>
     <string name="trime_app_slogan">击响中文之韵</string>
     <string name="external_storage_access_required">同文输入法需要存储权限以部署或读取方案和配置，点击“确定”前往授权。</string>
     <string name="external_storage_permission_not_available">存储权限不可用</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -203,7 +203,12 @@
     <string name="pref_keyboard__candidate">候选栏</string>
     <string name="keyboard__candidate_page_size">每页显示候选词数量</string>
     <string-array name="keyboard__candidate_page_size_entries" >
-        <item name="10000">自动填满候选栏</item>
+        <item name="10000">不超出候选栏</item>
+        <item name="10001">接近于候选栏</item>
+        <item name="10002">略多于候选栏</item>
+        <item name="10005">1.5倍候选栏宽度</item>
+        <item name="10010">2倍候选栏宽度</item>
+        <item name="10020">3倍候选栏宽度</item>
         <item name="0">由方案指定(需删除build目录中的方案并重新部署)</item>
         <item name="5">5</item>
         <item name="6">6</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -155,6 +155,7 @@
     <string name="pref__system_default">系统默认</string>
     <string name="keyboard__key_swipe_travel_title">触发按键滑动手势的距离</string>
     <string name="keyboard__hook_candidate">点击候选词</string>
+    <string name="keyboard__hook_candidate_commit">点击候选词后，模拟空格键完成上屏</string>
     <string name="trime_app_slogan">击响中文之韵</string>
     <string name="external_storage_access_required">同文输入法需要存储权限以部署或读取方案和配置，点击“确定”前往授权。</string>
     <string name="external_storage_permission_not_available">存储权限不可用</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -65,7 +65,7 @@
     <string name="keyboard__key_repeat_interval_title">重复按键的重复间隔</string>
     <string name="keyboard__show_switches_title">在候选栏中显示状态</string>
     <string name="keyboard__show_key_popup_title">按键时弹出显示字符</string>
-    <string name="keyboard__show_window_title">显示悬浮窗口</string>
+    <string name="keyboard__show_window_title">显示悬浮窗</string>
     <string name="keyboard__inline_preedit_title">嵌入式编辑模式</string>
     <string-array name="keyboard__inline_entries">
         <item>首选</item>
@@ -78,7 +78,7 @@
         <item name="light">亮色</item>
         <item name="dark">暗色</item>
     </string-array>
-    <string name="keyboard__soft_cursor_title">编码区使用插入符号(^)</string>
+    <string name="keyboard__soft_cursor_title">悬浮窗编码区使用插入符号(^)</string>
     <string name="pref_deploy">部署</string>
     <string name="pref_deploy_summary">修改设置后需要再次部署同文输入法平台</string>
     <string name="conf__synchronize_title">同步</string>
@@ -129,7 +129,7 @@
         <item name="1000">1000</item>
         <item name="-1">全部</item>
     </string-array>
-    <string name="keyboard__show_switche_arrow_title">在候选栏中显示状态时带箭头符号</string>
+    <string name="keyboard__show_switche_arrow_title">候选栏上的开关显示箭头符号(→)</string>
     <string name="keyboard__fullscreen_mode_title">横屏时全屏编辑</string>
     <string name="deploy_finish">部署完成</string>
     <string-array name="keyboard__fullscreen_mode_entries">
@@ -198,4 +198,24 @@
     <string name="keyboard__key_swipe_velocity_hi">连续击键时触发滑动手势的速度</string>
     <string name="about__buildinfo">编译信息</string>
     <string name="pref_trime_custom_qq">修改版QQ群</string>
+    <string name="keyboard__use_mini_keyboard_title">连接实体键盘时，显示迷你软键盘</string>
+    <string name="pref_keyboard__candidate">候选栏</string>
+    <string name="keyboard__candidate_page_size">每页显示候选词数量</string>
+    <string-array name="keyboard__candidate_page_size_entries" >
+        <item name="10000">自动填满候选栏</item>
+        <item name="0">由方案指定(需删除build目录中的方案并重新部署)</item>
+        <item name="5">5</item>
+        <item name="6">6</item>
+        <item name="7">7</item>
+        <item name="8">8</item>
+        <item name="9">9</item>
+        <item name="10">10</item>
+        <item name="11">11</item>
+        <item name="12">12</item>
+        <item name="15">15</item>
+        <item name="20">20</item>
+        <item name="30">30</item>
+        <item name="50">50</item>
+        <item name="100">100</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -130,7 +130,7 @@
         <item name="1000">1000</item>
         <item name="-1">全部</item>
     </string-array>
-    <string name="keyboard__show_switche_arrow_title">候選欄上的開關顯示箭頭符號(→)</string>
+    <string name="keyboard__show_switche_arrow_title">爲開關顯示箭頭符號(→)</string>
     <string name="keyboard__fullscreen_mode_title">橫屏時全屏編輯</string>
     <string name="deploy_finish">部署完成</string>
     <string-array name="keyboard__fullscreen_mode_entries">
@@ -156,7 +156,7 @@
     <string name="pref__system_default">系統預設</string>
     <string name="keyboard__key_swipe_travel_title">觸發滑動手勢的最短距離</string>
     <string name="keyboard__hook_candidate">點擊候選詞</string>
-    <string name="keyboard__hook_candidate_commit">點擊候選詞後，模擬空格鍵完成上屏</string>
+    <string name="keyboard__hook_candidate_commit">點擊候選詞後，模擬空格鍵完成上屏(暫未實現)</string>
     <string name="trime_app_slogan">擊響中文之韻</string>
     <string name="external_storage_access_required">同文輸入法需要儲存許可權以部署或讀取方案和配置，點選“確定”前往授權。</string>
     <string name="external_storage_permission_not_available">儲存許可權不可用</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -204,7 +204,12 @@
     <string name="pref_keyboard__candidate">候選欄</string>
     <string name="keyboard__candidate_page_size">每頁顯示候選詞數量</string>
     <string-array name="keyboard__candidate_page_size_entries" >
-        <item name="10000">自動填滿候選欄</item>
+        <item name="10000">不超出候選欄</item>
+        <item name="10001">接近於候選欄</item>
+        <item name="10002">略多於候選欄</item>
+        <item name="10005">1.5倍候選欄寬度</item>
+        <item name="10010">2倍候選欄寬度</item>
+        <item name="10020">3倍候選欄寬度</item>
         <item name="0">由方案指定(需刪除build目錄中的方案並重新部署)</item>
         <item name="5">5</item>
         <item name="6">6</item>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -156,6 +156,7 @@
     <string name="pref__system_default">系統預設</string>
     <string name="keyboard__key_swipe_travel_title">觸發滑動手勢的最短距離</string>
     <string name="keyboard__hook_candidate">點擊候選詞</string>
+    <string name="keyboard__hook_candidate_commit">點擊候選詞後，模擬空格鍵完成上屏</string>
     <string name="trime_app_slogan">擊響中文之韻</string>
     <string name="external_storage_access_required">同文輸入法需要儲存許可權以部署或讀取方案和配置，點選“確定”前往授權。</string>
     <string name="external_storage_permission_not_available">儲存許可權不可用</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -66,7 +66,7 @@
     <string name="keyboard__key_repeat_interval_title">重複按鍵的重複間隔</string>
     <string name="keyboard__show_switches_title">在候選欄中顯示狀態</string>
     <string name="keyboard__show_key_popup_title">按鍵時彈出顯示字符</string>
-    <string name="keyboard__show_window_title">顯示懸浮窗口</string>
+    <string name="keyboard__show_window_title">顯示懸浮窗</string>
     <string name="keyboard__inline_preedit_title">嵌入式編輯模式</string>
     <string-array name="keyboard__inline_entries">
         <item>首選</item>
@@ -79,7 +79,7 @@
         <item name="light">亮色</item>
         <item name="dark">暗色</item>
     </string-array>
-    <string name="keyboard__soft_cursor_title">編碼區使用插入符號(^)</string>
+    <string name="keyboard__soft_cursor_title">懸浮窗編碼區使用插入符號(^)</string>
     <string name="pref_deploy">部署</string>
     <string name="pref_deploy_summary">修改設定後需要再次部署同文輸入法平臺</string>
     <string name="conf__synchronize_title">同步</string>
@@ -130,7 +130,7 @@
         <item name="1000">1000</item>
         <item name="-1">全部</item>
     </string-array>
-    <string name="keyboard__show_switche_arrow_title">在候選欄中顯示狀態時帶箭頭符號</string>
+    <string name="keyboard__show_switche_arrow_title">候選欄上的開關顯示箭頭符號(→)</string>
     <string name="keyboard__fullscreen_mode_title">橫屏時全屏編輯</string>
     <string name="deploy_finish">部署完成</string>
     <string-array name="keyboard__fullscreen_mode_entries">
@@ -199,4 +199,24 @@
     <string name="keyboard__key_swipe_velocity_hi">連續擊鍵時觸發滑動手勢的速度</string>
     <string name="about__buildinfo">編譯信息</string>
     <string name="pref_trime_custom_qq">修改版QQ羣</string>
+    <string name="keyboard__use_mini_keyboard_title">連接實體鍵盤時，顯示迷你軟鍵盤</string>
+    <string name="pref_keyboard__candidate">候選欄</string>
+    <string name="keyboard__candidate_page_size">每頁顯示候選詞數量</string>
+    <string-array name="keyboard__candidate_page_size_entries" >
+        <item name="10000">自動填滿候選欄</item>
+        <item name="0">由方案指定(需刪除build目錄中的方案並重新部署)</item>
+        <item name="5">5</item>
+        <item name="6">6</item>
+        <item name="7">7</item>
+        <item name="8">8</item>
+        <item name="9">9</item>
+        <item name="10">10</item>
+        <item name="11">11</item>
+        <item name="12">12</item>
+        <item name="15">15</item>
+        <item name="20">20</item>
+        <item name="30">30</item>
+        <item name="50">50</item>
+        <item name="100">100</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -53,6 +53,10 @@
     <string name="conf__default_user_data_dir" translatable="false">/sdcard/rime</string>
     <string-array name="keyboard__candidate_page_size_values">
         <item>10000</item>
+        <item>10001</item>
+        <item>10005</item>
+        <item>10010</item>
+        <item>10020</item>
         <item>0</item>
         <item>5</item>
         <item>6</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -51,4 +51,21 @@
     </string-array>
     <string name="default_shared_data_dir" translatable="false">/sdcard/rime</string>
     <string name="conf__default_user_data_dir" translatable="false">/sdcard/rime</string>
+    <string-array name="keyboard__candidate_page_size_values">
+        <item>10000</item>
+        <item>0</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>15</item>
+        <item>20</item>
+        <item>30</item>
+        <item>50</item>
+        <item>100</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
         <item name="1000">1000</item>
         <item name="-1">All</item>
     </string-array>
-    <string name="keyboard__show_switche_arrow_title">Show arrow for candidate switch (→)</string>
+    <string name="keyboard__show_switche_arrow_title">Show arrow for switch (→)</string>
     <string name="keyboard__fullscreen_mode_title">Landscape fullscreen input</string>
     <string name="deploy_finish">Deploy finish</string>
     <string-array name="keyboard__fullscreen_mode_entries">
@@ -156,7 +156,7 @@
     <string name="pref__system_default">System Default</string>
     <string name="keyboard__key_swipe_travel_title">Min travel for gesture</string>
     <string name="keyboard__hook_candidate">Click candidate</string>
-    <string name="keyboard__hook_candidate_commit">Send Space when click candidate</string>
+    <string name="keyboard__hook_candidate_commit">Send Space when click candidate (coming soon)</string>
     <string name="trime_app_slogan">Trimes with Your Keystrokes</string>
     <string name="external_storage_access_required">Trime needs to access external storage to deploy or read schemas and config, tap OK to grant the permission.</string>
     <string name="external_storage_permission_not_available">External storage permission is not available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,7 +206,12 @@
     <string name="pref_keyboard__candidate">Candidate</string>
     <string name="keyboard__candidate_page_size">Candidate item count for each page</string>
     <string-array name="keyboard__candidate_page_size_entries" >
-        <item name="10000">Fill candidate</item>
+        <item name="10000">Less than candidate</item>
+        <item name="10001">close to candidate</item>
+        <item name="10002">More than candidate</item>
+        <item name="10005">1.5x candidate width</item>
+        <item name="10010">2x candidate width</item>
+        <item name="10020">3x candidate width</item>
         <item name="0">Scheme define (Need delete scheme in build path and depoly)</item>
         <item name="5">5</item>
         <item name="6">6</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,10 +153,10 @@
     <string name="about__support">Support</string>
     <string name="about__used_libraries">Third Party Open Source Libraries</string>
     <string name="about__used_library_dialog_title">Trime | Open Source Libraries</string>
-    <string name="other__selection_sense_title">Use Ctrl+Left/Right to move the cursor</string>
     <string name="pref__system_default">System Default</string>
     <string name="keyboard__key_swipe_travel_title">Min travel for gesture</string>
     <string name="keyboard__hook_candidate">Click candidate</string>
+    <string name="keyboard__hook_candidate_commit">Send Space when click candidate</string>
     <string name="trime_app_slogan">Trimes with Your Keystrokes</string>
     <string name="external_storage_access_required">Trime needs to access external storage to deploy or read schemas and config, tap OK to grant the permission.</string>
     <string name="external_storage_permission_not_available">External storage permission is not available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
         <item name="1000">1000</item>
         <item name="-1">All</item>
     </string-array>
-    <string name="keyboard__show_switche_arrow_title">Show arrow for candidate switch</string>
+    <string name="keyboard__show_switche_arrow_title">Show arrow for candidate switch (→)</string>
     <string name="keyboard__fullscreen_mode_title">Landscape fullscreen input</string>
     <string name="deploy_finish">Deploy finish</string>
     <string-array name="keyboard__fullscreen_mode_entries">
@@ -202,4 +202,24 @@
     <string name="pref_trime_custom_qq">Custom QQ Group</string>
     <string name="pref_trime_custom_qq_summary" translatable="false"> </string>
     <string name="pref_trime_custom_qq_data" translatable="false"> </string>
+    <string name="keyboard__use_mini_keyboard_title">Show mini keyboard when real keyboard linked</string>
+    <string name="pref_keyboard__candidate">Candidate</string>
+    <string name="keyboard__candidate_page_size">Candidate item count for each page</string>
+    <string-array name="keyboard__candidate_page_size_entries" >
+        <item name="10000">Fill candidate</item>
+        <item name="0">Scheme define (Need delete scheme in build path and depoly)</item>
+        <item name="5">5</item>
+        <item name="6">6</item>
+        <item name="7">7</item>
+        <item name="8">8</item>
+        <item name="9">9</item>
+        <item name="10">10</item>
+        <item name="11">11</item>
+        <item name="12">12</item>
+        <item name="15">15</item>
+        <item name="20">20</item>
+        <item name="30">30</item>
+        <item name="50">50</item>
+        <item name="100">100</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -6,7 +6,6 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
-        app:key="settings__keyboard_function"
         app:title="@string/pref_keyboard__function">
         <ListPreference
             android:defaultValue="preview"
@@ -25,20 +24,26 @@
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
         <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="keyboard__soft_cursor"
-            android:title="@string/keyboard__soft_cursor_title"
+            android:defaultValue="false"
+            android:key="keyboard__show_key_popup"
+            android:title="@string/keyboard__show_key_popup_title"
             app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="@string/pref_keyboard__candidate">
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="keyboard__show_window"
             android:title="@string/keyboard__show_window_title"
             app:iconSpaceReserved="false" />
         <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="keyboard__show_key_popup"
-            android:title="@string/keyboard__show_key_popup_title"
+            android:defaultValue="true"
+            android:key="keyboard__soft_cursor"
+            android:title="@string/keyboard__soft_cursor_title"
             app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="keyboard__show_switches"
@@ -49,7 +54,17 @@
             android:key="keyboard__show_switch_arrow"
             android:title="@string/keyboard__show_switche_arrow_title"
             app:iconSpaceReserved="false" />
+
+        <ListPreference
+            android:defaultValue="0"
+            android:entries="@array/keyboard__candidate_page_size_entries"
+            android:entryValues="@array/keyboard__candidate_page_size_values"
+            android:key="keyboard__candidate_page_size"
+            android:title="@string/keyboard__candidate_page_size"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
+
     <PreferenceCategory
         app:iconSpaceReserved="false"
         app:key="settings__keyboard_hook"

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -85,6 +85,11 @@
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
+            android:key="@string/keyboard__hook_candidate_commit"
+            android:title="@string/keyboard__hook_candidate_commit"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
             android:key="keyboard__hook_ctrl_lr"
             android:title="@string/keyboard__hook_ctrl_lr"
             app:iconSpaceReserved="false" />

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -85,7 +85,7 @@
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
-            android:key="@string/keyboard__hook_candidate_commit"
+            android:key="keyboard__hook_candidate_commit"
             android:title="@string/keyboard__hook_candidate_commit"
             app:iconSpaceReserved="false" />
 


### PR DESCRIPTION
## Pull request
1. 调整设置界面-偏好设置的分组，增加“候选栏”分组并移动部分选项
2. 在设置中增加“每页显示候选词数量”的选项
3. “每页显示候选词数量”的选项除固定数量外，包含6种动态填满候选栏的算法：不超出候选栏、接近于候选栏、略多于候选栏、1.5x / 2x / 3x，此六种算法不使用翻页键，而是使用在liquidKeyboard中展开候选选项的设计。
4. 在liquidKeyboard中增加类型”候选“，打字后可以切换到liquidKeyboard展开候选选项选字（需修改主题，默认主题已经修改；需要设置候选词数量为”自动填满候选栏“来启用）。
5. （如果选择动态填满候选栏的算法）候选栏滑动到末尾后，自动展开候选
6. 在主题style/comment_position中可以指定liquidKeyboard中的候选的comment显示的位置， 1顶部,  2底部,  3右侧（暂定，后续需要考虑使用设置界面设置，而不是主题）
7. 修复_hide_comment开关未能完全生效的问题
8. 切换到非candidate类型的liquidKeyboard时，隐藏悬浮窗

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
9. Manual build and test pass
10. GitHub action ci pass
11. At least one contributor reviews and votes
12. Can be merged clean without conflicts
13. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
