### PR TITLE
fix: rollback of dc27449

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -701,20 +701,17 @@ public class Trime extends LifecycleInputMethodService {
     super.onUpdateSelection(
         oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesStart, candidatesEnd);
     if ((candidatesEnd != -1) && ((newSelStart != candidatesEnd) || (newSelEnd != candidatesEnd))) {
-      // 移動光標時，commit
-      getCurrentInputConnection().finishComposingText();
-      performEscape();
+      // 移動光標時，更新候選區
+      if ((newSelEnd < candidatesEnd) && (newSelEnd >= candidatesStart)) {
+        final int n = newSelEnd - candidatesStart;
+        Rime.setCaretPos(n);
+        updateComposing();
+      }
     }
     if ((candidatesStart == -1 && candidatesEnd == -1) && (newSelStart == 0 && newSelEnd == 0)) {
       // 上屏後，清除候選區
       performEscape();
     }
-    if (candidatesEnd < newSelEnd || candidatesStart > newSelStart) {
-      // 點擊在"輸入文字"外，上屏
-      getCurrentInputConnection().finishComposingText();
-      performEscape();
-    }
-
     // Update the caps-lock status for the current cursor position.
     dispatchCapsStateToInputView();
   }


### PR DESCRIPTION
Rollback: "text cursor change then commit text", part of the commit in dc27449

#### Feature
Sometimes `onUpdateSelection()` will be called before the cursor or the candidate's length changes, causing `commitText` incorrectly. Need to add more conditions and find out the reason behind them.

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

