### PR TITLE
Fix the crash that happens when the screen is rotated.

### DIFF
--- a/app/src/main/java/com/osfans/trime/ui/main/LogActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/LogActivity.kt
@@ -67,7 +67,7 @@ class LogActivity : AppCompatActivity() {
                 rightMargin = navBars.right
                 bottomMargin = navBars.bottom
             }
-            binding.toolbar.toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            binding.logToolbar.toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 topMargin = statusBars.top
             }
             windowInsets
@@ -75,7 +75,7 @@ class LogActivity : AppCompatActivity() {
 
         setContentView(binding.root)
         with(binding) {
-            setSupportActionBar(toolbar.toolbar)
+            setSupportActionBar(logToolbar.toolbar)
             this@LogActivity.logView = logView
             if (intent.hasExtra(FROM_CRASH)) {
                 supportActionBar!!.setTitle(R.string.crash_logs)

--- a/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
@@ -65,11 +65,11 @@ class PrefMainActivity : AppCompatActivity() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
             val statusBars = windowInsets.getInsets(WindowInsetsCompat.Type.statusBars())
             val navBars = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            binding.toolbar.appBar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            binding.prefToolbar.appBar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 leftMargin = navBars.left
                 rightMargin = navBars.right
             }
-            binding.toolbar.toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            binding.prefToolbar.toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 topMargin = statusBars.top
             }
             binding.navHostFragment.updateLayoutParams<ViewGroup.MarginLayoutParams> {
@@ -80,19 +80,19 @@ class PrefMainActivity : AppCompatActivity() {
         }
 
         setContentView(binding.root)
-        setSupportActionBar(binding.toolbar.toolbar)
+        setSupportActionBar(binding.prefToolbar.toolbar)
         val appBarConfiguration = AppBarConfiguration(
             topLevelDestinationIds = setOf(),
             fallbackOnNavigateUpListener = ::onNavigateUpListener,
         )
         navHostFragment =
             supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
-        binding.toolbar.toolbar.setupWithNavController(navHostFragment.navController, appBarConfiguration)
+        binding.prefToolbar.toolbar.setupWithNavController(navHostFragment.navController, appBarConfiguration)
         viewModel.toolbarTitle.observe(this) {
-            binding.toolbar.toolbar.title = it
+            binding.prefToolbar.toolbar.title = it
         }
         viewModel.topOptionsMenu.observe(this) {
-            binding.toolbar.toolbar.menu.forEach { m ->
+            binding.prefToolbar.toolbar.menu.forEach { m ->
                 m.isVisible = it
             }
         }

--- a/app/src/main/res/layout/activity_log.xml
+++ b/app/src/main/res/layout/activity_log.xml
@@ -8,7 +8,7 @@
     tools:context=".ui.main.LogActivity">
 
     <include
-        android:id="@+id/toolbar"
+        android:id="@+id/logToolbar"
         layout="@layout/toolbar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -21,7 +21,7 @@
         app:layout_constraintBottom_toTopOf="@id/logButtons"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@id/logToolbar" />
 
     <LinearLayout
         android:id="@+id/logButtons"

--- a/app/src/main/res/layout/activity_pref.xml
+++ b/app/src/main/res/layout/activity_pref.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include android:id="@+id/toolbar" layout="@layout/toolbar" />
+    <include android:id="@+id/prefToolbar" layout="@layout/toolbar" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"


### PR DESCRIPTION
https://github.com/osfans/trime/issues/1014

## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #
Fix the crash that happens when the screen is rotated.
https://github.com/osfans/trime/issues/1014

在旋转屏幕时，Android系统检测到 `toolbar` 的id重复导致的崩溃。

在主设置界面和日志界面中存在相同的的id `toolbar`



#### Feature
Describe features of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

