### PR TITLE
fix: float window covers the input text on top/bottom edge

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -144,13 +144,12 @@ public class Trime extends LifecycleInputMethodService {
           if (mCandidateRoot == null || mCandidateRoot.getWindowToken() == null) return;
           if (!isPopupWindowEnabled) return;
 
-          final int minX = popupMarginH;
-          final int minY = popupMargin;
-
           DisplayMetrics displayMetrics = new DisplayMetrics();
           getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
-          final int maxX = displayMetrics.widthPixels - mPopupWindow.getWidth() - minX;
-          final int maxY = displayMetrics.heightPixels - mPopupWindow.getHeight() - minY;
+          final int minX = popupMarginH;
+          final int maxX = displayMetrics.widthPixels - mPopupWindow.getWidth() - popupMarginH;
+          final int minY = popupMargin + BarUtils.getStatusBarHeight() + mPopupWindow.getHeight();
+          final int maxY = displayMetrics.heightPixels - popupMargin - mPopupWindow.getHeight();
 
           int x = minX, y = minY;
           if (isWinFixed() || !isCursorUpdated) {
@@ -177,31 +176,35 @@ public class Trime extends LifecycleInputMethodService {
           } else {
             switch (popupWindowPos) {
               case LEFT:
-                x = (int) mPopupRectF.left;
-                y = (int) mPopupRectF.bottom + popupMargin;
-                break;
               case LEFT_UP:
                 x = (int) mPopupRectF.left;
-                y = (int) mPopupRectF.top - mPopupWindow.getHeight() - popupMargin;
                 break;
               case RIGHT:
-                x = (int) mPopupRectF.right;
-                y = (int) mPopupRectF.bottom + popupMargin;
-                break;
               case RIGHT_UP:
               default:
                 x = (int) mPopupRectF.right;
-                y = (int) mPopupRectF.top - mPopupWindow.getHeight() - popupMargin;
+            }
+            x = Math.max(minX, x);
+            x = Math.min(maxX, x);
+
+            switch (popupWindowPos) {
+              case RIGHT_UP:
+              case LEFT_UP:
+                y =
+                    ((int) mPopupRectF.top < minY)
+                        ? (int) mPopupRectF.bottom + popupMargin
+                        : (int) mPopupRectF.top - mPopupWindow.getHeight() - popupMargin;
                 break;
+              case RIGHT:
+              case LEFT:
+              default:
+                y =
+                    ((int) mPopupRectF.bottom > maxY)
+                        ? (int) mPopupRectF.top - mPopupWindow.getHeight() - popupMargin
+                        : (int) mPopupRectF.bottom + popupMargin;
             }
           }
-
-          // 只要修正一次就可以，别让悬浮窗超出了屏幕界限
-          x = Math.max(minX, x);
-          x = Math.min(maxX, x);
           y -= BarUtils.getStatusBarHeight(); // 不包含狀態欄
-          y = Math.max(minY, y);
-          y = Math.min(maxY, y);
 
           if (!mPopupWindow.isShowing()) {
             mPopupWindow.showAtLocation(mCandidateRoot, Gravity.START | Gravity.TOP, x, y);


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #

#### Feature

当在屏幕的上边缘或下边缘编辑文本的时候，悬浮窗口会遮挡正在上屏（包括刚刚已经上屏）的文字，该PR给出的方案是：

判断y轴的当前值与悬浮窗height的综合加减后，与y的可允许最大最小值比较，从而完成：

① 当在屏幕顶端编辑的时候，如果悬浮窗遮挡了正在上屏输入的文字，就会把悬浮窗口设置到输入框的下方来，即自动变成LEFT/RIGHT的样式；
② 当在屏幕底部编辑的时候，如果悬浮窗口遮挡了正在上屏的文字，就会把悬浮窗口设置到输入框的上方来，即自动变成LEFT_UP/RIGHT_UP的样式。

这样就能解决上下边缘编辑文字的时候，文字被遮挡的问题。同时也与商业输入法的样式保持一致。（注，x轴没有这个问题。) 

烦请审核。

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [ ] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

