### PR TITLE
feat: show variable length keys in liquid keyboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/core/Rime.java
+++ b/app/src/main/java/com/osfans/trime/core/Rime.java
@@ -76,6 +76,13 @@ public class Rime {
   public static class RimeCandidate {
     public String text;
     public String comment;
+
+    public RimeCandidate(String text, String comment) {
+      this.text = text;
+      this.comment = comment;
+    }
+
+    public RimeCandidate() {}
   }
 
   /** Rime候選區，包含多個{@link RimeCandidate 候選項} */

--- a/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
@@ -34,7 +34,7 @@ enum class SymbolKeyboardType {
     SHORT,
 
     //  按键长度不固定，与展开候选的样式相同；与
-    VAR,
+    VAR_LENGTH,
 
     //  长度较长，与草稿箱、剪贴板的样式相同，使用小号字体多行展示
     LONG,

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
@@ -20,7 +20,7 @@ import com.osfans.trime.ime.enums.PositionType;
 import com.osfans.trime.ime.text.TextInputManager;
 import java.util.List;
 
-// 显示长度不固定，字体大小正常的内容。用于类型 CANDIDATE, VAR
+// 显示长度不固定，字体大小正常的内容。用于类型 CANDIDATE, VAR_LENGTH
 public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
   private final Context myContext;
   private final TextInputManager textInputManager;

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
@@ -15,20 +15,18 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.flexbox.FlexboxLayoutManager;
 import com.osfans.trime.R;
 import com.osfans.trime.core.Rime;
-import com.osfans.trime.data.AppPrefs;
 import com.osfans.trime.data.Config;
-import com.osfans.trime.ime.core.Trime;
 import com.osfans.trime.ime.enums.PositionType;
 import com.osfans.trime.ime.text.TextInputManager;
+import java.util.List;
 
+// 显示长度不固定，字体大小正常的内容。用于类型 CANDIDATE, VAR
 public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
   private final Context myContext;
   private final TextInputManager textInputManager;
 
   // 候选词
   private Rime.RimeCandidate[] candidates;
-  private Trime trime;
-  private AppPrefs prefs;
 
   private int keyMarginX, keyMarginTop;
   private Integer textColor, textColor2, commentColor;
@@ -42,20 +40,24 @@ public class CandidateAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
   public CandidateAdapter(Context context) {
     myContext = context;
-    trime = Trime.getService();
-    prefs = AppPrefs.defaultInstance();
     candidates = new Rime.RimeCandidate[0];
     textInputManager = TextInputManager.Companion.getInstance();
     comment_position = 0;
   }
 
   public int updateCandidates() {
-
     candidates = Rime.getCandidatesWithoutSwitch();
     if (candidates == null) {
       candidates = new Rime.RimeCandidate[0];
     }
     return candidates.length;
+  }
+
+  public void setCandidates(List<SimpleKeyBean> list) {
+    candidates = new Rime.RimeCandidate[list.size()];
+    for (int i = 0; i < list.size(); i++) {
+      candidates[i] = new Rime.RimeCandidate(list.get(i).getText(), "");
+    }
   }
 
   @Override

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -97,7 +97,13 @@ public class LiquidKeyboard {
         break;
       case CANDIDATE:
         TabManager.get().select(i);
+        initCandidateAdapter();
         initCandidate();
+        break;
+      case VAR:
+        TabManager.get().select(i);
+        initCandidateAdapter();
+        initVAR(i);
         break;
       case HISTORY:
       case TABS:
@@ -336,7 +342,7 @@ public class LiquidKeyboard {
         });
   }
 
-  public void initCandidate() {
+  public void initCandidateAdapter() {
     keyboardView.removeAllViews();
     simpleAdapter = null;
     mClipboardAdapter = null;
@@ -354,13 +360,13 @@ public class LiquidKeyboard {
     flexboxLayoutManager.setJustifyContent(JustifyContent.FLEX_START); // 交叉轴的起点对齐。
     keyboardView.setLayoutManager(flexboxLayoutManager);
 
-    draft_max_size = Config.get(context).getDraftLimit();
-
-    draftBeanList = DraftDao.get().getAllSimpleBean(draft_max_size);
     candidateAdapter.configStyle(margin_x, margin_top);
 
     keyboardView.setAdapter(candidateAdapter);
     keyboardView.setSelected(true);
+  }
+
+  public void initCandidate() {
     candidateAdapter.updateCandidates();
 
     candidateAdapter.setOnItemClickListener(
@@ -369,6 +375,20 @@ public class LiquidKeyboard {
           if (Rime.isComposing()) {
             updateCandidates();
           } else Trime.getService().selectLiquidKeyboard(-1);
+        });
+  }
+
+  public void initVAR(int i) {
+    simpleKeyBeans.clear();
+    simpleKeyBeans.addAll(TabManager.get().select(i));
+    candidateAdapter.setCandidates(simpleKeyBeans);
+    candidateAdapter.setOnItemClickListener(
+        (view, position) -> {
+          InputConnection ic = Trime.getService().getCurrentInputConnection();
+          if (ic != null) {
+            SimpleKeyBean bean = simpleKeyBeans.get(position);
+            ic.commitText(bean.getText(), 1);
+          }
         });
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -100,10 +100,10 @@ public class LiquidKeyboard {
         initCandidateAdapter();
         initCandidate();
         break;
-      case VAR:
+      case VAR_LENGTH:
         TabManager.get().select(i);
         initCandidateAdapter();
-        initVAR(i);
+        initVarLengthKeys(i);
         break;
       case HISTORY:
       case TABS:
@@ -378,7 +378,7 @@ public class LiquidKeyboard {
         });
   }
 
-  public void initVAR(int i) {
+  public void initVarLengthKeys(int i) {
     simpleKeyBeans.clear();
     simpleKeyBeans.addAll(TabManager.get().select(i));
     candidateAdapter.setCandidates(simpleKeyBeans);


### PR DESCRIPTION
## Pull request
让液态键盘支持内容变长的按键。

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

为liquidKeyboard实装了VAR类型（复用了CandidateAdapter）
```
// 范例：
  yanwenzi:
    type: VAR
    name: "颜文字"
    keys: ["⎛⎝≥⏝⏝≤⎠⎞",  "QwQ", "(●—●)",  (๑• . •๑)", (๑•̀ㅂ•́)و✧",  "罒ω罒",  "(｡ì _ í｡)"]
```
#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
