### PR TITLE
fix: prevent NPE of `CompositionPopupWindow`

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -504,7 +504,9 @@ public class Trime extends LifecycleInputMethodService {
       listener.onDestroy();
     }
     eventListeners.clear();
-    mCompositionPopupWindow.destroy();
+    if (mCompositionPopupWindow != null) {
+      mCompositionPopupWindow.destroy();
+    }
     super.onDestroy();
 
     self = null;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #1188

#### Feature
Check for null before calling `CompositionPoupWindow.destroy()`.

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

