### PR TITLE
fix: reset to original state when restarting input in the same view

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1257,7 +1257,7 @@ public class Trime extends LifecycleInputMethodService {
   }
 
   /** 模擬PC鍵盤中Esc鍵的功能：清除輸入的編碼和候選項 */
-  private void performEscape() {
+  public void performEscape() {
     if (isComposing()) textInputManager.onKey(KeyEvent.KEYCODE_ESCAPE, 0);
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -189,6 +189,9 @@ class TextInputManager private constructor() :
         ) {
             super.onStartInputView(instance, restarting)
             Trime.getService().selectLiquidKeyboard(-1)
+            if (restarting) {
+                trime.performEscape()
+            }
             isComposable = false
             var tempAsciiMode = if (shouldResetAsciiMode) false else null
             val keyboardType =


### PR DESCRIPTION
## Pull request

#### Issue tracker

Fixes #1134

#### Feature
Clear any composing input or view when input is restarted in the same text view, thus ensuring a fresh input UI.

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [ ] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

