### PR TITLE
fix: timing sync crash above Android 12

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/broadcast/IntentReceiver.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/IntentReceiver.kt
@@ -72,7 +72,11 @@ class IntentReceiver : BroadcastReceiver(), CoroutineScope by MainScope() {
                     context,
                     0,
                     Intent("com.osfans.trime.timing.sync"),
-                    PendingIntent.FLAG_UPDATE_CURRENT,
+                    if (VERSION.SDK_INT >= VERSION_CODES.M) {
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    } else {
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                    },
                 )
                 if (VERSION.SDK_INT >= VERSION_CODES.M) { // 根据SDK设置alarm任务
                     alarmManager.setExactAndAllowWhileIdle(

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -339,7 +339,9 @@ public class Trime extends LifecycleInputMethodService {
               this,
               0,
               new Intent("com.osfans.trime.timing.sync"),
-              PendingIntent.FLAG_UPDATE_CURRENT);
+              VERSION.SDK_INT >= VERSION_CODES.M
+                  ? (PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE)
+                  : PendingIntent.FLAG_UPDATE_CURRENT);
       if (VERSION.SDK_INT >= VERSION_CODES.M) { // 根据SDK设置alarm任务
         alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerTime, pendingIntent);
       } else {

--- a/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
@@ -114,7 +114,11 @@ class ProfileFragment :
                     context,
                     0,
                     Intent("com.osfans.trime.timing.sync"),
-                    PendingIntent.FLAG_UPDATE_CURRENT,
+                    if (VERSION.SDK_INT >= VERSION_CODES.M) {
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    } else {
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                    },
                 )
                 val cal = Calendar.getInstance()
                 if (get<SwitchPreferenceCompat>("profile_timing_sync")?.isChecked == true) { // 当定时同步偏好打开时


### PR DESCRIPTION
We need explicitly specify the mutability of PendingIntent above Android 12 and it's better to use immutable flag (added in API level 23, M) as we just use the intent directly.

## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #

#### Feature
Describe features of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

