### PR TITLE
修复预设按键的option参数中%1$s ~ %4$s取值问题

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/EditorInstance.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/EditorInstance.kt
@@ -2,6 +2,7 @@ package com.osfans.trime.ime.core
 
 import android.inputmethodservice.InputMethodService
 import android.os.SystemClock
+import android.text.TextUtils
 import android.view.InputDevice
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
@@ -124,6 +125,28 @@ class EditorInstance(private val ims: InputMethodService) {
             return ""
         }
         return ic.getTextBeforeCursor(n.coerceAtMost(1024), 0)?.toString() ?: ""
+    }
+
+    /** 獲得當前漢字：候選字、選中字、剛上屏字/光標前字/光標前所有字、光標後所有字
+     * %s或者%1$s爲當前字符
+     * %2$s爲當前輸入的編碼
+     * %3$s爲光標前字符
+     * %4$s爲光標前所有字符
+     * */
+    fun getActiveText(type: Int): String {
+        if (type == 2) return Rime.RimeGetInput() // 當前編碼
+        var s = Rime.getComposingText() // 當前候選
+        if (TextUtils.isEmpty(s)) {
+            val ic = inputConnection
+            var cs = if (ic != null) ic.getSelectedText(0) else null // 選中字
+            if (type == 1 && TextUtils.isEmpty(cs)) cs = lastCommittedText // 剛上屏字
+            if (TextUtils.isEmpty(cs) && ic != null) {
+                cs = ic.getTextBeforeCursor(if (type == 4) 1024 else 1, 0) // 光標前字
+            }
+            if (TextUtils.isEmpty(cs) && ic != null) cs = ic.getTextAfterCursor(1024, 0) // 光標後面所有字
+            if (cs != null) s = cs.toString()
+        }
+        return s
     }
 
     /**

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -354,13 +354,23 @@ class TextInputManager private constructor() :
                 // %2$s爲當前輸入的編碼
                 // %3$s爲光標前字符
                 // %4$s爲光標前所有字符
-                val arg = String.format(
-                    event.option,
-                    activeEditorInstance.lastCommittedText,
-                    Rime.RimeGetInput(),
-                    activeEditorInstance.getTextBeforeCursor(1),
-                    activeEditorInstance.getTextBeforeCursor(1024)
-                )
+                var arg = event.option
+                val activeTextRegex = Regex(".*%(\\d*)\\$" + "s.*")
+                if (arg.matches(activeTextRegex)) {
+                    var activeTextMode =
+                        arg.replaceFirst(activeTextRegex, "$1").toDouble().toInt()
+                    if (activeTextMode <1)
+                        activeTextMode = 1
+                    val activeText = activeEditorInstance.getActiveText(activeTextMode)
+                    arg = String.format(
+                        arg,
+                        activeEditorInstance.lastCommittedText,
+                        Rime.RimeGetInput(),
+                        activeText,
+                        activeText
+                    )
+                }
+
                 if (event.command == "liquid_keyboard") {
                     trime.selectLiquidKeyboard(arg)
                 } else if (event.command == "paste_by_char") {


### PR DESCRIPTION
## Pull request

  预设按键的option参数中%1$s ~ %4$s可以获取光标位置文字，但是目前存在bug

  暂未查到是哪个pr的修改，涉及文件的commit hash如下：
  
  afc3f2f6ced1185cb059f58fb4808e98573b6781
  843f52d76b2be58c6f5fb53cf8976f4a37068812

  由于这两个变更导致取值没有做回滚处理，导致实际获取的字符串与原有版本不同，用户体验下降。
  最为凸出的问题是没有自动获取光标选中范围内的文字
  
#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
