### PR TITLE
Upgrade gradle to 8.0.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ fun buildInfo(): String {
 }
 
 android {
+    namespace = "com.osfans.trime"
     compileSdk = 33
     ndkVersion = "24.0.8215888"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,6 +135,11 @@ android {
         jvmTarget = "1.8"
     }
 
+    // hack workaround lint gradle 8.0.2
+    lintOptions {
+        isCheckReleaseBuilds = false
+    }
+
     externalNativeBuild {
         cmake {
             version = "3.22.1"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,9 +19,7 @@
  */
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.osfans.trime">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
- chore: hack workaround for gradle 8.0.2
- chore: upgrade gralde to 8.0.2
- fix: move namespace to gradle file

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Gradle task
Tasks passed on every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Manual test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login to fetch artifact

https://github.com/osfans/trime/actions

#### Additional Info
