### PR TITLE
液态键盘新增SYMBOL类型, 用于输入符号表内容

### DIFF
--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -698,7 +698,7 @@ liquid_keyboard:
   single_width: 60    #single类型的按键宽度
   vertical_gap: 1     #纵向按键间隙
   margin_x: 0.5         #左右按键间隙的1/2
-  keyboards: [emoji, math, ascii, cn, history, clipboard, collection, draft, tabs, exit, candidate, list, ids , table, symbol, unit, new, jp, pinyin, grease, rusa, korea, lation, yinbiao, yanwenzi, exit]  #tab列表
+  keyboards: [emoji, math, ascii, cn, history, clipboard, collection, draft, tabs, exit, candidate, list, ids , table, symbol, unit, new, jp, pinyin, grease, rusa, korea, lation, yinbiao, yanwenzi, symbollist, exit]  #tab列表
   exit:
     name: 返回
     type: NO_KEY
@@ -816,7 +816,10 @@ liquid_keyboard:
     type: SINGLE
     name: 假名
     keys: "あいうえおかがきぎくぐけげこごさざしじすずせぜそぞただちぢつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろわをんアィイウェエオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロワヲン"
-
+  symbollist:
+    type: SYMBOL
+    name: 符号表
+    keys: [ 符号: '/fh', 电脑: '/dn', 象棋: '/xq', 麻将: '/mj', 骰子: '/sz', 扑克: '/pk', 天气: '/tq', 音乐: '/yy', 八卦: '/bg', 易经: '/lssg', 天体: '/tt',  星座: '/xz',  星号: '/xh',  方块: '/fk',  几何: '/jh',  箭头: '/jt',  数学: '/sx',  上标: '/sb',  下标: '/xb',  单位: '/dw',  货币: '/hb',  拼音: '/py',  注音: '/zy',  假名: '/jm',  片假: '/pjm',  韩文: '/hw',  希腊: '/xl',  希大: '/xld', 罗马:   '/lm',  罗大:   '/lmd', 俄语:   '/ey',  俄大:   '/eyd', 表情:  '/bq',  一: '/1',  二: '/2',  三: '/3',  四: '/4',  五: '/5',  六: '/6',  七: '/7',  八: '/8',  九: '/9',  零: '/0',  十: '/10',  分数: '/fs',  标点: '/bd',  偏旁: '/pp',  竖标:  '/bdz'  ]
 
 
 android_keys:
@@ -922,7 +925,7 @@ preset_keys:
   Keyboard_letter: {label: 字母, send: Eisu_toggle, select: default}
   Keyboard_default: {label: 返回, send: Eisu_toggle, select: .default}
   Keyboard_switch: {label: 鍵盤, send: Eisu_toggle, select: .next}
-  liquid_keyboard_switch: { label: 更多, send: function, command: liquid_keyboard, option: "特殊" }
+  liquid_keyboard_switch: { label: 更多, send: function, command: liquid_keyboard, option: "符号表" }
   liquid_keyboard_exit: {label: 返回, send: function, command: liquid_keyboard, option: "-1"}  #退出liquidkeyboard
   liquid_keyboard_emoji: { label: 🙂, send: function, command: liquid_keyboard, option: "emoji" }
   liquid_keyboard_clipboard: { label: 剪贴, send: function, command: liquid_keyboard, option: "剪贴" }

--- a/app/src/main/java/com/osfans/trime/core/Rime.java
+++ b/app/src/main/java/com/osfans/trime/core/Rime.java
@@ -26,6 +26,7 @@ import com.osfans.trime.data.AppPrefs;
 import com.osfans.trime.data.DataManager;
 import com.osfans.trime.data.opencc.OpenCCDictManager;
 import com.osfans.trime.ime.core.Trime;
+import com.osfans.trime.ime.symbol.SimpleKeyBean;
 import java.io.BufferedReader;
 import java.io.CharArrayWriter;
 import java.io.File;
