### PR TITLE
fix: Keyboard label not Change when composing

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.java
@@ -124,7 +124,7 @@ public class Key {
         s = CollectionUtils.obtainString(mk, typeStr, "");
         if (!TextUtils.isEmpty(s)) {
           events[type.ordinal()] = new Event(mKeyboard, s);
-          hasComposingKey = type.ordinal() < KeyEventType.COMBO.ordinal();
+          if (type.ordinal() < KeyEventType.COMBO.ordinal()) hasComposingKey = true;
         } else if (type == KeyEventType.CLICK) {
           events[type.ordinal()] = new Event(mKeyboard, "");
         }


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
当键盘按键定义了composing时，在输入过程中改变按键。

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [ ] `./gradlew spotlessCheck`
- [ ] `./gradlew assembleDebug`

#### Manual test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
