### PR TITLE
修复按键背景错误

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
@@ -28,6 +28,8 @@ import com.osfans.trime.core.Rime;
 import com.osfans.trime.data.Config;
 import com.osfans.trime.ime.enums.KeyEventType;
 import com.osfans.trime.util.ConfigGetter;
+import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import timber.log.Timber;
@@ -48,13 +50,14 @@ public class Key {
   public static final int[] KEY_STATE_PRESSED = {android.R.attr.state_pressed};
   public static final int[][] KEY_STATES =
       new int[][] {
-        KEY_STATE_PRESSED_ON, // 0
-        KEY_STATE_PRESSED_OFF, // 1
-        KEY_STATE_NORMAL_ON, // 2
-        KEY_STATE_NORMAL_OFF, // 3
-        KEY_STATE_PRESSED, // 4
-        KEY_STATE_NORMAL // 5
+        KEY_STATE_PRESSED_ON, // 0    "hilited_on_key_back_color"   锁定时按下的背景
+        KEY_STATE_PRESSED_OFF, // 1   "hilited_off_key_back_color"  功能键按下的背景
+        KEY_STATE_NORMAL_ON, // 2     "on_key_back_color"           锁定时背景
+        KEY_STATE_NORMAL_OFF, // 3    "off_key_back_color"          功能键背景
+        KEY_STATE_PRESSED, // 4       "hilited_key_back_color"      按键按下的背景
+        KEY_STATE_NORMAL // 5         "key_back_color"              按键背景
       };
+
   public static Map<String, Map<String, String>> presetKeys;
   private static final int EVENT_NUM = KeyEventType.values().length;
   public Event[] events = new Event[EVENT_NUM];
@@ -321,9 +324,7 @@ public class Key {
   }
 
   private boolean isNormal(int[] drawableState) {
-    return (drawableState == KEY_STATE_NORMAL
-        || drawableState == KEY_STATE_NORMAL_ON
-        || drawableState == KEY_STATE_NORMAL_OFF);
+    return (drawableState == KEY_STATE_NORMAL || drawableState == KEY_STATE_NORMAL_OFF);
   }
 
   public Drawable getBackColorForState(int[] drawableState) {
@@ -428,8 +429,6 @@ public class Key {
   public int[] getCurrentDrawableState() {
     int[] states = KEY_STATE_NORMAL;
     boolean isShifted = isTrimeModifierKey() && mKeyboard.hasModifier(getModifierKeyOnMask());
-    // only for modiferKey debug
-    if (isTrimeModifierKey()) mKeyboard.printModifierKeyState("getCurrentDrawableState");
 
     if (isShifted || on) {
       if (pressed) {
@@ -450,6 +449,18 @@ public class Key {
         }
       }
     }
+
+    // only for modiferKey debug
+    if (isTrimeModifierKey())
+      mKeyboard.printModifierKeyState(
+          MessageFormat.format(
+              "getCurrentDrawableState() Key={0} states={1} on={2} isShifted={3} pressed={4} sticky={5}",
+              getLabel(),
+              Arrays.asList(KEY_STATES).indexOf(states),
+              on,
+              isShifted,
+              pressed,
+              getClick().isSticky()));
     return states;
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -897,6 +897,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
       int[] drawableState = key.getCurrentDrawableState();
       keyBackground = key.getBackColorForState(drawableState);
       if (keyBackground == null) {
+        Timber.i("onBufferDraw() keyBackground==null, key=%s", key.getLabel());
         try {
           final int index = (int) findStateDrawableIndex.invoke(mKeyBackColor, drawableState);
           keyBackground = (Drawable) getStateDrawable.invoke(mKeyBackColor, index);


### PR DESCRIPTION
## Pull request

#### Issue tracker
点击Ctrl Alt Meta键后，未能像点击shift一样产生按键被选中的视觉效果
排查后发现，原因为com.osfans.trime.ime.keyboard.key类中的isNormal()方法错误地把KEY_STATE_NORMAL_ON判定为显示普通背景
pr对此问题进行了修复

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
