### PR TITLE
chore(CI):Deprecated "set-output" command

### DIFF
--- a/script/cache-hash.sh
+++ b/script/cache-hash.sh
@@ -5,11 +5,11 @@ MAGIC=magic.txt
 echo auto generated contents >> $MAGIC
 
 # fetch jni relative elements
-grep ndkVersion app/build.gradle >> $MAGIC
+grep ndkVersion app/build.gradle.kts >> $MAGIC
 
 elments=("buildTypes" "externalNativeBuild" "splits")
 for element in ${elments[@]}; do
-  awk "/$element/,/\}/" app/build.gradle >> $MAGIC
+  awk "/$element/,/\}/" app/build.gradle.kts >> $MAGIC
 done
 
 JNI_FILES="$MAGIC app/src/main/jni/cmake/* app/src/main/jni/librime_jni/* app/src/main/jni/CMakeLists.txt"
@@ -18,4 +18,4 @@ hash=$(git submodule status)
 hash=$hash$($DIGEST_ALGORITHM $JNI_FILES)
 hash=$(echo $hash | $DIGEST_ALGORITHM | cut -c-64)
 
-echo "::set-output name=hash::$hash"
+echo "{hash}={hash}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Deprecated "set-output" command
(script/cache-hash.sh)Modify filename to build.gradle.kts

## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes

#### Feature
Deprecated "set-output" command
(script/cache-hash.sh)Modify filename to build.gradle.kts

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

