### PR TITLE
Improve Performance of Liquid Keyboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -441,8 +441,8 @@ public class Trime extends LifecycleInputMethodService {
       // 设置液体键盘处于隐藏状态
       TabManager.get().setTabExited();
       symbolInput.setVisibility(View.GONE);
+      updateComposing();
     }
-    updateComposing();
     mainInput.setVisibility(tabIndex >= 0 ? View.GONE : View.VISIBLE);
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.java
@@ -39,6 +39,7 @@ public class CandidateAdapter extends RecyclerView.Adapter<CandidateAdapter.View
   public void updateCandidates(List<CandidateListItem> candidates) {
     mCandidates.clear();
     mCandidates.addAll(candidates);
+    notifyDataSetChanged();
   }
 
   @Override

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -90,7 +90,12 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
             SymbolKeyboardType.VAR_LENGTH -> {
                 initVarLengthKeys(TabManager.get().select(i))
             }
-            SymbolKeyboardType.SYMBOL, SymbolKeyboardType.HISTORY, SymbolKeyboardType.TABS -> {
+            SymbolKeyboardType.TABS -> {
+                TabManager.get().select(i)
+                initVarLengthKeys(TabManager.get().tabSwitchData)
+                Timber.v("All tags in TABS: TabManager.get().tabSwitchData = ${TabManager.get().tabSwitchData}")
+            }
+            SymbolKeyboardType.SYMBOL, SymbolKeyboardType.HISTORY -> {
                 TabManager.get().select(i)
                 initFixData(i)
             }
@@ -162,10 +167,6 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
         when (tabTag.type) {
             SymbolKeyboardType.HISTORY ->
                 simpleAdapter.updateBeans(symbolHistory.toOrderedList().map(::SimpleKeyBean))
-            SymbolKeyboardType.TABS -> {
-                simpleAdapter.updateBeans(TabManager.get().tabSwitchData)
-                Timber.v("All tags in TABS: TabManager.get().tabSwitchData = ${TabManager.get().tabSwitchData}")
-            }
             else ->
                 simpleAdapter.updateBeans(TabManager.get().select(i))
         }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -9,11 +9,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.blankj.utilcode.util.ScreenUtils
+import com.blankj.utilcode.util.SizeUtils
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
-import com.osfans.trime.R
 import com.osfans.trime.core.CandidateListItem
 import com.osfans.trime.core.Rime
 import com.osfans.trime.data.SymbolHistory
@@ -107,9 +107,8 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
     private fun initFixData(i: Int) {
         val tabTag = TabManager.getTag(i)
 
-        val itemWidth = context.resources.getDimensionPixelSize(R.dimen.simple_item_size)
-        val itemMargin = context.resources.getDimensionPixelSize(R.dimen.simple_key_margin_x)
-        val columnCount = ScreenUtils.getScreenWidth() / (itemWidth + itemMargin)
+        val itemWidth = SizeUtils.dp2px(theme.liquid.getFloat("single_width"))
+        val columnCount = ScreenUtils.getAppScreenWidth() / itemWidth
         val simpleAdapter =
             SimpleAdapter(theme, columnCount).apply {
                 // 列表适配器的点击监听事件

--- a/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.java
@@ -8,14 +8,17 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+import com.osfans.trime.R;
 import com.osfans.trime.data.theme.FontManager;
 import com.osfans.trime.data.theme.Theme;
-import com.osfans.trime.databinding.SimpleKeyItemBinding;
+import com.osfans.trime.databinding.SimpleItemOneBinding;
+import com.osfans.trime.databinding.SimpleItemRowBinding;
 import java.util.ArrayList;
 import java.util.List;
 
 public class SimpleAdapter extends RecyclerView.Adapter<SimpleAdapter.ViewHolder> {
   private final @NonNull List<SimpleKeyBean> mBeans = new ArrayList<>();
+  private final @NonNull List<List<SimpleKeyBean>> mBeansByRows = new ArrayList<>();
 
   @NonNull
   public final List<SimpleKeyBean> getBeans() {
@@ -23,62 +26,119 @@ public class SimpleAdapter extends RecyclerView.Adapter<SimpleAdapter.ViewHolder
   }
 
   private final Theme theme;
+  private final int columnSize;
 
-  public SimpleAdapter(@NonNull Theme theme) {
+  public SimpleAdapter(@NonNull Theme theme, int columnSize) {
     this.theme = theme;
+    this.columnSize = columnSize;
   }
 
   public void updateBeans(List<SimpleKeyBean> beans) {
     mBeans.clear();
     mBeans.addAll(beans);
+    mBeansByRows.clear();
+
+    ArrayList<SimpleKeyBean> t = new ArrayList<>();
+    for (int i = 0; i < mBeans.size(); i++) {
+      t.add(mBeans.get(i));
+      if ((i + 1) % columnSize == 0) {
+        mBeansByRows.add(t);
+        t = new ArrayList<>();
+      }
+    }
+    if (!t.isEmpty()) {
+      mBeansByRows.add(t);
+    }
   }
 
   @Override
   public int getItemCount() {
-    return mBeans.size();
+    return mBeansByRows.size();
+  }
+
+  @Override
+  public long getItemId(int position) {
+    return position * 1000L;
   }
 
   @NonNull
   @Override
   public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-    final SimpleKeyItemBinding binding =
-        SimpleKeyItemBinding.inflate(LayoutInflater.from(parent.getContext()));
-    binding.simpleKeyPin.setVisibility(View.INVISIBLE);
-    return new ViewHolder(binding);
+    final SimpleItemRowBinding binding =
+        SimpleItemRowBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
+    int size = parent.getResources().getDimensionPixelSize(R.dimen.simple_item_size);
+    ViewGroup.LayoutParams p = new ViewGroup.LayoutParams(size, size);
+
+    List<SimpleItemOneBinding> bindings = new ArrayList<>();
+    for (int i = 0; i < columnSize; i++) {
+      SimpleItemOneBinding view =
+          SimpleItemOneBinding.inflate(LayoutInflater.from(parent.getContext()), null, false);
+      bindings.add(view);
+      binding.wrapper.addView(view.getRoot(), p);
+    }
+    ViewHolder holder = new ViewHolder(binding, bindings);
+
+    for (int i = 0; i < holder.simpleKeyTexts.size(); i++) {
+      holder.wrappers.get(i).setTag((Integer) i);
+
+      TextView textView = holder.simpleKeyTexts.get(i);
+
+      textView.setTextColor(theme.colors.getColor("key_text_color"));
+      textView.setTypeface(FontManager.getTypeface(theme.style.getString("key_font")));
+      textView.setGravity(Gravity.CENTER);
+      textView.setEllipsize(TextUtils.TruncateAt.MARQUEE);
+
+      final float labelTextSize = theme.style.getFloat("label_text_size");
+      if (labelTextSize > 0) textView.setTextSize(labelTextSize);
+
+      textView.setBackground(
+          theme.colors.getDrawable(
+              "key_back_color", "key_border", "key_border_color", "round_corner", null));
+    }
+    return holder;
   }
 
   public static class ViewHolder extends RecyclerView.ViewHolder {
-    final TextView simpleKeyText;
+    List<TextView> simpleKeyTexts;
+    List<ViewGroup> wrappers;
 
-    public ViewHolder(@NonNull SimpleKeyItemBinding binding) {
+    public ViewHolder(@NonNull SimpleItemRowBinding binding, List<SimpleItemOneBinding> views) {
       super(binding.getRoot());
 
-      simpleKeyText = binding.simpleKey;
+      simpleKeyTexts = new ArrayList<>();
+      wrappers = new ArrayList<>();
+      for (int i = 0; i < views.size(); i++) {
+        simpleKeyTexts.add((TextView) (views.get(i).getRoot().getChildAt(0)));
+        ((ViewGroup) views.get(i).getRoot()).getChildAt(1).setVisibility(View.GONE);
+        wrappers.add(views.get(i).getRoot());
+      }
     }
   }
 
   @Override
   public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-    final SimpleKeyBean bean = mBeans.get(position);
+    final List<SimpleKeyBean> bean = mBeansByRows.get(position);
 
-    holder.simpleKeyText.setText(bean.getLabel());
-    holder.simpleKeyText.setTextColor(theme.colors.getColor("key_text_color"));
-    holder.simpleKeyText.setTypeface(FontManager.getTypeface(theme.style.getString("key_font")));
-    holder.simpleKeyText.setGravity(Gravity.CENTER);
-    holder.simpleKeyText.setEllipsize(TextUtils.TruncateAt.MARQUEE);
+    for (int i = 0; i < holder.simpleKeyTexts.size(); i++) {
+      holder.simpleKeyTexts.get(i).setText("");
+      if (i < bean.size()) {
+        holder.wrappers.get(i).setVisibility(View.VISIBLE);
+        holder.simpleKeyTexts.get(i).setText(bean.get(i).getLabel());
+      } else {
+        holder.wrappers.get(i).setVisibility(View.INVISIBLE);
+      }
 
-    final float labelTextSize = theme.style.getFloat("label_text_size");
-    if (labelTextSize > 0) holder.simpleKeyText.setTextSize(labelTextSize);
-
-    holder.itemView.setBackground(
-        theme.colors.getDrawable(
-            "key_back_color", "key_border", "key_border_color", "round_corner", null));
-
-    if (listener != null) {
-      holder.itemView.setOnClickListener(
-          view -> {
-            listener.onSimpleKeyClick(position);
-          });
+      if (listener != null) {
+        holder
+            .wrappers
+            .get(i)
+            .setOnClickListener(
+                view -> {
+                  if (view.getTag() != null) {
+                    listener.onSimpleKeyClick(position * columnSize + (int) view.getTag());
+                  }
+                });
+      }
     }
   }
 

--- a/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.java
@@ -49,6 +49,8 @@ public class SimpleAdapter extends RecyclerView.Adapter<SimpleAdapter.ViewHolder
     if (!t.isEmpty()) {
       mBeansByRows.add(t);
     }
+
+    notifyDataSetChanged();
   }
 
   @Override

--- a/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.java
@@ -8,7 +8,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
-import com.osfans.trime.R;
+import com.blankj.utilcode.util.SizeUtils;
 import com.osfans.trime.data.theme.FontManager;
 import com.osfans.trime.data.theme.Theme;
 import com.osfans.trime.databinding.SimpleItemOneBinding;
@@ -66,7 +66,7 @@ public class SimpleAdapter extends RecyclerView.Adapter<SimpleAdapter.ViewHolder
   public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
     final SimpleItemRowBinding binding =
         SimpleItemRowBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
-    int size = parent.getResources().getDimensionPixelSize(R.dimen.simple_item_size);
+    int size = SizeUtils.dp2px(theme.liquid.getFloat("single_width"));
     ViewGroup.LayoutParams p = new ViewGroup.LayoutParams(size, size);
 
     List<SimpleItemOneBinding> bindings = new ArrayList<>();

--- a/app/src/main/res/layout/simple_item_one.xml
+++ b/app/src/main/res/layout/simple_item_one.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?android:attr/selectableItemBackground"
+    >
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:ellipsize="end"
+        android:maxLines="4"
+        android:padding="4dp"
+        android:textColor="#333333"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
+    <ImageView
+        android:layout_width="12dp"
+        android:layout_height="12dp"
+        android:layout_gravity="end"
+        android:layout_marginEnd="2dp"
+        android:layout_marginBottom="2dp"
+        android:alpha="0.4"
+        android:contentDescription="simple_key_pin"
+        android:src="@drawable/ic_baseline_push_pin_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
+
+</FrameLayout>
+

--- a/app/src/main/res/layout/simple_item_row.xml
+++ b/app/src/main/res/layout/simple_item_row.xml
@@ -6,6 +6,6 @@
     android:id="@+id/wrapper"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:justifyContent="space_between"
+    app:justifyContent="space_around"
 
     />

--- a/app/src/main/res/layout/simple_item_row.xml
+++ b/app/src/main/res/layout/simple_item_row.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/wrapper"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:justifyContent="space_between"
+
+    />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="simple_key_margin_x">4dp</dimen>
-    <dimen name="simple_item_size">44dp</dimen>
-</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="simple_key_margin_x">2dp</dimen>
-    <dimen name="simple_key_single_width">50dp</dimen>
+    <dimen name="simple_key_margin_x">4dp</dimen>
+    <dimen name="simple_item_size">44dp</dimen>
 </resources>


### PR DESCRIPTION
## Pull request

#### Issue tracker

Fixes #940 
Fixes #1172 
Refs #1148

#### Feature
Improve the performance of "Liquid Keyboard" by changing the implementation of `SimpleAdapter`.

In this PR, each `ViewHolder` of `SimpleAdapter` represents one row of view, and each view hold multiple items.  So a simple `LinearLayoutManager` can be used instead of `FlexboxLayoutManager`.  Also, the same adapter will be re-used for the same data type, so switching liquid keyboard of the same data-type will be faster.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

