### PR TITLE
fix: missing default.custom.yaml

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/Config.java
+++ b/app/src/main/java/com/osfans/trime/data/Config.java
@@ -30,7 +30,6 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.NinePatchDrawable;
-import android.os.SystemClock;
 import android.util.TypedValue;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -182,25 +181,13 @@ public class Config {
     boolean isOverwrite = AppVersionUtils.INSTANCE.isDifferentVersion(appPrefs);
     String defaultFile = "trime.yaml";
     Timber.d(methodName + "copy");
-    if (isOverwrite) {
-      copyFileOrDir("", true);
-    } else if (isExist) {
-      String path = new File("", defaultFile).getPath();
-      copyFileOrDir(path, false);
-    } else {
-      copyFileOrDir("", false);
-    }
-    Timber.d(methodName + "copy2");
-    while (!new File(sharedDataDir, defaultFile).exists()) {
-      SystemClock.sleep(100);
-      copyFileOrDir("", isOverwrite);
-    }
+    copyFileOrDir("", isOverwrite);
     // 缺失导致获取方案列表为空
     Timber.d(methodName + "copy default.custom.yaml");
     final String defaultCustom = "default.custom.yaml";
-    if (!new File(sharedDataDir, defaultCustom).exists()) {
+    if (!new File(userDataDir, defaultCustom).exists()) {
       try {
-        new File(sharedDataDir, defaultCustom).createNewFile();
+        new File(userDataDir, defaultCustom).createNewFile();
       } catch (IOException e) {
         e.printStackTrace();
       }


### PR DESCRIPTION
## Pull request
修复重置用户文件夹、共用文件夹内的文件后，在勾选使用的方案的界面中无法列出方案列表，提示”请在用户文件夹中放入default.yaml、输入法方案！“的问题

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
