### PR TITLE
优化Shift组合键

### DIFF
--- a/app/src/main/java/com/osfans/trime/core/Rime.java
+++ b/app/src/main/java/com/osfans/trime/core/Rime.java
@@ -285,6 +285,14 @@ public class Rime {
     return mStatus.is_ascii_mode;
   }
 
+  public static boolean isAsciiPunch() {
+    return mStatus.is_ascii_punct;
+  }
+
+  public static boolean showAsciiPunch() {
+    return mStatus.is_ascii_punct || mStatus.is_ascii_mode;
+  }
+
   public static RimeComposition getComposition() {
     if (mContext == null) return null;
     return mContext.composition;

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -183,6 +183,9 @@ class AppPrefs(
             const val HOOK_CTRL_CV = "keyboard__hook_ctrl_cv"
             const val HOOK_CTRL_LR = "keyboard__hook_ctrl_lr"
             const val HOOK_CTRL_ZY = "keyboard__hook_ctrl_zy"
+            const val HOOK_SHIFT_SPACE = "keyboard__hook_shift_space"
+            const val HOOK_SHIFT_NUM = "keyboard__hook_shift_num"
+            const val HOOK_SHIFT_SYMBOL = "keyboard__hook_shift_symbol"
 
             const val SOUND_ENABLED = "keyboard__key_sound"
             const val SOUND_VOLUME = "keyboard__key_sound_volume"
@@ -251,6 +254,15 @@ class AppPrefs(
             private set
         var hookCtrlZY: Boolean = false
             get() = prefs.getPref(HOOK_CTRL_ZY, false)
+            private set
+        var hookShiftSpace: Boolean = false
+            get() = prefs.getPref(HOOK_SHIFT_SPACE, false)
+            private set
+        var hookShiftNum: Boolean = false
+            get() = prefs.getPref(HOOK_SHIFT_NUM, false)
+            private set
+        var hookShiftSymbol: Boolean = false
+            get() = prefs.getPref(HOOK_SHIFT_SYMBOL, false)
             private set
 
         var soundEnabled: Boolean = false

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1087,7 +1087,7 @@ public class Trime extends LifecycleInputMethodService {
   private boolean hookKeyboard(int code, int mask) { // 編輯操作
     final @Nullable InputConnection ic = getCurrentInputConnection();
     if (ic == null) return false;
-    if (Event.hasModifier(mask, KeyEvent.META_CTRL_ON)) {
+    if (mask == KeyEvent.META_CTRL_ON) {
 
       if (VERSION.SDK_INT >= VERSION_CODES.M) {
         if (getPrefs().getKeyboard().getHookCtrlZY()) {

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -934,12 +934,15 @@ public class Trime extends LifecycleInputMethodService {
   private boolean composeEvent(@NonNull KeyEvent event) {
     final int keyCode = event.getKeyCode();
     if (keyCode == KeyEvent.KEYCODE_MENU) return false; // 不處理 Menu 鍵
-    if (Keycode.Companion.hasSymbolLabel(keyCode)) return false; // 只處理安卓標準按鍵
+    if (!Keycode.Companion.isStdKey(keyCode)) return false; // 只處理安卓標準按鍵
     if (event.getRepeatCount() == 0 && Key.isTrimeModifierKey(keyCode)) {
       boolean ret =
           onRimeKey(
               Event.getRimeEvent(
-                  keyCode, event.getAction() == KeyEvent.ACTION_DOWN ? 0 : Rime.META_RELEASE_ON));
+                  keyCode,
+                  event.getAction() == KeyEvent.ACTION_DOWN
+                      ? event.getModifiers()
+                      : Rime.META_RELEASE_ON));
       if (isComposing()) setCandidatesViewShown(textInputManager.isComposable()); // 藍牙鍵盤打字時顯示候選欄
       return ret;
     }

--- a/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
@@ -59,14 +59,18 @@ enum class Keycode {
 
     companion object {
 
+        // librime keyname (x11) - trime keycode (兼容Android)
         private val convertMap: HashMap<String, Keycode> = hashMapOf()
+
+        // 部分符号的 trime keycode (兼容Android) - key label
         private val reverseMap: HashMap<Keycode, String> = hashMapOf()
 
         init {
-            for (type in Keycode.values()) {
+            for (type in values()) {
                 convertMap[type.toString()] = type
             }
 
+            // android keycode 包含的数字开头的按键
             reverseMap[_3D_MODE] = "3D_MODE"
             reverseMap[_0] = "0"
             reverseMap[_1] = "1"
@@ -81,19 +85,26 @@ enum class Keycode {
             reverseMap[_8] = "8"
             reverseMap[_9] = "9"
 
-            reverseMap[KP_0] = "0"
-            reverseMap[KP_1] = "1"
-            reverseMap[KP_2] = "2"
-            reverseMap[KP_3] = "3"
-            reverseMap[KP_4] = "4"
-            reverseMap[KP_5] = "5"
-            reverseMap[KP_6] = "6"
-            reverseMap[KP_7] = "7"
-            reverseMap[KP_8] = "8"
-            reverseMap[KP_9] = "9"
-            reverseMap[KP_8] = "8"
-            reverseMap[KP_9] = "9"
+            // android keycode 已包含的符号
+            reverseMap[grave] = "`"
+            reverseMap[at] = "@"
+            reverseMap[numbersign] = "#"
+            reverseMap[asterisk] = "*"
+            reverseMap[parenleft] = "("
+            reverseMap[parenright] = ")"
+            reverseMap[minus] = "-"
+            reverseMap[equal] = "="
+            reverseMap[plus] = "+"
+            reverseMap[bracketleft] = "["
+            reverseMap[bracketright] = "]"
+            reverseMap[backslash] = "\\"
+            reverseMap[semicolon] = ";"
+            reverseMap[apostrophe] = "'"
+            reverseMap[comma] = ","
+            reverseMap[period] = "."
+            reverseMap[slash] = "/"
 
+            // android keycode未包含的符号
             reverseMap[exclam] = "!"
             reverseMap[quotedbl] = "\""
             reverseMap[dollar] = "$"
@@ -113,18 +124,30 @@ enum class Keycode {
             reverseMap.forEach {
                 convertMap[it.value] = it.key
             }
+
+            // android keycode 包含的小键盘，仅用于输出label，不用于label转按键
+            reverseMap[KP_0] = "0"
+            reverseMap[KP_1] = "1"
+            reverseMap[KP_2] = "2"
+            reverseMap[KP_3] = "3"
+            reverseMap[KP_4] = "4"
+            reverseMap[KP_5] = "5"
+            reverseMap[KP_6] = "6"
+            reverseMap[KP_7] = "7"
+            reverseMap[KP_8] = "8"
+            reverseMap[KP_9] = "9"
+            reverseMap[KP_8] = "8"
+            reverseMap[KP_9] = "9"
         }
 
         fun isStdKey(keycode: Int): Boolean {
-            return keycode < A.ordinal
+            return keycode < A.ordinal && keycode > 0
         }
 
         fun hasSymbolLabel(keycode: Int): Boolean {
             if (keycode < 0 || keycode > values().size)
                 return false
-
-            return keycode >= A.ordinal ||
-                (keycode >= KP_0.ordinal && keycode <= KP_9.ordinal)
+            return keycode >= A.ordinal || reverseMap.containsKey(values()[keycode])
         }
 
         fun getSymbolLabell(keycode: Keycode): String {

--- a/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/Keycode.kt
@@ -2,6 +2,8 @@ package com.osfans.trime.ime.enums
 
 import android.text.TextUtils
 import android.view.KeyEvent
+import com.osfans.trime.ime.keyboard.Key
+import timber.log.Timber
 
 enum class Keycode {
     // 与原trime.yaml主题android_key/name小节相比，差异如下：
@@ -144,6 +146,52 @@ enum class Keycode {
             return keycode < A.ordinal && keycode > 0
         }
 
+        fun toStdKeyEvent(keycode: Int, mask: Int = 0): IntArray {
+            var event = IntArray(2)
+            if (keycode < 0 || keycode > values().size)
+                return event
+            if (keycode < A.ordinal) {
+                event[0] = keycode
+                event[1] = mask
+            } else {
+                if (keycode <= Z.ordinal)
+                    event[0] = keycode - A.ordinal + a.ordinal
+                else if (keycode == exclam.ordinal)
+                    event[0] = _1.ordinal
+                else if (keycode == dollar.ordinal)
+                    event[0] = _4.ordinal
+                else if (keycode == percent.ordinal)
+                    event[0] = _5.ordinal
+                else if (keycode == asciicircum.ordinal)
+                    event[0] = _6.ordinal
+                else if (keycode == ampersand.ordinal)
+                    event[0] = _7.ordinal
+                else if (keycode == quotedbl.ordinal)
+                    event[0] = apostrophe.ordinal
+                else if (keycode == colon.ordinal)
+                    event[0] = semicolon.ordinal
+                else if (keycode == less.ordinal)
+                    event[0] = comma.ordinal
+                else if (keycode == greater.ordinal)
+                    event[0] = period.ordinal
+                else if (keycode == question.ordinal)
+                    event[0] = slash.ordinal
+                else if (keycode == underscore.ordinal)
+                    event[0] = minus.ordinal
+                else if (keycode == braceleft.ordinal)
+                    event[0] = bracketleft.ordinal
+                else if (keycode == braceright.ordinal)
+                    event[0] = bracketright.ordinal
+                else if (keycode == asciitilde.ordinal)
+                    event[0] = grave.ordinal
+                else if (keycode == bar.ordinal)
+                    event[0] = backslash.ordinal
+
+                event[1] = mask or KeyEvent.META_SHIFT_ON
+            }
+            return event
+        }
+
         fun hasSymbolLabel(keycode: Int): Boolean {
             if (keycode < 0 || keycode > values().size)
                 return false
@@ -152,6 +200,30 @@ enum class Keycode {
 
         fun getSymbolLabell(keycode: Keycode): String {
             return reverseMap[keycode] ?: ""
+        }
+
+        fun getDisplayLabel(keyCode: Int, mask: Int): String? {
+            var s: String? = ""
+            if (isStdKey(keyCode)) {
+                // Android keycode区域
+                if (Key.getKcm().isPrintingKey(keyCode)) {
+                    val event = KeyEvent(0, 0, KeyEvent.ACTION_DOWN, keyCode, 0, mask)
+                    val k = event.getUnicodeChar(mask)
+                    Timber.d("getDisplayLabel() keycode=$keyCode, mask=$mask, k=$k")
+                    if (k > 0) {
+                        s += k.toChar()
+                    } else {
+                        var c = Key.getKcm().getDisplayLabel(keyCode)
+                        if (Character.isUpperCase(c)) c = c.lowercaseChar()
+                        s = c.toString()
+                    }
+                } else {
+                    s = keyNameOf(keyCode)
+                }
+            } else if (hasSymbolLabel(keyCode)) { // 可見符號
+                s = getSymbolLabell(valueOf(keyCode))
+            }
+            return s
         }
 
         private val masks = hashMapOf(

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
@@ -22,6 +22,7 @@ import android.text.TextUtils;
 import android.view.KeyEvent;
 import androidx.annotation.NonNull;
 import com.osfans.trime.core.Rime;
+import com.osfans.trime.data.AppPrefs;
 import com.osfans.trime.data.Config;
 import com.osfans.trime.ime.enums.Keycode;
 import com.osfans.trime.util.ConfigGetter;
@@ -193,8 +194,22 @@ public class Event {
 
   public String getLabel() {
     if (!TextUtils.isEmpty(toggle)) return (String) states.get(Rime.getOption(toggle) ? 1 : 0);
-    if ((mKeyboard.getModifer() | mask & KeyEvent.META_SHIFT_ON) != 0)
+
+    if (mKeyboard.isOnlyShiftOn()) {
+      if (code >= KeyEvent.KEYCODE_0
+          && code <= KeyEvent.KEYCODE_9
+          && !AppPrefs.defaultInstance().getKeyboard().getHookShiftNum())
+        return adjustCase(shiftLabel);
+      if (code >= KeyEvent.KEYCODE_GRAVE && code <= KeyEvent.KEYCODE_SLASH
+          || code == KeyEvent.KEYCODE_COMMA
+          || code == KeyEvent.KEYCODE_PERIOD) {
+        if (!AppPrefs.defaultInstance().getKeyboard().getHookShiftSymbol())
+          return adjustCase(shiftLabel);
+      }
+    } else if ((mKeyboard.getModifer() | mask & KeyEvent.META_SHIFT_ON) != 0) {
       return adjustCase(shiftLabel);
+    }
+
     return adjustCase(label);
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
@@ -229,33 +229,8 @@ public class Event {
     if (c == KeyEvent.KEYCODE_SPACE) {
       label = Rime.getSchemaName();
     } else {
-      if (c > 0) label = getDisplayLabel(c);
+      if (c > 0) label = Keycode.Companion.getDisplayLabel(c, mask);
     }
-  }
-
-  public String getDisplayLabel(int keyCode) {
-    String s = "";
-    if (Keycode.Companion.isStdKey(keyCode)) {
-      // Android keycode区域
-      if (Key.getKcm().isPrintingKey(keyCode)) {
-        KeyEvent event = new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, keyCode, 0, mask);
-        int k = event.getUnicodeChar(mask);
-
-        Timber.d("getDisplayLabel() keycode=" + keyCode + ", mask=" + mask + ", k=" + k);
-        if (k > 0) {
-          s += ((char) (k));
-        } else {
-          char c = Key.getKcm().getDisplayLabel(keyCode);
-          if (Character.isUpperCase(c)) c = Character.toLowerCase(c);
-          s = String.valueOf(c);
-        }
-      } else {
-        s = Keycode.keyNameOf(keyCode);
-      }
-    } else if (Keycode.Companion.hasSymbolLabel(keyCode)) { // 可見符號
-      s = Keycode.Companion.getSymbolLabell(Keycode.valueOf(keyCode));
-    }
-    return s;
   }
 
   public static int getClickCode(String s) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.java
@@ -206,7 +206,7 @@ public class Event {
         if (!AppPrefs.defaultInstance().getKeyboard().getHookShiftSymbol())
           return adjustCase(shiftLabel);
       }
-    } else if ((mKeyboard.getModifer() | mask & KeyEvent.META_SHIFT_ON) != 0) {
+    } else if (((mKeyboard.getModifer() | mask) & KeyEvent.META_SHIFT_ON) != 0) {
       return adjustCase(shiftLabel);
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
@@ -244,8 +244,10 @@ public class Key {
     return on;
   }
 
-  public void setOn(boolean on) {
-    this.on = on;
+  public boolean setOn(boolean on) {
+    if (on && this.on) this.on = false;
+    else this.on = on;
+    return this.on;
   }
 
   public String getPopupCharacters() {
@@ -495,12 +497,11 @@ public class Key {
     return (c == KeyEvent.KEYCODE_SYM);
   }
 
-  // shift键在点击时是否触发锁定
+  // Shift、Ctrl、Alt、Meta等修饰键在点击时是否触发锁定
   public boolean isShiftLock() {
     String s = getClick().getShiftLock();
     if ("long".equals(s)) return false;
-    if ("click".equals(s)) return true;
-    return !Rime.isAsciiMode();
+    return "click".equals(s);
   }
 
   /**

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
@@ -500,8 +500,11 @@ public class Key {
   // Shift、Ctrl、Alt、Meta等修饰键在点击时是否触发锁定
   public boolean isShiftLock() {
     String s = getClick().getShiftLock();
+    // shift_lock #ascii_long: 英文長按中文單按鎖定, long: 長按鎖定, click: 單按鎖定
     if ("long".equals(s)) return false;
-    return "click".equals(s);
+    if ("click".equals(s)) return true;
+    if ("ascii_long".equals(s)) return !Rime.isAsciiMode();
+    return false;
   }
 
   /**

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
@@ -577,7 +577,7 @@ public class Key {
     Event event = getEvent();
     if (!TextUtils.isEmpty(label)
         && event == getClick()
-        && (events[KeyEventType.ASCII.ordinal()] == null && !Rime.isAsciiMode()))
+        && (events[KeyEventType.ASCII.ordinal()] == null && !Rime.showAsciiPunch()))
       return label; // 中文狀態顯示標籤
     return event.getLabel();
   }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -642,6 +642,12 @@ public class Keyboard {
   //    return setModifier(KeyEvent.META_FUNCTION_ON, on || keyDown);
   //  }
 
+  public boolean isOnlyShiftOn() {
+    if (mShiftKey != null && mShiftKey.isOn() && mModifierState == KeyEvent.META_SHIFT_ON)
+      return true;
+    return false;
+  }
+
   public boolean resetShifted() {
     if (mShiftKey != null && !mShiftKey.isOn()) return setModifier(KeyEvent.META_SHIFT_ON, false);
     return false;

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -595,21 +595,22 @@ public class Keyboard {
    */
   public boolean clikModifierKey(boolean on, int keycode) {
     boolean keyDown = !hasModifier(keycode);
-    on = on & keyDown;
-    if (mShiftKey != null) mShiftKey.setOn(on);
+    boolean keepOn = on;
 
-    if (keycode == KeyEvent.META_SHIFT_ON) {
-      mShiftKey.setOn(on);
-    } else if (keycode == KeyEvent.META_ALT_ON) {
-      mAltKey.setOn(on);
-    } else if (keycode == KeyEvent.META_CTRL_ON) {
-      mCtrlKey.setOn(on);
-    } else if (keycode == KeyEvent.META_META_ON) {
-      mMetaKey.setOn(on);
-    } else if (keycode == KeyEvent.KEYCODE_SYM) {
-      mSymKey.setOn(on);
+    if (keycode == KeyEvent.META_SHIFT_ON && mShiftKey != null) {
+      keepOn = mShiftKey.setOn(on);
+    } else if (keycode == KeyEvent.META_ALT_ON && mAltKey != null) {
+      keepOn = mAltKey.setOn(on);
+    } else if (keycode == KeyEvent.META_CTRL_ON && mCtrlKey != null) {
+      keepOn = mCtrlKey.setOn(on);
+    } else if (keycode == KeyEvent.META_META_ON && mMetaKey != null) {
+      keepOn = mMetaKey.setOn(on);
+    } else if (keycode == KeyEvent.KEYCODE_SYM && mSymKey != null) {
+      keepOn = mSymKey.setOn(on);
     }
-    return setModifier(keycode, on || keyDown);
+
+    if (on) return setModifier(keycode, keepOn);
+    else return setModifier(keycode, keyDown);
   }
 
   public boolean setAltOn(boolean on, boolean keyDown) {
@@ -642,10 +643,27 @@ public class Keyboard {
   //    return setModifier(KeyEvent.META_FUNCTION_ON, on || keyDown);
   //  }
 
+  private final int MASK_META_WITHOUT_SHIFT =
+      KeyEvent.META_CTRL_ON | KeyEvent.META_ALT_ON | KeyEvent.META_SYM_ON | KeyEvent.META_META_ON;
+  private final int MASK_META_WITHOUT_CTRL =
+      KeyEvent.META_SHIFT_ON | KeyEvent.META_ALT_ON | KeyEvent.META_SYM_ON | KeyEvent.META_META_ON;
+  private final int MASK_META_WITHOUT_ALT =
+      KeyEvent.META_CTRL_ON | KeyEvent.META_SHIFT_ON | KeyEvent.META_SYM_ON | KeyEvent.META_META_ON;
+  private final int MASK_META_WITHOUT_SYS =
+      KeyEvent.META_CTRL_ON | KeyEvent.META_ALT_ON | KeyEvent.META_SHIFT_ON | KeyEvent.META_META_ON;
+  private final int MASK_META_WITHOUT_META =
+      KeyEvent.META_CTRL_ON | KeyEvent.META_ALT_ON | KeyEvent.META_SYM_ON | KeyEvent.META_SHIFT_ON;
+  private final int MASK_META =
+      KeyEvent.META_CTRL_ON
+          | KeyEvent.META_ALT_ON
+          | KeyEvent.META_SYM_ON
+          | KeyEvent.META_META_ON
+          | KeyEvent.META_SHIFT_ON;
+
   public boolean isOnlyShiftOn() {
-    if (mShiftKey != null && mShiftKey.isOn() && mModifierState == KeyEvent.META_SHIFT_ON)
-      return true;
-    return false;
+    return (mShiftKey != null
+        && mShiftKey.isOn()
+        && (mModifierState & MASK_META_WITHOUT_SHIFT) == 0);
   }
 
   public boolean resetShifted() {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -674,6 +674,11 @@ public class Keyboard {
   public boolean resetModifer() {
     // 这里改为了一次性重置全部修饰键状态并返回TRUE刷新UI，可能有bug
     mModifierState = 0;
+    if (mShiftKey != null && mShiftKey.isOn()) mModifierState = KeyEvent.META_SHIFT_ON;
+    if (mAltKey != null && mAltKey.isOn()) mModifierState |= KeyEvent.META_ALT_ON;
+    if (mCtrlKey != null && mCtrlKey.isOn()) mModifierState |= KeyEvent.META_CTRL_ON;
+    if (mMetaKey != null && mMetaKey.isOn()) mModifierState |= KeyEvent.META_META_ON;
+    if (mSymKey != null && mSymKey.isOn()) mModifierState |= KeyEvent.KEYCODE_SYM;
     return true;
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -1088,7 +1088,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
         // TextEntryState.keyPressedAt(key, x, y);
         final int[] codes = new int[MAX_NEARBY_KEYS];
         Arrays.fill(codes, NOT_A_KEY);
-        getKeyIndices(x, y, codes);
+        // getKeyIndices(x, y, codes); // 这里实际上并没有生效
         Timber.d("\t<TrimeInput>\tdetectAndSendKey()\tonEvent, code=%d, key.getEvent", code);
         // 可以在这里把 mKeyboard.getModifer() 获取的修饰键状态写入event里
         mKeyboardActionListener.onEvent(key.getEvent(type.ordinal()));

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -600,7 +600,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
   /**
    * 设置键盘修饰键的状态
    *
-   * @param key 按下的修饰键
+   * @param key 按下的修饰键(非组合键）
    * @return
    */
   public boolean setModifier(Key key) {
@@ -979,6 +979,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
         paint.setShadowLayer(0, 0, 0, 0);
       }
       canvas.translate(-key.getX() - kbdPaddingLeft, -key.getY() - kbdPaddingTop);
+      //      break;
     }
     mInvalidatedKey = null;
     // Overlay a dark rectangle to dim the keyboard

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -414,7 +414,10 @@ class TextInputManager private constructor() :
                         }
                     }
                 }
-                onKey(event.code, event.mask or trime.keyboardSwitcher.currentKeyboard.modifer)
+                if (event.mask == 0)
+                    onKey(event.code, trime.keyboardSwitcher.currentKeyboard.modifer)
+                else
+                    onKey(event.code, event.mask)
             }
         }
     }

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -396,7 +396,26 @@ class TextInputManager private constructor() :
             }
             KeyEvent.KEYCODE_PROG_RED -> trime.showColorDialog() // Color schemes
             KeyEvent.KEYCODE_MENU -> trime.showOptionsDialog()
-            else -> onKey(event.code, event.mask or trime.keyboardSwitcher.currentKeyboard.modifer)
+            else -> {
+                if (event.mask == 0 && trime.keyboardSwitcher.currentKeyboard.isOnlyShiftOn) {
+                    if (event.code == KeyEvent.KEYCODE_SPACE && prefs.keyboard.hookShiftSpace) {
+                        onKey(event.code, 0)
+                        return
+                    } else if (event.code >= KeyEvent.KEYCODE_0 && event.code <= KeyEvent.KEYCODE_9 && prefs.keyboard.hookShiftNum) {
+                        onKey(event.code, 0)
+                        return
+                    } else if (prefs.keyboard.hookShiftSymbol) {
+                        if (event.code >= KeyEvent.KEYCODE_GRAVE && event.code <= KeyEvent.KEYCODE_SLASH ||
+                            event.code == KeyEvent.KEYCODE_COMMA ||
+                            event.code == KeyEvent.KEYCODE_PERIOD
+                        ) {
+                            onKey(event.code, 0)
+                            return
+                        }
+                    }
+                }
+                onKey(event.code, event.mask or trime.keyboardSwitcher.currentKeyboard.modifer)
+            }
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -13,7 +13,7 @@ import com.osfans.trime.ime.broadcast.IntentReceiver
 import com.osfans.trime.ime.core.EditorInstance
 import com.osfans.trime.ime.core.Speech
 import com.osfans.trime.ime.core.Trime
-import com.osfans.trime.ime.enums.Keycode
+import com.osfans.trime.ime.enums.Keycode.Companion.toStdKeyEvent
 import com.osfans.trime.ime.enums.SymbolKeyboardType
 import com.osfans.trime.ime.keyboard.Event
 import com.osfans.trime.ime.keyboard.Keyboard.printModifierKeyState
@@ -421,14 +421,13 @@ class TextInputManager private constructor() :
 
     override fun onKey(keyEventCode: Int, metaState: Int) {
         printModifierKeyState(metaState, "keyEventCode=" + keyEventCode)
+
+        // 优先由librime处理按键事件
         if (trime.handleKey(keyEventCode, metaState)) return
-        if (Keycode.hasSymbolLabel(keyEventCode)) {
-            needSendUpRimeKey = false
-            activeEditorInstance.commitText(Keycode.getSymbolLabell(Keycode.valueOf(keyEventCode)))
-            return
-        }
+        // 大写字母和部分符号转换为Shift+Android keyevent
+        val event = toStdKeyEvent(keyEventCode, metaState)
         needSendUpRimeKey = false
-        activeEditorInstance.sendDownUpKeyEvent(keyEventCode, metaState)
+        activeEditorInstance.sendDownUpKeyEvent(event[0], event[1])
     }
 
     override fun onText(text: CharSequence?) {

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -13,6 +13,7 @@ import com.osfans.trime.ime.broadcast.IntentReceiver
 import com.osfans.trime.ime.core.EditorInstance
 import com.osfans.trime.ime.core.Speech
 import com.osfans.trime.ime.core.Trime
+import com.osfans.trime.ime.enums.Keycode
 import com.osfans.trime.ime.enums.Keycode.Companion.toStdKeyEvent
 import com.osfans.trime.ime.enums.SymbolKeyboardType
 import com.osfans.trime.ime.keyboard.Event
@@ -427,6 +428,18 @@ class TextInputManager private constructor() :
 
         // 优先由librime处理按键事件
         if (trime.handleKey(keyEventCode, metaState)) return
+
+        // 如果没有修饰键，或者只有shift修饰键，可以直接commit字符
+        val shiftState = metaState or KeyEvent.META_SHIFT_ON
+        if (shiftState == KeyEvent.META_SHIFT_ON || shiftState == 0) {
+            val text = Keycode.getDisplayLabel(keyEventCode, metaState)
+            if (text!!.length == 1) {
+                needSendUpRimeKey = false
+                activeEditorInstance.commitText(text)
+                return
+            }
+        }
+
         // 大写字母和部分符号转换为Shift+Android keyevent
         val event = toStdKeyEvent(keyEventCode, metaState)
         needSendUpRimeKey = false

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -206,6 +206,9 @@
     <string name="keyboard__candidate_page_size">每页显示候选词数量</string>
     <string name="copy_done">已复制</string>
     <string name="delete_done">已删除</string>
+    <string name="keyboard__hook_shift_space">点击空格时，忽略Shift的锁定状态</string>
+    <string name="keyboard__hook_shift_num">点击0-9时，忽略Shift的锁定状态</string>
+    <string name="keyboard__hook_shift_symbol">点击符号键时，忽略Shift的锁定状态</string>
     <string-array name="keyboard__candidate_page_size_entries" >
         <item name="10000">不超出候选栏</item>
         <item name="10001">接近于候选栏</item>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -207,6 +207,9 @@
     <string name="keyboard__candidate_page_size">每頁顯示候選詞數量</string>
     <string name="copy_done">已複製</string>
     <string name="delete_done">已刪除</string>
+    <string name="keyboard__hook_shift_space">點擊空格時，忽略Shift的鎖定狀態</string>
+    <string name="keyboard__hook_shift_num">點擊0-9時，忽略Shift的鎖定狀態</string>
+    <string name="keyboard__hook_shift_symbol">點擊符號鍵時，忽略Shift的鎖定狀態</string>
     <string-array name="keyboard__candidate_page_size_entries" >
         <item name="10000">不超出候選欄</item>
         <item name="10001">接近於候選欄</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,6 +209,9 @@
     <string name="keyboard__candidate_page_size">Candidate item count for each page</string>
     <string name="copy_done">Copied to clipboard!</string>
     <string name="delete_done">Deleted</string>
+    <string name="keyboard__hook_shift_space">Ignore Shift locked for Space</string>
+    <string name="keyboard__hook_shift_num">Ignore Shift locked for 0-9</string>
+    <string name="keyboard__hook_shift_symbol">Ignore Shift locked for Symbol keys</string>
     <string-array name="keyboard__candidate_page_size_entries" >
         <item name="10000">Less than candidate</item>
         <item name="10001">close to candidate</item>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -127,6 +127,21 @@
             android:title="@string/keyboard__hook_ctrl_zy"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            android:key="keyboard__hook_shift_space"
+            android:title="@string/keyboard__hook_shift_space"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            android:key="keyboard__hook_shift_num"
+            android:title="@string/keyboard__hook_shift_num"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            android:key="keyboard__hook_shift_symbol"
+            android:title="@string/keyboard__hook_shift_symbol"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Pull request
1. 同文的软键盘没有大小写锁定键，而是通过模拟长按shift实现连续输入大写字母。
由于shift+空格、数字、部分符号都有另外的功能，导致实际体验较差。
此pr通過在設置中增加開關，部分解决了此问题。
2. 通过模拟shift，修复了librime未处理按键时，不在Android keyevent中的大写字母和部分符号无法被系统处理的问题。
3. 当点击shift后，刷新按键label为组合键模式中的label。
4. 英文标点模式下，符号键显示英文标点。
5. 由于同文目前没有内置numlock的状态处理，当按小键盘按键时，无法发送数字。考虑到常规输入使用的是小键盘的数字功能，自动增加了numlock的锁定mask，从而彻底解决了小键盘输入数字的问题 #804 。

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
6. GitHub action ci pass
7. At least one contributor reviews and votes
8. Can be merged clean without conflicts
9. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
