### PR TITLE
Fix ascii mode setting

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -353,7 +353,6 @@ class TextInputManager private constructor() :
             KeyEvent.KEYCODE_EISU -> { // Switch keyboard
                 KeyboardSwitcher.switchKeyboard(event.select)
                 /** Set ascii mode according to keyboard's settings, can not place into [Rime.handleRimeNotification] */
-                Rime.setOption("ascii_mode", KeyboardSwitcher.currentKeyboard.asciiMode)
                 trime.bindKeyboardToInputView()
                 trime.updateComposing()
             }


### PR DESCRIPTION
## Pull request

#### Issue
Step to reproduce: first switch to the English ascii keyboard then switch to the symbol (符號) keyboard. Then, I expect the keyboard would return to the English keyboard when I press "返回". However, it always goes back to the Chinese keyboard.

#### Feature
I removed a line of code to fix the problem. However, I don't completely understand how the `keyboardSwitcher` settings and options of `Rime` work together, so perhaps this is not the proper fix.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
