### PR TITLE
fix: handle html hex code input

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/theme/Theme.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/Theme.kt
@@ -236,16 +236,24 @@ class Theme private constructor(isDarkMode: Boolean) {
         ): Drawable? {
             if (key == null) return null
             val o = theme.currentColors[key]
+            var color = o
             if (o is String) {
-                val bitmap = bitmapDrawable(o)
-                if (bitmap != null) {
-                    if (!alphaKey.isNullOrEmpty() && theme.style.getObject(alphaKey) != null) {
-                        bitmap.alpha = MathUtils.clamp(theme.style.getInt(alphaKey), 0, 255)
+                if (isImageString(o)) {
+                    val bitmap = bitmapDrawable(o)
+                    if (bitmap != null) {
+                        if (!alphaKey.isNullOrEmpty() && theme.style.getObject(alphaKey) != null) {
+                            bitmap.alpha = MathUtils.clamp(theme.style.getInt(alphaKey), 0, 255)
+                        }
+                        return bitmap
                     }
-                    return bitmap
+                } else {
+                    // it is html hex color string (e.g. #ff0000)
+                    color = ColorUtils.parseColor(o)
                 }
-            } else if (o is Int) {
-                val gradient = GradientDrawable().apply { setColor(o) }
+            }
+
+            if (color is Int) {
+                val gradient = GradientDrawable().apply { setColor(color) }
                 if (roundCornerKey.isNotEmpty()) {
                     gradient.cornerRadius = theme.style.getFloat(roundCornerKey)
                 }


### PR DESCRIPTION
Additional fix for #1061

## Pull request


#### Feature
Correctly handle HTML string hex code as color in "theme"

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

