### PR TITLE
Rollback 1133

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -698,17 +698,20 @@ public class Trime extends LifecycleInputMethodService {
     super.onUpdateSelection(
         oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesStart, candidatesEnd);
     if ((candidatesEnd != -1) && ((newSelStart != candidatesEnd) || (newSelEnd != candidatesEnd))) {
-      // 移動光標時，更新候選區
-      if ((newSelEnd < candidatesEnd) && (newSelEnd >= candidatesStart)) {
-        final int n = newSelEnd - candidatesStart;
-        Rime.setCaretPos(n);
-        updateComposing();
-      }
+      // 移動光標時，commit
+      getCurrentInputConnection().finishComposingText();
+      performEscape();
     }
     if ((candidatesStart == -1 && candidatesEnd == -1) && (newSelStart == 0 && newSelEnd == 0)) {
       // 上屏後，清除候選區
       performEscape();
     }
+    if (candidatesEnd < newSelEnd || candidatesStart > newSelStart) {
+      // 點擊在"輸入文字"外，上屏
+      getCurrentInputConnection().finishComposingText();
+      performEscape();
+    }
+
     // Update the caps-lock status for the current cursor position.
     dispatchCapsStateToInputView();
   }
@@ -913,7 +916,13 @@ public class Trime extends LifecycleInputMethodService {
     return Rime.isComposing();
   }
 
+  /**
+   * Commit the current composing text together with the new text
+   *
+   * @param text the new text to be committed
+   */
   public void commitText(String text) {
+    getCurrentInputConnection().finishComposingText();
     activeEditorInstance.commitText(text, true);
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -698,20 +698,17 @@ public class Trime extends LifecycleInputMethodService {
     super.onUpdateSelection(
         oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesStart, candidatesEnd);
     if ((candidatesEnd != -1) && ((newSelStart != candidatesEnd) || (newSelEnd != candidatesEnd))) {
-      // 移動光標時，commit
-      getCurrentInputConnection().finishComposingText();
-      performEscape();
+      // 移動光標時，更新候選區
+      if ((newSelEnd < candidatesEnd) && (newSelEnd >= candidatesStart)) {
+        final int n = newSelEnd - candidatesStart;
+        Rime.setCaretPos(n);
+        updateComposing();
+      }
     }
     if ((candidatesStart == -1 && candidatesEnd == -1) && (newSelStart == 0 && newSelEnd == 0)) {
       // 上屏後，清除候選區
       performEscape();
     }
-    if (candidatesEnd < newSelEnd || candidatesStart > newSelStart) {
-      // 點擊在"輸入文字"外，上屏
-      getCurrentInputConnection().finishComposingText();
-      performEscape();
-    }
-
     // Update the caps-lock status for the current cursor position.
     dispatchCapsStateToInputView();
   }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1257,7 +1257,7 @@ public class Trime extends LifecycleInputMethodService {
   }
 
   /** 模擬PC鍵盤中Esc鍵的功能：清除輸入的編碼和候選項 */
-  private void performEscape() {
+  public void performEscape() {
     if (isComposing()) textInputManager.onKey(KeyEvent.KEYCODE_ESCAPE, 0);
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -105,12 +105,10 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
                     if (tabTag.type === SymbolKeyboardType.SYMBOL) {
                         service.inputSymbol(bean.text)
                     } else if (tabTag.type !== SymbolKeyboardType.TABS) {
-                        service.currentInputConnection?.run {
-                            commitText(bean.text, 1)
-                            if (tabTag.type !== SymbolKeyboardType.HISTORY) {
-                                symbolHistory.insert(bean.text)
-                                symbolHistory.save()
-                            }
+                        service.commitText(bean.text)
+                        if (tabTag.type !== SymbolKeyboardType.HISTORY) {
+                            symbolHistory.insert(bean.text)
+                            symbolHistory.save()
                         }
                     } else {
                         val tag = TabManager.get().getTabSwitchTabTag(position)
@@ -162,7 +160,7 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
                 setListener(
                     object : FlexibleAdapter.Listener {
                         override fun onPaste(bean: DatabaseBean) {
-                            service.currentInputConnection?.commitText(bean.text, 1)
+                            service.commitText(bean.text)
                         }
 
                         override suspend fun onPin(bean: DatabaseBean) {

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -189,6 +189,9 @@ class TextInputManager private constructor() :
         ) {
             super.onStartInputView(instance, restarting)
             Trime.getService().selectLiquidKeyboard(-1)
+            if (restarting) {
+                trime.performEscape()
+            }
             isComposable = false
             var tempAsciiMode = if (shouldResetAsciiMode) false else null
             val keyboardType =


### PR DESCRIPTION
## Pull request

#### Issue tracker
Rollback: "text cursor change then commit text"


#### Feature
Sometimes `onUpdateSelection()` will be called before the cursor or the candidate's length changed, causing `commitText` incorrectly.  Need to add more condition and find out the reason behind.

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

