### PR TITLE
Initialize the `keyboardView.layoutManager` every time into the liquid keyboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -410,6 +410,10 @@ public class Trime extends LifecycleInputMethodService {
       symbolInput.getLayoutParams().height = mainInput.getHeight();
       symbolInput.setVisibility(View.VISIBLE);
 
+      // 检测横屏/竖屏  初始化flexbox
+      final int orientation = getResources().getConfiguration().orientation;
+      liquidKeyboard.initFlexbox(orientation==Configuration.ORIENTATION_LANDSCAPE);
+
       symbolKeyboardType = liquidKeyboard.select(tabIndex);
       tabView.updateTabWidth();
       if (inputRootBinding != null) {

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -410,10 +410,6 @@ public class Trime extends LifecycleInputMethodService {
       symbolInput.getLayoutParams().height = mainInput.getHeight();
       symbolInput.setVisibility(View.VISIBLE);
 
-      // 检测横屏/竖屏  初始化flexbox
-      final int orientation = getResources().getConfiguration().orientation;
-      liquidKeyboard.initFlexbox(orientation==Configuration.ORIENTATION_LANDSCAPE);
-
       symbolKeyboardType = liquidKeyboard.select(tabIndex);
       tabView.updateTabWidth();
       if (inputRootBinding != null) {

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -35,13 +35,7 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
     private lateinit var keyboardView: RecyclerView
     private val symbolHistory = SymbolHistory(180)
 
-    private val flexbox: FlexboxLayoutManager by lazy {
-        return@lazy FlexboxLayoutManager(context).apply {
-            flexDirection = FlexDirection.ROW // 主轴为水平方向，起点在左端。
-            flexWrap = FlexWrap.WRAP // 按正常方向换行
-            justifyContent = JustifyContent.FLEX_START // 交叉轴的起点对齐
-        }
-    }
+    private lateinit var flexbox: FlexboxLayoutManager
 
     private val oneColumnStaggeredGrid: StaggeredGridLayoutManager by lazy {
         return@lazy StaggeredGridLayoutManager(1, StaggeredGridLayoutManager.VERTICAL)
@@ -53,6 +47,25 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
             val space = dp2px(3)
             addItemDecoration(SpacesItemDecoration(space))
             setPadding(space)
+        }
+    }
+
+    /**
+     * 根据屏幕状态初始化 flexbox
+     */
+    fun initFlexbox(isLandscape: Boolean) {
+        if (isLandscape) {
+            flexbox = FlexboxLayoutManager(context).apply {
+                flexDirection = FlexDirection.COLUMN // 主轴为垂直方向，起点在左端。
+                flexWrap = FlexWrap.WRAP // 按正常方向换行
+                justifyContent = JustifyContent.FLEX_START // 交叉轴的起点对齐
+            }
+        } else {
+            flexbox = FlexboxLayoutManager(context).apply {
+                flexDirection = FlexDirection.ROW // 主轴为水平方向，起点在左端。
+                flexWrap = FlexWrap.WRAP // 按正常方向换行
+                justifyContent = JustifyContent.FLEX_START // 交叉轴的起点对齐
+            }
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -35,12 +35,6 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
     private lateinit var keyboardView: RecyclerView
     private val symbolHistory = SymbolHistory(180)
 
-    private lateinit var flexbox: FlexboxLayoutManager
-
-    private val oneColumnStaggeredGrid: StaggeredGridLayoutManager by lazy {
-        return@lazy StaggeredGridLayoutManager(1, StaggeredGridLayoutManager.VERTICAL)
-    }
-
     fun setKeyboardView(view: RecyclerView) {
         keyboardView = view
         keyboardView.apply {
@@ -50,23 +44,26 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
         }
     }
 
+// 及时更新layoutManager, 以防在旋转屏幕后打开液体键盘crash
     /**
-     * 根据屏幕状态初始化 flexbox
+     * 使用FlexboxLayoutManager时调用此函数获取
      */
-    fun initFlexbox(isLandscape: Boolean) {
-        if (isLandscape) {
-            flexbox = FlexboxLayoutManager(context).apply {
-                flexDirection = FlexDirection.COLUMN // 主轴为垂直方向，起点在左端。
-                flexWrap = FlexWrap.WRAP // 按正常方向换行
-                justifyContent = JustifyContent.FLEX_START // 交叉轴的起点对齐
-            }
-        } else {
-            flexbox = FlexboxLayoutManager(context).apply {
-                flexDirection = FlexDirection.ROW // 主轴为水平方向，起点在左端。
-                flexWrap = FlexWrap.WRAP // 按正常方向换行
-                justifyContent = JustifyContent.FLEX_START // 交叉轴的起点对齐
-            }
+    private fun getFlexbox(): FlexboxLayoutManager {
+        return FlexboxLayoutManager(context).apply {
+            flexDirection = FlexDirection.ROW // 主轴为水平方向，起点在左端。
+            flexWrap = FlexWrap.WRAP // 按正常方向换行
+            justifyContent = JustifyContent.FLEX_START // 交叉轴的起点对齐
         }
+    }
+
+    /**
+     * 使用StaggeredGridLayoutManager时调用此函数获取
+     */
+    private fun getOneColumnStaggeredGrid(): StaggeredGridLayoutManager {
+        return StaggeredGridLayoutManager(
+            1,
+            StaggeredGridLayoutManager.VERTICAL,
+        )
     }
 
     fun select(i: Int): SymbolKeyboardType {
@@ -137,7 +134,7 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
             }
         }
         keyboardView.apply {
-            layoutManager = flexbox
+            layoutManager = getFlexbox()
             /*
             Timber.d(
                 "configStylet() single_width=%s, keyHeight=%s, margin_x=%s, margin_top=%s",
@@ -239,7 +236,7 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
             })
         }
         keyboardView.apply {
-            layoutManager = oneColumnStaggeredGrid
+            layoutManager = getOneColumnStaggeredGrid()
             adapter = dbAdapter
             // 调用ListView的setSelected(!ListView.isSelected())方法，这样就能及时刷新布局
             isSelected = true
@@ -281,7 +278,7 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
         }
         // 设置布局管理器
         keyboardView.apply {
-            layoutManager = flexbox
+            layoutManager = getFlexbox()
             adapter = candidateAdapter
             isSelected = true
         }
@@ -298,7 +295,7 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
         }
         // 设置布局管理器
         keyboardView.apply {
-            layoutManager = flexbox
+            layoutManager = getFlexbox()
             adapter = candidateAdapter
             keyboardView.isSelected = true
         }


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #
~~fix: init flexbox by screen orientation~~ **This commit message is wrong description.**

**Initialize the keyboardView.layoutManager every time into the liquid keyboard.**


**修复的bug：**
当旋转屏幕后（无论期间是否开启过键盘；如果开启过键盘，那么将100%复现），打开液体键盘（liquid keyboard）有一定几率导致crash。而在3.2.6版本中并没有这个问题。


crash log: 
[com.osfans.trime-2023-06-20T11_09_41Z.txt](https://github.com/osfans/trime/files/12241687/com.osfans.trime-2023-06-20T11_09_41Z.txt)
[com.osfans.trime-2023-07-18T18_08_43Z.txt](https://github.com/osfans/trime/files/12241688/com.osfans.trime-2023-07-18T18_08_43Z.txt)
[com.osfans.trime-2023-07-31T01_57_54Z.txt](https://github.com/osfans/trime/files/12241703/com.osfans.trime-2023-07-31T01_57_54Z.txt)
[com.osfans.trime-2023-08-02T03_16_34Z.txt](https://github.com/osfans/trime/files/12241705/com.osfans.trime-2023-08-02T03_16_34Z.txt)


> 持续追踪了两个月，今天终于发现稳定复现bug的方法，经过调试并和历史源码对比，最终确定修复方法


#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

