### PR TITLE
Fix incorrect sheme ID when getting keyboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/theme/Theme.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/Theme.kt
@@ -250,9 +250,8 @@ class Theme {
             val remapped =
                 if (".default" == name) {
                     val currentSchemaId = Rime.getCurrentRimeSchema()
-                    val shortSchemaId = currentSchemaId.split("_".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()[0]
-                    if (theme.presetKeyboards!!.containsKey(shortSchemaId)) {
-                        return shortSchemaId
+                    if (theme.presetKeyboards!!.containsKey(currentSchemaId)) {
+                        return currentSchemaId
                     } else {
                         val alphabet = SchemaManager.getActiveSchema().alphabet
                         val twentySix = "qwerty"

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -966,7 +966,13 @@ public class Trime extends LifecycleInputMethodService {
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
     Timber.i("\t<TrimeInput>\tonKeyDown()\tkeycode=%d, event=%s", keyCode, event.toString());
-    if (composeEvent(event) && onKeyEvent(event)) return true;
+    if (composeEvent(event) && onKeyEvent(event)) {
+      if (!isWindowShown) {
+        return super.onKeyDown(keyCode, event);
+      } else {
+        return true;
+      }
+    }
     return super.onKeyDown(keyCode, event);
   }
 
@@ -975,7 +981,11 @@ public class Trime extends LifecycleInputMethodService {
     Timber.i("\t<TrimeInput>\tonKeyUp()\tkeycode=%d, event=%s", keyCode, event.toString());
     if (composeEvent(event) && textInputManager.getNeedSendUpRimeKey()) {
       textInputManager.onRelease(keyCode);
-      return true;
+      if (!isWindowShown) {
+        return super.onKeyUp(keyCode, event);
+      } else {
+        return true;
+      }
     }
     return super.onKeyUp(keyCode, event);
   }


### PR DESCRIPTION

## Pull request

Fix scheme ID when getting its keyboard, and throw out volume key event if keyboard is not visible.

#### Issue tracker
Fixes will automatically close the related issues

Fixes #803
Fix #907

#### Feature
Describe features of pull request

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

