### PR TITLE
fix: missing init values for `LandscapeInputUIMode`

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/landscapeinput/LandscapeInputUIMode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/landscapeinput/LandscapeInputUIMode.kt
@@ -10,7 +10,12 @@ enum class LandscapeInputUIMode {
     ;
 
     companion object {
-        private val convertMap: HashMap<String, LandscapeInputUIMode> = hashMapOf()
+        private val convertMap: HashMap<String, LandscapeInputUIMode> =
+            hashMapOf(
+                Pair("AUTO_SHOW", AUTO_SHOW),
+                Pair("ALWAYS_SHOW", ALWAYS_SHOW),
+                Pair("NEVER_SHOW", NEVER_SHOW),
+            )
 
         fun fromString(mode: String): LandscapeInputUIMode {
             val type = convertMap[mode.uppercase(Locale.getDefault())]


### PR DESCRIPTION
Supply the initial values so it can correctly convert `String` to `enum`.


## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #930

#### Feature
Describe features of pull request

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [ ] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

