### PR TITLE
fix: don't ensure at least one `EXIT` in liquid keyboard tabs

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
@@ -20,7 +20,6 @@ public class TabManager {
   private final List<List<SimpleKeyBean>> keyboards = new ArrayList<>();
   private static TabManager self;
   private final List<SimpleKeyBean> notKeyboard = new ArrayList<>();
-  private final TabTag tagExit = new TabTag("返回", SymbolKeyboardType.NO_KEY, KeyCommandType.EXIT);
 
   public static void updateSelf() {
     self = new TabManager();
@@ -221,17 +220,6 @@ public class TabManager {
   }
 
   public ArrayList<TabTag> getTabCandidates() {
-    boolean addExit = true;
-    for (TabTag tag : tabTags) {
-      if (tag.command == KeyCommandType.EXIT) {
-        addExit = false;
-        break;
-      }
-    }
-    if (addExit) {
-      tabTags.add(tagExit);
-      keyboards.add(notKeyboard);
-    }
     return tabTags;
   }
 }


### PR DESCRIPTION
We have floating window for liquid keyboard since 33c348734acd842197ffb4c1701e18376abb7948, `EXIT` is not always necessary in tabs.