@@ -46,6 +47,8 @@ import timber.log.Timber;
  *     href="https://github.com/BYVoid/OpenCC">OpenCC</a>
  */
 public class Rime {
+  private static Map<String, Object> mSymbols;
+
   /** Rime編碼區 */
   public static class RimeComposition {
     int length;
@@ -145,6 +148,7 @@ public class Rime {
 
     Map<String, Object> schema = new HashMap<String, Object>();
     List<Map<String, Object>> switches = new ArrayList<Map<String, Object>>();
+    Map<String, Object> symbolMap = new HashMap<>();
 
     public RimeSchema(String schema_id) {
       Timber.d("RimeSchema() start");
@@ -161,6 +165,14 @@ public class Rime {
       o = schema_get_value(schema_id, "menu");
       if (o == null || !(o instanceof HashMap)) return;
       Timber.d("RimeSchema() menu.page_size=" + ((Map<Object, Object>) o).get("page_size"));
+
+      // todo 取回的key正常，value为null，导致symbolMap无法正常使用
+      o = schema_get_value(schema_id, "punctuator/symbols");
+      if (o != null && o instanceof HashMap) {
+        symbolMap = (Map<String, Object>) o;
+      } else {
+        symbolMap = new HashMap<>();
+      }
     }
 
     public void check() {
@@ -328,6 +340,26 @@ public class Rime {
     Timber.d("initSchema() getStatus");
     getStatus();
     Timber.d("initSchema() done");
+    mSymbols = mSchema.symbolMap;
+  }
+
+  public static boolean hasSymbols(String key) {
+    return (mSymbols.containsKey(key));
+  }
+
+  public static List<String> getSymbols(String key) {
+    if (mSymbols.containsKey(key)) {
+      return (List<String>) mSymbols.get(key);
+    }
+    return new ArrayList<String>();
+  }
+
+  public static List<SimpleKeyBean> getSymbolKeyBeans() {
+    List<SimpleKeyBean> list = new ArrayList<>();
+    for (Map.Entry m : mSymbols.entrySet()) {
+      list.add(new SimpleKeyBean(m.getKey().toString()));
+    }
+    return list;
   }
 
   @SuppressWarnings("UnusedReturnValue")

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -427,6 +427,16 @@ public class Trime extends LifecycleInputMethodService {
 
   private SymbolKeyboardType symbolKeyboardType = SymbolKeyboardType.NO_KEY;
 
+  public void inputSymbol(final String text) {
+    textInputManager.onPress(KeyEvent.KEYCODE_UNKNOWN);
+    if (Rime.isAsciiMode()) Rime.setOption("ascii_mode", false);
+    boolean asciiPunch = Rime.isAsciiPunch();
+    if (asciiPunch) Rime.setOption("ascii_punct", false);
+    textInputManager.onText("{Escape}" + text);
+    if (asciiPunch) Rime.setOption("ascii_punct", true);
+    Trime.getService().selectLiquidKeyboard(-1);
+  }
+
   public void selectLiquidKeyboard(final int tabIndex) {
     final LinearLayout symbolInputView =
         inputRootBinding != null ? inputRootBinding.symbol.symbolInput : null;

--- a/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
+++ b/app/src/main/java/com/osfans/trime/ime/enums/SymbolKeyboardType.kt
@@ -33,6 +33,9 @@ enum class SymbolKeyboardType {
     //  按键使用固定宽度。单个字符即按键。SINGLE是默认类型的按键
     SINGLE,
 
+    //  模拟输入符号表的动作，点击后跳转回主键盘
+    SYMBOL,
+
     //  按键使用固定宽度。如不设置宽度，则自动换行
     SHORT,
 

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.java
@@ -121,6 +121,7 @@ public class LiquidKeyboard {
         initCandidateAdapter();
         initVarLengthKeys(i);
         break;
+      case SYMBOL:
       case HISTORY:
       case TABS:
         TabManager.get().select(i);
@@ -254,7 +255,9 @@ public class LiquidKeyboard {
     // 列表适配器的点击监听事件
     simpleAdapter.setOnItemClickListener(
         (view, position) -> {
-          if (keyboardType != SymbolKeyboardType.TABS) {
+          if (keyboardType == SymbolKeyboardType.SYMBOL) {
+            Trime.getService().inputSymbol(simpleKeyBeans.get(position).getText());
+          } else if (keyboardType != SymbolKeyboardType.TABS) {
             InputConnection ic = Trime.getService().getCurrentInputConnection();
             if (ic != null) {
               SimpleKeyBean bean = simpleKeyBeans.get(position);

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
@@ -1,6 +1,7 @@
 package com.osfans.trime.ime.symbol;
 
 import androidx.annotation.NonNull;
+import com.osfans.trime.core.Rime;
 import com.osfans.trime.ime.enums.KeyCommandType;
 import com.osfans.trime.ime.enums.SymbolKeyboardType;
 import java.util.ArrayList;
@@ -119,11 +120,16 @@ public class TabManager {
               String s = (String) o;
               keys.add(new SimpleKeyBean(s));
             } else if (o instanceof Map<?, ?>) {
-              Map<?, ?> p = (Map<?, ?>) o;
+              Map<String, String> p = (Map<String, String>) o;
               if (p.containsKey("click")) {
                 if (p.containsKey("label"))
                   keys.add(new SimpleKeyBean((String) p.get("click"), (String) p.get("label")));
                 else keys.add(new SimpleKeyBean((String) p.get("click")));
+              } else {
+                for (Map.Entry<String, String> entry : p.entrySet()) {
+                  if (Rime.hasSymbols(entry.getValue()))
+                    keys.add(new SimpleKeyBean(entry.getValue(), entry.getKey()));
+                }
               }
             }
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
1. 默认主题已经添加，主键盘点击符号-更多，由原先的打开emoji改为打开符号表。
2. keys列表中的key为显示的label，value为模拟输入的内容
3. 点击此类型的按键后，自动清空输入的内容，切换为中文输入模式、中文标点模式，输入内容到librime后取回候选词、恢复中英文标点模式、返回原先的普通键盘，用户从候选栏选取标点。由于有和方案校验、自动切换模式的机制，超越了同文风symbols键盘。
```
  symbollist:
    type: SYMBOL
    name: 符号表
    keys: [ 符号: '/fh', 电脑: '/dn', 象棋: '/xq', 麻将: '/mj', 骰子: '/sz', 扑克: '/pk', 天气: '/tq', 音乐: '/yy', 八卦: '/bg', 易经: '/lssg', 天体: '/tt',  星座: '/xz',  星号: '/xh',  方块: '/fk',  几何: '/jh',  箭头: '/jt',  数学: '/sx',  上标: '/sb',  下标: '/xb',  单位: '/dw',  货币: '/hb',  拼音: '/py',  注音: '/zy',  假名: '/jm',  片假: '/pjm',  韩文: '/hw',  希腊: '/xl',  希大: '/xld', 罗马:   '/lm',  罗大:   '/lmd', 俄语:   '/ey',  俄大:   '/eyd', 表情:  '/bq',  一: '/1',  二: '/2',  三: '/3',  四: '/4',  五: '/5',  六: '/6',  七: '/7',  八: '/8',  九: '/9',  零: '/0',  十: '/10',  分数: '/fs',  标点: '/bd',  偏旁: '/pp',  竖标:  '/bdz'  ]

```

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
4. Manual build and test pass
5. GitHub action ci pass
6. At least one contributor reviews and votes
7. Can be merged clean without conflicts
8. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
