### PR TITLE
ci: upload arm64_v8a apk and librime_jni.so artifacts

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -55,7 +55,23 @@ jobs:
       - name: Upload Trime artifact
         uses: actions/upload-artifact@v3
         with:
-          name: trime.zip
+          name: trime
           path: app/build/outputs/apk/**/*.apk
+          # keep 90 days
+          retention-days: 90
+
+      - name: Upload Trime artifact (ARM64_V8A only)
+        uses: actions/upload-artifact@v3
+        with:
+          name: trime_arm64_v8a
+          path: app/build/outputs/apk/**/*arm64-v8a-debug.apk
+          # keep 90 days
+          retention-days: 90
+
+      - name: Upload jni artifact (librime_jni.so)
+        uses: actions/upload-artifact@v3
+        with:
+          name: librime_jni
+          path: app/build/intermediates/stripped_native_libs/debug/out/lib/*
           # keep 90 days
           retention-days: 90


### PR DESCRIPTION
## Pull request
为commit ci增加保存的artifacts

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
1. 单独保存commit-ci编译的arm64-v8a APK（目前最普遍使用的ABI），减少下载开销。
2. 保存commit-ci编译的librime_jni.so，方便本地无法编译成功jni的人获取到最新elf文件。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
3. Manual build and test pass
4. GitHub action ci pass
5. At least one contributor reviews and votes
6. Can be merged clean without conflicts
7. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
