### PR TITLE
Fixes reset ascii_mode at switching keyboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -353,7 +353,9 @@ class TextInputManager private constructor() :
             KeyEvent.KEYCODE_EISU -> { // Switch keyboard
                 KeyboardSwitcher.switchKeyboard(event.select)
                 /** Set ascii mode according to keyboard's settings, can not place into [Rime.handleRimeNotification] */
-                Rime.setOption("ascii_mode", KeyboardSwitcher.currentKeyboard.asciiMode)
+                if (shouldResetAsciiMode && KeyboardSwitcher.currentKeyboard.isResetAsciiMode) {
+                    Rime.setOption("ascii_mode", KeyboardSwitcher.currentKeyboard.asciiMode)
+                }
                 trime.bindKeyboardToInputView()
                 trime.updateComposing()
             }


### PR DESCRIPTION
## Pull request

#### Issue tracker

 #897 #879 #808

#### Feature
当切换键盘时，只有设置了 `reset_ascii_mode` 为 `true` 的键盘配置才会重置 `ascii_mode`。


#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [ ] `./gradlew spotlessCheck`
- [ ] `./gradlew assembleDebug`

#### Manual test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
