### PR TITLE
add: Monochrome icon for Android 13+ devices

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_app_icon.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_app_icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_app_icon_background"/>
     <foreground android:drawable="@drawable/ic_app_icon_foreground"/>
+    <monochrome android:drawable="@drawable/ic_app_icon_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_app_icon_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_app_icon_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_app_icon_background"/>
     <foreground android:drawable="@drawable/ic_app_icon_foreground"/>
+    <monochrome android:drawable="@drawable/ic_app_icon_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
## Pull request

#### Feature
Add monochrome icon for Android 13+ devices, change the icon color to Material dynamic theme color.

