### PR TITLE
chore: set jdk version of kotlin for codegen module & Set jni Build type for gradle release build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,6 +104,11 @@ android {
             signingConfig = signingConfigs.getByName("release")
 
             resValue("string", "trime_app_name", "@string/app_name_release")
+            externalNativeBuild {
+                cmake {
+                    arguments("-DCMAKE_BUILD_TYPE=Release")
+                }
+            }
         }
         debug {
             applicationIdSuffix = ".debug"

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -4,12 +4,12 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 dependencies {


### PR DESCRIPTION
## Pull request
set jdk version of kotlin for codegen module
Set jni Build type for gradle release build
#### Issue tracker
Fixes will automatically close the related issues

Fixes #
Fixes #1006 #926
#### Feature
Describe features of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

