### PR TITLE
Security and privacy: Disable `draft`, `clipboard`, `collection`

### DIFF
--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -698,7 +698,7 @@ liquid_keyboard:
   single_width: 60    #single类型的按键宽度
   vertical_gap: 1     #纵向按键间隙
   margin_x: 0.5         #左右按键间隙的1/2
-  keyboards: [emoji, math, ascii, cn, history, clipboard, collection, draft, tabs, exit, candidate, list, ids , table, symbol, unit, new, jp, pinyin, grease, rusa, korea, lation, yinbiao, yanwenzi, symbollist, exit]  #tab列表
+  keyboards: [emoji, math, ascii, cn, history, tabs, exit, candidate, list, ids , table, symbol, unit, new, jp, pinyin, grease, rusa, korea, lation, yinbiao, yanwenzi, symbollist, exit]  #tab列表
   exit:
     name: 返回
     type: NO_KEY


### PR DESCRIPTION
Security and privacy risk: disable `draft`, `collection` and `clipboard` keyboard in `liquid_keyboard` by default

When using trime as keyboard to unlock your phone in lockscreen, the password is recorded in `draft` keyboard. If you enable `draft` keyboard and your phone is stolen, other people can simply unlock your phone by using your recent input in the `draft` keyboard. For security reason, this should be disable by default.

For privacy reason, `clipboard` and `collection` should also be disabled because it can show sensitive information in lockscreen.