### PR TITLE
Fix send twice `Enter`

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -604,9 +604,13 @@ public class Trime extends LifecycleInputMethodService {
   }
 
   private void handleReturnKey() {
-    if (editorInfo == null) sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER);
+    if (editorInfo == null) {
+      sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER);
+      return;
+    }
     if ((editorInfo.inputType & InputType.TYPE_MASK_CLASS) == InputType.TYPE_NULL) {
       sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER);
+      return;
     }
     if (BitFlagsKt.hasFlag(editorInfo.imeOptions, EditorInfo.IME_FLAG_NO_ENTER_ACTION)) {
       final InputConnection ic = getCurrentInputConnection();


### PR DESCRIPTION
1. fix: fix NullPointerException
2. fix: fix send twice enter (https://github.com/osfans/trime/issues/957)

## Pull request

#### Issue tracker
#957 
#1053 

Fixes #
1. fix: fix NullPointerException
2. fix: fix send twice enter

fix #957 

#### Feature
Describe features of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
4. GitHub action ci pass
5. At least one contributor reviews and votes
6. Can be merged clean without conflicts
7. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

