### PR TITLE
Add memory leak detection library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,6 +116,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
     implementation "com.google.android.flexbox:flexbox:3.0.0"
+    
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 }
 repositories {
     mavenCentral()


### PR DESCRIPTION
# Pull request

## Feature
Add leakcanary Version 2.9.1. leakcanary is a memory leak detection library for Android. 

That’s it, there is no code change needed!
Ref: https://github.com/square/leakcanary

## Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

## Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

## Manual test
- [x] Done

## Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

## Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions
