### PR TITLE
 修复非中文模式下小键盘数字键无法输入

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
@@ -81,6 +81,19 @@ enum class Keycode {
             reverseMap[_8] = "8"
             reverseMap[_9] = "9"
 
+            reverseMap[KP_0] = "0"
+            reverseMap[KP_1] = "1"
+            reverseMap[KP_2] = "2"
+            reverseMap[KP_3] = "3"
+            reverseMap[KP_4] = "4"
+            reverseMap[KP_5] = "5"
+            reverseMap[KP_6] = "6"
+            reverseMap[KP_7] = "7"
+            reverseMap[KP_8] = "8"
+            reverseMap[KP_9] = "9"
+            reverseMap[KP_8] = "8"
+            reverseMap[KP_9] = "9"
+
             reverseMap[exclam] = "!"
             reverseMap[quotedbl] = "\""
             reverseMap[dollar] = "$"
@@ -107,7 +120,11 @@ enum class Keycode {
         }
 
         fun hasSymbolLabel(keycode: Int): Boolean {
-            return keycode >= A.ordinal && keycode < values().size
+            if (keycode < 0 || keycode > values().size)
+                return false
+
+            return keycode >= A.ordinal ||
+                (keycode >= KP_0.ordinal && keycode <= KP_9.ordinal)
         }
 
         fun getSymbolLabell(keycode: Keycode): String {


### PR DESCRIPTION
## Pull request
fix: KP_0 - KP_9 could not input

注意： 此PR并未从根源修复  #804  ，而是仅仅从表面解决了小键盘0-9的输入问题。
如果一个按键未被librime处理，也不在com.osfans.trime.ime.enums.Keycode作为特殊符号键被处理，还没有被同文当作特例解析，仍然无法正常使用。

#### Feature 

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
