### PR TITLE
Refactor and fix matrix build CI

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -25,10 +25,10 @@ jobs:
           echo ${GITHUB_REF#refs/*/}
           echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
-      - name: Install coreutils macOS
+      - name: Install macOS utils
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install coreutils
+          brew install coreutils clang-format
 
       - name: Calculate JNI cache hash
         id: cache-hash

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -27,7 +27,7 @@ jobs:
           echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
       - name: Install macOS utils
-        if: startsWith(matrix.os, 'macOS')
+        if: startsWith(matrix.os, 'macos')
         run: |
           brew install coreutils clang-format
 

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -11,7 +11,7 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-13
-          - windows-2022
+          # - windows-2022
     steps:
       - name: Fetch source code
         uses: actions/checkout@v4

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -11,7 +11,7 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-13
-          # - windows-2022
+          - windows-2022
     steps:
       - name: Fetch source code
         uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 17
           # will restore cache of dependencies and wrappers
           cache: 'gradle'
 
@@ -59,7 +59,7 @@ jobs:
         uses: android-actions/setup-android@v3
         
       - name: Check code style
-        shell: bash
+        if: ${{ !startsWith(matrix.os, 'windows') }}
         run: |
           make style-lint
 

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -25,6 +25,11 @@ jobs:
           echo ${GITHUB_REF#refs/*/}
           echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
+      - name: Install coreutils macOS
+        if: startsWith(matrix.os, 'macOS')
+        run: |
+          brew install coreutils
+
       - name: Calculate JNI cache hash
         id: cache-hash
         shell: bash

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -52,9 +52,6 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
         
       - name: Check code style
         run: |

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 21
           # will restore cache of dependencies and wrappers
           cache: 'gradle'
 

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -35,7 +35,7 @@ jobs:
         id: jni-cache
         with:
           path: "app/prebuilt"
-          key: jni-debug-${{ steps.cache-hash.outputs.hash }}
+          key: ${{ matrix.os }}-trime-jni-debug-${{ steps.cache-hash.outputs.hash }}
 
       - name: Fetch submodules
         if: ${{ !steps.jni-cache.outputs.cache-hit }}

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -59,8 +59,9 @@ jobs:
         uses: android-actions/setup-android@v3
         
       - name: Check code style
+        shell: bash
         run: |
-          ./gradlew spotlessCheck
+          make style-lint
 
       # `make debug` works not well on Windows
       - name: Build debug Trime

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         
-      - name: Check code format
+      - name: Check code style
         run: |
           ./gradlew spotlessCheck
 

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -58,7 +58,7 @@ jobs:
           ./gradlew spotlessCheck
 
       # `make debug` works not well on Windows
-      - name: Build Debug APK
+      - name: Build debug Trime
         run: |
           ./gradlew :app:assembleDebug
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -66,8 +66,9 @@ jobs:
         uses: android-actions/setup-android@v3
         
       - name: Check code style
+        shell: bash
         run: |
-          ./gradlew spotlessCheck
+          make style-lint
 
       # `make debug` works not well on Windows
       - name: Build debug Trime

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         
-      - name: Check code format
+      - name: Check code style
         run: |
           ./gradlew spotlessCheck
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 21
           # will restore cache of dependencies and wrappers
           cache: 'gradle'
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -32,6 +32,11 @@ jobs:
           echo ${GITHUB_REF#refs/*/}
           echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
+      - name: Install coreutils macOS
+        if: startsWith(matrix.os, 'macOS')
+        run: |
+          brew install coreutils
+
       - name: Calculate JNI cache hash
         id: cache-hash
         shell: bash

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -42,7 +42,7 @@ jobs:
         id: jni-cache
         with:
           path: "app/prebuilt"
-          key: jni-debug-${{ steps.cache-hash.outputs.hash }}
+          key: ${{ matrix.os }}-trime-jni-debug-${{ steps.cache-hash.outputs.hash }}
 
       - name: Fetch submodules
         if: ${{ !steps.jni-cache.outputs.cache-hit }}

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -59,9 +59,6 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
         
       - name: Check code style
         run: |

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -34,7 +34,7 @@ jobs:
           echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
       - name: Install macOS utils
-        if: startsWith(matrix.os, 'macOS')
+        if: startsWith(matrix.os, 'macos')
         run: |
           brew install coreutils clang-format
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -65,7 +65,7 @@ jobs:
           ./gradlew spotlessCheck
 
       # `make debug` works not well on Windows
-      - name: Build Debug APK
+      - name: Build debug Trime
         run: |
           ./gradlew :app:assembleDebug
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-13
-          # - windows-2022
+          - windows-2022
     steps:
       - name: Fetch source code
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 17
           # will restore cache of dependencies and wrappers
           cache: 'gradle'
 
@@ -66,7 +66,7 @@ jobs:
         uses: android-actions/setup-android@v3
         
       - name: Check code style
-        shell: bash
+        if: ${{ !startsWith(matrix.os, 'windows') }}
         run: |
           make style-lint
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-13
-          - windows-2022
+          # - windows-2022
     steps:
       - name: Fetch source code
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -32,10 +32,10 @@ jobs:
           echo ${GITHUB_REF#refs/*/}
           echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
-      - name: Install coreutils macOS
+      - name: Install macOS utils
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install coreutils
+          brew install coreutils clang-format
 
       - name: Calculate JNI cache hash
         id: cache-hash

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -29,7 +29,7 @@ jobs:
         id: jni-cache
         with:
           path: "app/prebuilt"
-          key: jni-release-${{ steps.cache-hash.outputs.hash }}
+          key: ${{ matrix.os }}-trime-jni-debug-${{ steps.cache-hash.outputs.hash }}
 
       - name: Fetch submodules
         if: ${{ !steps.jni-cache.outputs.cache-hit }}

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 21
           # will restore cache of dependencies and wrappers
           cache: 'gradle'
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -29,7 +29,7 @@ jobs:
         id: jni-cache
         with:
           path: "app/prebuilt"
-          key: ${{ matrix.os }}-trime-jni-debug-${{ steps.cache-hash.outputs.hash }}
+          key: ${{ runner.os }}-trime-jni-debug-${{ steps.cache-hash.outputs.hash }}
 
       - name: Fetch submodules
         if: ${{ !steps.jni-cache.outputs.cache-hit }}


### PR DESCRIPTION
## Pull request
Refactor and fix matrix build CI

- ci: add matrix os in cache key
- ci: rename code style job name
- ci: upgrade checkout action to v4 in release
- ci: remove duplicated gradle setup job
- ci: upgrade jdk to 21
- ci: rename build trime job name
- ci: fix sha256sum not found in macOS
- ci: check C++ files with style job
- ci: disable windows runner due to build issue
- ci: install clang-format in macOS

#### Issue tracker
Fixes will automatically close the related issues

Fixes #

#### Feature
Describe features of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

