### PR TITLE
feat: define keyboard layout and label in split files

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -985,7 +985,6 @@ preset_keyboards:
     author: "暖暖"
     name: 26键默认布局
     width: 10
-  #  height: 48
     ascii_mode: 0
     keys:
       - {click: q, long_click: 1, key_back_color: bh1, key_text_color: th1}
@@ -1028,6 +1027,179 @@ preset_keyboards:
       - {click: '.', label: '。', long_click: liquid_keyboard_clipboard, key_back_color: bh4, key_text_color: th4}
       - {click: '/', long_click: liquid_keyboard_switch , key_text_size: "18", key_back_color: bh4, key_text_color: th4}
       - {click: Return, composing: Return1, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
+
+  qwerty:
+    author: "tumuyan"
+    name: 26键字母布局
+    import_preset: default
+
+  qwerty0_=:
+    author: "tumuyan"
+    name: 44键布局
+    import_preset: qwerty0_
+
+  qwerty0:
+    author: "tumuyan"
+    name: 26键字母+数字键布局
+    width: 10
+    ascii_mode: 0
+    keys:
+      - {click: '1', key_back_color: bh1, key_text_color: th1}
+      - {click: '2', key_back_color: bh1, key_text_color: th1}
+      - {click: '3', key_back_color: bh1, key_text_color: th1}
+      - {click: '4', key_back_color: bh1, key_text_color: th1}
+      - {click: '5', key_back_color: bh1, key_text_color: th1}
+      - {click: '6', key_back_color: bh1, key_text_color: th1}
+      - {click: '7', key_back_color: bh1, key_text_color: th1}
+      - {click: '8', key_back_color: bh1, key_text_color: th1}
+      - {click: '9', key_back_color: bh1, key_text_color: th1}
+      - {click: '0', key_back_color: bh1, key_text_color: th1}
+
+      - {click: q, long_click: '`', key_back_color: bh1, key_text_color: th1}
+      - {click: w, long_click: '-', key_back_color: bh1, key_text_color: th1}
+      - {click: e, long_click: '=', key_back_color: bh1, key_text_color: th1}
+      - {click: r, long_click: '[', key_back_color: bh1, key_text_color: th1}
+      - {click: t, long_click: ']', key_back_color: bh1, key_text_color: th1}
+      - {click: y, long_click: '\', key_back_color: bh1, key_text_color: th1}
+      - {click: u, long_click: ';', key_back_color: bh1, key_text_color: th1}
+      - {click: i, long_click: "'", key_back_color: bh1, key_text_color: th1}
+      - {click: o, long_click: "{Left}", key_back_color: bh1, key_text_color: th1}
+      - {click: p, long_click: "{Right}", key_back_color: bh1, key_text_color: th1}
+
+      - {width: 5, key_back_color: bh2, key_text_color: th2}
+      - {click: a, long_click: select_all, key_back_color: bh2, key_text_color: th2}
+      - {click: s, long_click: '@', key_back_color: bh2, key_text_color: th2}
+      - {click: d, long_click: '#', key_back_color: bh2, key_text_color: th2}
+      - {click: f, long_click: '$', key_back_color: bh2, key_text_color: th2}
+      - {click: g, long_click: '%', swipe_down: "date_time", key_back_color: bh2, key_text_color: th2}
+      - {click: h, long_click: '!', swipe_down: "+", key_back_color: bh2, key_text_color: th2}
+      - {click: j, long_click: '&', swipe_down: "-", key_back_color: bh2, key_text_color: th2}
+      - {click: k, long_click: '*', swipe_down: "_", key_back_color: bh2, key_text_color: th2}
+      - {click: l, long_click: '(){Left}', swipe_down: "=", key_back_color: bh2, key_text_color: th2}
+      - {width: 5, key_back_color: bh2, key_text_color: th2}
+
+      - {click: Shift_L, composing: delimiter, width: 15, hilited_key_back_color: benter, key_back_color: bbs, key_text_color: tbs}
+      - {click: z, long_click: '`', swipe_down: '[]{Left}', key_back_color: bh3, key_text_color: th3}
+      - {click: x, long_click: cut, swipe_down: '{}{Left}', key_back_color: bh3, key_text_color: th3}
+      - {click: c, long_click: copy, swipe_down: ' ', key_back_color: bh3, key_text_color: th3}
+      - {click: v, long_click: paste_clip, swipe_down: paste, key_back_color: bh3, key_text_color: th3}
+      - {click: b, long_click: ";", swipe_down: "\\", key_back_color: bh3, key_text_color: th3}
+      - {click: n, long_click: ":", key_back_color: bh3, key_text_color: th3}
+      - {click: m, long_click: '?', swipe_down: "|", key_back_color: bh3, key_text_color: th3}
+      - {click: BackSpace, width: 15, key_back_color: bbs, key_text_color: tbs}
+
+      - {click: Keyboard_number, long_click: Menu, width: 12.5, key_back_color: bgn, key_text_color: tgn}
+      - {click: Keyboard_bqrw, long_click: Theme_settings, swipe_down: Color_switch, swipe_up: Color_switch, width: 12.5, key_text_size: "18", key_back_color: bgn, key_text_color: tgn}
+      - {click: ',', label: '，', long_click: '<>{Left}', key_back_color: bh4, key_text_color: th4}
+      - {click: space, long_click: Mode_switch, swipe_left: "Left", swipe_right: "Right", swipe_up: Schema_switchcn, width: 30, key_back_color: bkg, key_text_color: tkg}
+      - {click: '.', label: '。', long_click: liquid_keyboard_clipboard, key_back_color: bh4, key_text_color: th4}
+      - {click: '/', long_click: liquid_keyboard_switch , key_text_size: "18", key_back_color: bh4, key_text_color: th4}
+      - {click: Return, composing: Return1, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
+
+  qwerty_:
+    author: "tumuyan"
+    name: 30键布局
+    width: 10
+    ascii_mode: 0
+    keys:
+      - {click: q, long_click: 1, key_back_color: bh1, key_text_color: th1}
+      - {click: w, long_click: 2, key_back_color: bh1, key_text_color: th1}
+      - {click: e, long_click: 3, key_back_color: bh1, key_text_color: th1}
+      - {click: r, long_click: 4, key_back_color: bh1, key_text_color: th1}
+      - {click: t, long_click: 5, key_back_color: bh1, key_text_color: th1}
+      - {click: y, long_click: 6, key_back_color: bh1, key_text_color: th1}
+      - {click: u, long_click: 7, key_back_color: bh1, key_text_color: th1}
+      - {click: i, long_click: 8, key_back_color: bh1, key_text_color: th1}
+      - {click: o, long_click: 9, key_back_color: bh1, key_text_color: th1}
+      - {click: p, long_click: 0, key_back_color: bh1, key_text_color: th1}
+
+      - {click: a, long_click: select_all, key_back_color: bh2, key_text_color: th2}
+      - {click: s, long_click: '@', key_back_color: bh2, key_text_color: th2}
+      - {click: d, long_click: '#', key_back_color: bh2, key_text_color: th2}
+      - {click: f, long_click: '$', key_back_color: bh2, key_text_color: th2}
+      - {click: g, long_click: '%', swipe_down: "date_time", key_back_color: bh2, key_text_color: th2}
+      - {click: h, long_click: '!', key_back_color: bh2, key_text_color: th2}
+      - {click: j, long_click: '(){Left}', swipe_down: "-", key_back_color: bh2, key_text_color: th2}
+      - {click: k, long_click: '-', key_back_color: bh2, key_text_color: th2}
+      - {click: l, long_click: '=', key_back_color: bh2, key_text_color: th2}
+      - {click: ';', long_click: "'", key_back_color: bh2, key_text_color: th2}
+
+      - {click: Shift_L, composing: delimiter, width: 15, hilited_key_back_color: benter, key_back_color: bbs, key_text_color: tbs}
+      - {click: z, long_click: '`', swipe_down: '[]{Left}', key_back_color: bh3, key_text_color: th3}
+      - {click: x, long_click: cut, swipe_down: '{}{Left}', key_back_color: bh3, key_text_color: th3}
+      - {click: c, long_click: copy, swipe_down: ' ', key_back_color: bh3, key_text_color: th3}
+      - {click: v, long_click: paste_clip, swipe_down: paste, key_back_color: bh3, key_text_color: th3}
+      - {click: b, long_click: "[", key_back_color: bh3, key_text_color: th3}
+      - {click: n, long_click: "]", key_back_color: bh3, key_text_color: th3}
+      - {click: m, long_click: '\\', key_back_color: bh3, key_text_color: th3}
+      - {click: BackSpace, width: 15, key_back_color: bbs, key_text_color: tbs}
+
+      - {click: Keyboard_number, long_click: Menu, width: 12.5, key_back_color: bgn, key_text_color: tgn}
+      - {click: Keyboard_bqrw, long_click: Theme_settings, swipe_down: Color_switch, swipe_up: Color_switch, width: 12.5, key_text_size: "18", key_back_color: bgn, key_text_color: tgn}
+      - {click: ',', long_click: '<>{Left}', key_back_color: bh4, key_text_color: th4}
+      - {click: space, long_click: Mode_switch, swipe_left: "Left", swipe_right: "Right", swipe_up: Schema_switchcn, width: 30, key_back_color: bkg, key_text_color: tkg}
+      - {click: '.', long_click: liquid_keyboard_clipboard, key_back_color: bh4, key_text_color: th4}
+      - {click: '/', long_click: liquid_keyboard_switch , key_text_size: "18", key_back_color: bh4, key_text_color: th4}
+      - {click: Return, composing: Return1, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
+
+
+  qwerty0_:
+    author: "tumuyan"
+    name: 40键布局
+    width: 10
+    ascii_mode: 0
+    keys:
+      - {click: '1', key_back_color: bh1, key_text_color: th1}
+      - {click: '2', key_back_color: bh1, key_text_color: th1}
+      - {click: '3', key_back_color: bh1, key_text_color: th1}
+      - {click: '4', key_back_color: bh1, key_text_color: th1}
+      - {click: '5', key_back_color: bh1, key_text_color: th1}
+      - {click: '6', key_back_color: bh1, key_text_color: th1}
+      - {click: '7', key_back_color: bh1, key_text_color: th1}
+      - {click: '8', key_back_color: bh1, key_text_color: th1}
+      - {click: '9', key_back_color: bh1, key_text_color: th1}
+      - {click: '0', key_back_color: bh1, key_text_color: th1}
+
+      - {click: q, long_click: '`', key_back_color: bh1, key_text_color: th1}
+      - {click: w, long_click: '-', key_back_color: bh1, key_text_color: th1}
+      - {click: e, long_click: '=', key_back_color: bh1, key_text_color: th1}
+      - {click: r, long_click: '[', key_back_color: bh1, key_text_color: th1}
+      - {click: t, long_click: ']', key_back_color: bh1, key_text_color: th1}
+      - {click: y, long_click: '\', key_back_color: bh1, key_text_color: th1}
+      - {click: u, long_click: ';', key_back_color: bh1, key_text_color: th1}
+      - {click: i, long_click: "'", key_back_color: bh1, key_text_color: th1}
+      - {click: o, long_click: "{Left}", key_back_color: bh1, key_text_color: th1}
+      - {click: p, long_click: "{Right}", key_back_color: bh1, key_text_color: th1}
+
+      - {click: a, long_click: select_all, key_back_color: bh2, key_text_color: th2}
+      - {click: s, long_click: '@', key_back_color: bh2, key_text_color: th2}
+      - {click: d, long_click: '#', key_back_color: bh2, key_text_color: th2}
+      - {click: f, long_click: '$', key_back_color: bh2, key_text_color: th2}
+      - {click: g, long_click: '%', swipe_down: "date_time", key_back_color: bh2, key_text_color: th2}
+      - {click: h, long_click: '!', key_back_color: bh2, key_text_color: th2}
+      - {click: j, long_click: '(){Left}', swipe_down: "-", key_back_color: bh2, key_text_color: th2}
+      - {click: k, long_click: '-', key_back_color: bh2, key_text_color: th2}
+      - {click: l, long_click: '=', key_back_color: bh2, key_text_color: th2}
+      - {click: ';', long_click: "'", key_back_color: bh2, key_text_color: th2}
+
+      - {click: Shift_L, composing: delimiter, width: 15, hilited_key_back_color: benter, key_back_color: bbs, key_text_color: tbs}
+      - {click: z, long_click: '`', swipe_down: '[]{Left}', key_back_color: bh3, key_text_color: th3}
+      - {click: x, long_click: cut, swipe_down: '{}{Left}', key_back_color: bh3, key_text_color: th3}
+      - {click: c, long_click: copy, swipe_down: ' ', key_back_color: bh3, key_text_color: th3}
+      - {click: v, long_click: paste_clip, swipe_down: paste, key_back_color: bh3, key_text_color: th3}
+      - {click: b, long_click: "[", key_back_color: bh3, key_text_color: th3}
+      - {click: n, long_click: "]", key_back_color: bh3, key_text_color: th3}
+      - {click: m, long_click: '\\', key_back_color: bh3, key_text_color: th3}
+      - {click: BackSpace, width: 15, key_back_color: bbs, key_text_color: tbs}
+
+      - {click: Keyboard_number, long_click: Menu, width: 12.5, key_back_color: bgn, key_text_color: tgn}
+      - {click: Keyboard_bqrw, long_click: Theme_settings, swipe_down: Color_switch, swipe_up: Color_switch, width: 12.5, key_text_size: "18", key_back_color: bgn, key_text_color: tgn}
+      - {click: ',', long_click: '<>{Left}', key_back_color: bh4, key_text_color: th4}
+      - {click: space, long_click: Mode_switch, swipe_left: "Left", swipe_right: "Right", swipe_up: Schema_switchcn, width: 30, key_back_color: bkg, key_text_color: tkg}
+      - {click: '.', long_click: liquid_keyboard_clipboard, key_back_color: bh4, key_text_color: th4}
+      - {click: '/', long_click: liquid_keyboard_switch , key_text_size: "18", key_back_color: bh4, key_text_color: th4}
+      - {click: Return, composing: Return1, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
+
 
   letter:
     author: "暖暖"

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1051,6 +1051,7 @@ public class Trime extends LifecycleInputMethodService {
   // 处理键盘事件(Android keycode)
   public boolean handleKey(int keyEventCode, int metaState) { // 軟鍵盤
     textInputManager.setNeedSendUpRimeKey(false);
+    // todo 英文模式下，跳过rime处理流程
     if (onRimeKey(Event.getRimeEvent(keyEventCode, metaState))) {
       // 如果输入法消费了按键事件，则需要释放按键
       textInputManager.setNeedSendUpRimeKey(true);

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -660,10 +660,16 @@ public class Keyboard {
           | KeyEvent.META_META_ON
           | KeyEvent.META_SHIFT_ON;
 
+  // shift被锁定，并且没有shift之外的修饰键被按下。
   public boolean isOnlyShiftOn() {
     return (mShiftKey != null
         && mShiftKey.isOn()
         && (mModifierState & MASK_META_WITHOUT_SHIFT) == 0);
+  }
+
+  // 修饰键中只有shift可能被按下
+  public boolean mayShifted() {
+    return (mModifierState & MASK_META_WITHOUT_SHIFT) == 0;
   }
 
   public boolean resetShifted() {


### PR DESCRIPTION
## Pull request
每个主题都只需要设计固定数量的主键盘，就可以自动适配大多数输入方案；
键盘label可以根据用户喜好自由定义；

#### Issue tracker
#827 

#### Feature
对原有方案、主题无影响。

新特性需要在方案中增加如下内容：
```
  schema/keyboard:
    layout: qwerty  #指定皮肤中的按键配列
    label: upcase    #指定keyboard.yaml中的按键label
```
新特性建议在方案中预设如下主键盘（已经对同文风主题增加了必要的键盘）：

- qwerty 基本字母（26字母+`,.`）
- qwerty0 基本字母+数字
- qwerty_ 30键 基本字母+一类符号`,./;`
- qwerty0_ 40键 基本字母+一类符号`,./;`
- qwerty0_= 基本字母+一类符号+二类符号 （考虑到屏幕尺寸，可以不设计此配列，而是使用import_preset: qwerty0_ ）
- 123 默认为中文的数字键盘，使用小键盘数字键+若干必要按键。考虑到目前九键方案不够成熟，可以不设计此配列

新特性需要在build目录放置keyboard.yaml定义键盘label。
#827 已经上传了示例keyboard.yaml文件。

当方案指定的键盘配列存在于主题中时，自动加载对应配列；
当方案指定的label存在于keyboard.yaml文件中时，自动加载中文输入状态下的label。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
