### PR TITLE
chore(gradle): get git branch info from ci

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -11,6 +11,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get branch name
+        id: vars
+        run: |
+          echo ${GITHUB_REF#refs/*/}
+          echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
+
       - name: Calculate JNI cache hash
         id: cache-hash
         run: script/cache-hash.sh

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -11,6 +11,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get branch name
+        id: vars
+        run: |
+          echo ${GITHUB_REF#refs/*/}
+          echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
+
       - name: Calculate JNI cache hash
         id: cache-hash
         run: script/cache-hash.sh

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get branch name
+        id: vars
+        run: |
+          echo ${GITHUB_REF#refs/*/}
+          echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
+
       - name: Calculate JNI cache hash
         id: cache-hash
         run: script/cache-hash.sh

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,10 @@ def getCommitInfo(){
 }
 
 def getGitBranch(){
-    ' git symbolic-ref --short -q HEAD'.execute().text.trim()
+    def text = 'git symbolic-ref --short -q HEAD'.execute().text.trim()
+    if(text.length()<1)
+        return System.getenv("CI_BRANCH")
+    return text
 }
 
 def getGitVersion() {


### PR DESCRIPTION
## Pull request
解决了自动编译版本的关于页面中，branch信息可能为空的问题。

原有git命令在本地编译时正常，在ci编译存在没能正确获取branch信息的情况（本地commit并push后没有问题，主要发生在github在线操作仓库，比如增加tag/提交pr）

变更前获取到branch信息的commit ci
https://github.com/osfans/trime/actions/runs/2600357973
```
Build: Commit CI \nDate: 2022-07-02 04:44 UTC \nCommit: v3.2.7-1-g7cacd64, 2022-07-02 12:19:45 +0800 \nBranch: develop \nRepository: https://github.com/osfans/trime
Warning: This version only understands SDK XML versions up to 2 but an SDK XML file of version 3 was encountered. This can happen if you use versions of Android Studio and the command-line tools that were released at different times.
Warning: unexpected element (uri:"", local:"base-extension"). Expected elements are <{}codename>,<{}layoutlib>,<{}api-level>
```
变更前未获取到branch信息的commit ci
https://github.com/osfans/trime/actions/runs/2600357973
```
Build: Commit CI \nDate: 2022-07-02 04:1[9](https://github.com/osfans/trime/runs/7159608554?check_suite_focus=true#step:10:10) UTC \nCommit: v3.2.6-91-g8f[12](https://github.com/osfans/trime/runs/7159608554?check_suite_focus=true#step:10:13)815, 2022-07-02 12:15:50 +0800 \nBranch:  \nRepository: https://github.com/osfans/trime
```

修改gradle后，ci自动获取branch信息并写入环境变量，如果没有获得branch信息，gradle从环境变量取值。

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
