### PR TITLE
Add Landscape Keyboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -6,6 +6,7 @@ import androidx.preference.PreferenceManager
 import com.blankj.utilcode.util.PathUtils
 import com.osfans.trime.R
 import com.osfans.trime.ime.enums.InlineModeType
+import com.osfans.trime.ime.keyboard.KeyboardPrefs
 import com.osfans.trime.ime.landscapeinput.LandscapeInputUIMode
 import com.osfans.trime.util.appContext
 import java.lang.ref.WeakReference
@@ -142,6 +143,7 @@ class AppPrefs(
             const val FLOATING_WINDOW_ENABLED = "keyboard__show_window"
             const val POPUP_KEY_PRESS_ENABLED = "keyboard__show_key_popup"
             const val SWITCHES_ENABLED = "keyboard__show_switches"
+            const val SPLIT = "keyboard__split"
             const val SWITCH_ARROW_ENABLED = "keyboard__show_switch_arrow"
             const val FULLSCREEN_MODE = "keyboard__fullscreen_mode"
             const val CANDIDATE_PAGE_SIZE = "keyboard__candidate_page_size"

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -144,6 +144,7 @@ class AppPrefs(
             const val POPUP_KEY_PRESS_ENABLED = "keyboard__show_key_popup"
             const val SWITCHES_ENABLED = "keyboard__show_switches"
             const val SPLIT = "keyboard__split"
+            const val SPLIT_SPACE_PERCENT = "keyboard__split_space"
             const val SWITCH_ARROW_ENABLED = "keyboard__show_switch_arrow"
             const val FULLSCREEN_MODE = "keyboard__fullscreen_mode"
             const val CANDIDATE_PAGE_SIZE = "keyboard__candidate_page_size"
@@ -206,6 +207,8 @@ class AppPrefs(
             private set
         val splitOption: String
             get() = prefs.getPref(SPLIT, KeyboardPrefs.SPLIT_OPTION_NEVER)
+        val splitSpacePercent: Int
+            get() = prefs.getPref(SPLIT_SPACE_PERCENT, 100)
         var candidatePageSize: String = "0"
             get() = prefs.getPref(CANDIDATE_PAGE_SIZE, "0")
             private set

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -204,6 +204,8 @@ class AppPrefs(
         var switchArrowEnabled: Boolean = false
             get() = prefs.getPref(SWITCH_ARROW_ENABLED, true)
             private set
+        val splitOption: String
+            get() = prefs.getPref(SPLIT, KeyboardPrefs.SPLIT_OPTION_NEVER)
         var candidatePageSize: String = "0"
             get() = prefs.getPref(CANDIDATE_PAGE_SIZE, "0")
             private set

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -90,6 +90,9 @@ public class Keyboard {
 
   private boolean resetAsciiMode;
 
+  private String mLandscapeKeyboard;
+  private int mLandscapePercent;
+
   // Variables for pre-computing nearest keys.
   private String mLabelTransform;
   private int mCellWidth;
@@ -192,6 +195,12 @@ public class Keyboard {
     if (mAsciiMode == 0)
       mAsciiKeyboard = CollectionUtils.obtainString(keyboardConfig, "ascii_keyboard", "");
     resetAsciiMode = CollectionUtils.obtainBoolean(keyboardConfig, "reset_ascii_mode", false);
+    mLandscapeKeyboard = CollectionUtils.obtainString(keyboardConfig, "landscape_keyboard", "");
+    mLandscapePercent =
+        CollectionUtils.obtainInt(
+            keyboardConfig,
+            "landscape_split_percent",
+            AppPrefs.defaultInstance().getKeyboard().getSplitSpacePercent());
     mLock = CollectionUtils.obtainBoolean(keyboardConfig, "lock", false);
     int columns = CollectionUtils.obtainInt(keyboardConfig, "columns", 30);
     int defaultWidth =
@@ -240,12 +249,12 @@ public class Keyboard {
     int column = 0;
     mTotalWidth = 0;
 
-    Boolean isSplit = new KeyboardPrefs().isSplit();
+    Boolean isSplit = new KeyboardPrefs().isSplit() && isLandscapeSplit();
     KeyboardSize keyboardSize =
         new KeyboardSizeCalculator(
                 name,
                 isSplit,
-                AppPrefs.defaultInstance().getKeyboard().getSplitSpacePercent(),
+                mLandscapePercent,
                 maxColumns,
                 mDisplayWidth,
                 keyboardHeight,
@@ -785,6 +794,14 @@ public class Keyboard {
 
   public String getAsciiKeyboard() {
     return mAsciiKeyboard;
+  }
+
+  public boolean isLandscapeSplit() {
+    return mLandscapePercent > 0;
+  }
+
+  public String getLandscapeKeyboard() {
+    return mLandscapeKeyboard;
   }
 
   public boolean isLabelUppercase() {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -113,7 +113,8 @@ public class Keyboard {
 
     final Theme theme = Theme.get();
     int[] keyboardPadding = theme.getKeyboardPadding();
-    mDisplayWidth = ScreenUtils.getScreenWidth() - keyboardPadding[0] - keyboardPadding[1];
+    mDisplayWidth = ScreenUtils.getAppScreenWidth() - keyboardPadding[0] - keyboardPadding[1];
+
     /* Height of the screen */
     // final int mDisplayHeight = dm.heightPixels;
     // Log.v(TAG, "keyboard's display metrics:" + dm);

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -21,6 +21,7 @@ package com.osfans.trime.ime.keyboard;
 import android.graphics.drawable.Drawable;
 import android.view.KeyEvent;
 import com.blankj.utilcode.util.ScreenUtils;
+import com.osfans.trime.data.AppPrefs;
 import com.osfans.trime.data.theme.Theme;
 import com.osfans.trime.util.CollectionUtils;
 import com.osfans.trime.util.DimensionsKt;
@@ -242,13 +243,13 @@ public class Keyboard {
     Boolean isSplit = new KeyboardPrefs().isSplit();
     KeyboardSize keyboardSize =
         new KeyboardSizeCalculator(
-                isSplit,
                 name,
+                isSplit,
+                AppPrefs.defaultInstance().getKeyboard().getSplitSpacePercent(),
                 maxColumns,
                 mDisplayWidth,
                 keyboardHeight,
                 keyboardKeyWidth,
-                (int) (mDisplayWidth * theme.style.getFloat("key_width")),
                 defaultHeight,
                 horizontalGap,
                 verticalGap,

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -249,7 +249,7 @@ public class Keyboard {
     int column = 0;
     mTotalWidth = 0;
 
-    Boolean isSplit = new KeyboardPrefs().isSplit() && isLandscapeSplit();
+    Boolean isSplit = new KeyboardPrefs().isLandscapeMode() && isLandscapeSplit();
     KeyboardSize keyboardSize =
         new KeyboardSizeCalculator(
                 name,

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -258,6 +258,7 @@ public class Keyboard {
     defaultWidth = (int) (oneWeightWidthPx * keyboardKeyWidth);
 
     try {
+      float rowWidthWeight = 0;
       for (Map<String, Object> mk : lm) {
         int gap = mDefaultHorizontalGap;
         float keyWidth = CollectionUtils.obtainFloat(mk, "width", keyboardKeyWidth);
@@ -267,11 +268,21 @@ public class Keyboard {
         widthPx -= gap;
         if (column >= maxColumns || x + widthPx > mDisplayWidth) {
           // new row
+          rowWidthWeight = 0;
           x = gap / 2;
           y += mDefaultVerticalGap + rowHeight;
           column = 0;
           row++;
           if (mKeys.size() > 0) mKeys.get(mKeys.size() - 1).edgeFlags |= Keyboard.EDGE_RIGHT;
+        }
+        rowWidthWeight += keyWidth;
+        if (isSplit && rowWidthWeight >= keyboardSize.getRowWidthTotalWeight().get(row) / 2 + 1) {
+          x +=
+              (int)
+                  (keyboardSize.getRowWidthTotalWeight().get(row)
+                      * keyboardSize.getMultiplier()
+                      * oneWeightWidthPx); // (10 * (defaultWidth));
+          rowWidthWeight = Integer.MIN_VALUE;
         }
         if (column == 0) {
           if (keyboardHeight > 0) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -239,7 +239,7 @@ public class Keyboard {
     int column = 0;
     mTotalWidth = 0;
 
-    Boolean isSplit = false;
+    Boolean isSplit = new KeyboardPrefs().isSplit();
     KeyboardSize keyboardSize =
         new KeyboardSizeCalculator(
                 isSplit,

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.java
@@ -278,12 +278,23 @@ public class Keyboard {
         }
         rowWidthWeight += keyWidth;
         if (isSplit && rowWidthWeight >= keyboardSize.getRowWidthTotalWeight().get(row) / 2 + 1) {
-          x +=
-              (int)
-                  (keyboardSize.getRowWidthTotalWeight().get(row)
-                      * keyboardSize.getMultiplier()
-                      * oneWeightWidthPx); // (10 * (defaultWidth));
           rowWidthWeight = Integer.MIN_VALUE;
+
+          if (keyWidth > 20) {
+            // enlarge the key if this key is a long key
+            widthPx =
+                (int)
+                        ((keyboardSize.getRowWidthTotalWeight().get(row)
+                                * keyboardSize.getMultiplier())
+                            * oneWeightWidthPx)
+                    + widthPx;
+          } else {
+            x +=
+                (int)
+                    (keyboardSize.getRowWidthTotalWeight().get(row)
+                        * keyboardSize.getMultiplier()
+                        * oneWeightWidthPx); // (10 * (defaultWidth));
+          }
         }
         if (column == 0) {
           if (keyboardHeight > 0) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardPrefs.kt
@@ -6,7 +6,7 @@ import com.osfans.trime.data.AppPrefs
 class KeyboardPrefs {
     private val prefs = AppPrefs.defaultInstance()
 
-    fun isSplit(): Boolean {
+    fun isLandscapeMode(): Boolean {
         return when (prefs.keyboard.splitOption) {
             SPLIT_OPTION_AUTO -> isWideScreen()
             SPLIT_OPTION_LANDSCAPE -> ScreenUtils.isLandscape()

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardPrefs.kt
@@ -1,0 +1,30 @@
+package com.osfans.trime.ime.keyboard
+
+import com.blankj.utilcode.util.ScreenUtils
+import com.osfans.trime.data.AppPrefs
+
+class KeyboardPrefs {
+    private val prefs = AppPrefs.defaultInstance()
+
+    fun isSplit(): Boolean {
+        return when (prefs.keyboard.splitOption) {
+            SPLIT_OPTION_AUTO -> isWideScreen()
+            SPLIT_OPTION_LANDSCAPE -> ScreenUtils.isLandscape()
+            SPLIT_OPTION_ALWAYS -> true
+            else -> false
+        }
+    }
+
+    private fun isWideScreen(): Boolean {
+        return ScreenUtils.getAppScreenWidth() / ScreenUtils.getScreenDensity() > WIDE_SCREEN_WIDTH_DP
+    }
+
+    companion object {
+        const val SPLIT_OPTION_AUTO = "auto"
+        const val SPLIT_OPTION_LANDSCAPE = "landscape"
+        const val SPLIT_OPTION_NEVER = "never"
+        const val SPLIT_OPTION_ALWAYS = "always"
+
+        private const val WIDE_SCREEN_WIDTH_DP = 600
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSize.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSize.kt
@@ -1,0 +1,8 @@
+package com.osfans.trime.ime.keyboard
+
+data class KeyboardSize(
+    val rowWidthTotalWeight: Map<Int, Float>,
+    val defaultWidth: Float,
+    val multiplier: Float,
+    val height: List<Int>,
+)

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSizeCalculator.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSizeCalculator.kt
@@ -5,19 +5,19 @@ import com.osfans.trime.util.sp2px
 import kotlin.math.abs
 
 class KeyboardSizeCalculator(
-    private val isSplit: Boolean,
     val name: String,
+    isSplit: Boolean,
+    splitPercent: Int,
     private val maxColumns: Int,
     private val mAllowedWidth: Int,
     private val keyboardHeight: Int,
     private val keyboardKeyWidth: Float,
-    private val themeKeyWidthPx: Int,
     private val keyHeight: Int,
     private val mDefaultHorizontalGap: Int,
     private val mDefaultVerticalGap: Int,
     private val autoHeightIndex: Int,
 ) {
-    val splitSpaceRatio: Float = if (isSplit) 1f else 0f
+    private val splitSpaceRatio: Float = if (isSplit) (splitPercent / 100f) else 0f
 
     fun calc(lm: List<Map<String, Any>>): KeyboardSize {
         var x = mDefaultHorizontalGap / 2

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSizeCalculator.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSizeCalculator.kt
@@ -1,0 +1,138 @@
+package com.osfans.trime.ime.keyboard
+
+import com.osfans.trime.util.CollectionUtils.obtainFloat
+import com.osfans.trime.util.sp2px
+import kotlin.math.abs
+
+class KeyboardSizeCalculator(
+    private val isSplit: Boolean,
+    val name: String,
+    private val maxColumns: Int,
+    private val mAllowedWidth: Int,
+    private val keyboardHeight: Int,
+    private val keyboardKeyWidth: Float,
+    private val themeKeyWidthPx: Int,
+    private val keyHeight: Int,
+    private val mDefaultHorizontalGap: Int,
+    private val mDefaultVerticalGap: Int,
+    private val autoHeightIndex: Int,
+) {
+    val splitSpaceRatio: Float = if (isSplit) 1f else 0f
+
+    fun calc(lm: List<Map<String, Any>>): KeyboardSize {
+        var x = mDefaultHorizontalGap / 2
+        var y = 0
+        var column = 0
+        var row = 0
+
+        var rowHeight = keyHeight
+
+        var rawSumHeight = 0
+        val rawHeight = ArrayList<Int>()
+
+        var totalKeyWidth = 0f
+        var maxColumn = 0
+        val rowTotalWeight = HashMap<Int, Float>()
+
+        for (mk in lm) {
+            val weight = obtainFloat(mk, "width", 0f)
+            val keyWidthWeight =
+                if (weight == 0f) {
+                    keyboardKeyWidth
+                } else {
+                    weight
+                }
+            val widthPx =
+                (keyWidthWeight * mAllowedWidth / MAX_TOTAL_WEIGHT).toInt() - mDefaultHorizontalGap
+            if (column >= maxColumns || x + widthPx > mAllowedWidth) {
+                maxColumn = maxOf(maxColumn, column)
+                rowTotalWeight[row] = totalKeyWidth
+
+                x = mDefaultHorizontalGap / 2
+                y += mDefaultVerticalGap + rowHeight
+                totalKeyWidth = 0f
+                column = 0
+                row++
+                rawSumHeight += rowHeight
+                rawHeight.add(rowHeight)
+            }
+
+            if (column == 0) {
+                val heightK = sp2px(obtainFloat(mk, "height", 0f)).toInt()
+                rowHeight = if (heightK > 0) heightK else keyHeight
+            }
+            totalKeyWidth += keyWidthWeight
+            if (!mk.containsKey("click")) { // 無按鍵事件
+                x += widthPx + mDefaultHorizontalGap
+                continue // 縮進
+            }
+            column++
+            val rightGap = abs(mAllowedWidth - x - widthPx - mDefaultHorizontalGap / 2)
+            x += (
+                if (rightGap <= mAllowedWidth / MAX_TOTAL_WEIGHT) {
+                    mAllowedWidth - x -
+                        mDefaultHorizontalGap / 2
+                } else {
+                    widthPx
+                }
+            ) + mDefaultHorizontalGap
+        }
+        rowTotalWeight[row] = totalKeyWidth
+
+        rawSumHeight += rowHeight
+        rawHeight.add(rowHeight)
+
+        return KeyboardSize(
+            rowTotalWeight,
+            calculateOneWeightWidthPx(),
+            splitSpaceRatio,
+            calculateAdjustedHeight(rawSumHeight, rawHeight, autoHeightIndex),
+        )
+    }
+
+    private fun calculateOneWeightWidthPx(): Float {
+        return (mAllowedWidth / (MAX_TOTAL_WEIGHT * (1 + splitSpaceRatio)))
+    }
+
+    private fun calculateAdjustedHeight(
+        rawSumHeight: Int,
+        rawHeight: List<Int>,
+        autoHeightIndex: Int,
+    ): List<Int> {
+        var scale: Float =
+            keyboardHeight.toFloat() / (rawSumHeight + mDefaultVerticalGap * (rawHeight.size + 1))
+
+        val verticalGap = Math.ceil((mDefaultVerticalGap * scale).toDouble()).toInt()
+
+        var autoHeight: Int = keyboardHeight - verticalGap * (rawHeight.size + 1)
+
+        scale = (autoHeight.toFloat()) / rawSumHeight
+
+        var finalAutoHeightIndex = -100
+        if (autoHeightIndex < 0) {
+            finalAutoHeightIndex = rawHeight.size + autoHeightIndex
+            if (finalAutoHeightIndex < 0) finalAutoHeightIndex = 0
+        } else if (autoHeightIndex >= rawHeight.size) {
+            finalAutoHeightIndex = rawHeight.size - 1
+        }
+
+        val newHeight = rawHeight.toMutableList()
+        for (i in rawHeight.indices) {
+            if (i != finalAutoHeightIndex) {
+                val h: Int = (rawHeight[i] * scale).toInt()
+                newHeight[i] = h
+                autoHeight -= h
+            }
+        }
+        if (autoHeight < 1) {
+            if (rawHeight[autoHeight] > 0) autoHeight = 1
+        }
+        newHeight[finalAutoHeightIndex] = autoHeight
+
+        return newHeight
+    }
+
+    companion object {
+        private const val MAX_TOTAL_WEIGHT = 100
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ui/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/KeyboardFragment.kt
@@ -46,7 +46,7 @@ class KeyboardFragment :
             -> {
                 trime?.resetKeyboard()
             }
-            AppPrefs.Keyboard.SPLIT -> {
+            AppPrefs.Keyboard.SPLIT, AppPrefs.Keyboard.SPLIT_SPACE_PERCENT -> {
                 trime?.initKeyboard()
             }
             "keyboard__show_window" -> {

--- a/app/src/main/java/com/osfans/trime/ui/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/KeyboardFragment.kt
@@ -46,6 +46,9 @@ class KeyboardFragment :
             -> {
                 trime?.resetKeyboard()
             }
+            AppPrefs.Keyboard.SPLIT -> {
+                trime?.initKeyboard()
+            }
             "keyboard__show_window" -> {
                 trime?.resetCandidate()
             }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -64,6 +64,7 @@
     <string name="keyboard__long_click_delete_candidate_title">长按删除候选词</string>
     <string name="keyboard__show_switches_title">在候选栏中显示状态</string>
     <string name="keyboard__show_key_popup_title">按键时弹出显示字符</string>
+    <string name="keyboard__split_title">分割鍵盤</string>
     <string name="keyboard__show_window_title">显示悬浮窗</string>
     <string name="keyboard__inline_preedit_title">嵌入式编辑模式</string>
     <string-array name="keyboard__inline_entries">
@@ -71,6 +72,12 @@
         <item>编码</item>
         <item>输入码</item>
         <item>无</item>
+    </string-array>
+    <string-array name="keyboard__split_entries">
+        <item>永不</item>
+        <item>只在橫屏時</item>
+        <item>在闊螢幕或橫屏時</item>
+        <item>永遠都是</item>
     </string-array>
     <string-array name="other__ui_mode_entries" >
         <item name="auto">系统默认</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -64,7 +64,6 @@
     <string name="keyboard__long_click_delete_candidate_title">长按删除候选词</string>
     <string name="keyboard__show_switches_title">在候选栏中显示状态</string>
     <string name="keyboard__show_key_popup_title">按键时弹出显示字符</string>
-    <string name="keyboard__split_title">分割鍵盤</string>
     <string name="keyboard__show_window_title">显示悬浮窗</string>
     <string name="keyboard__inline_preedit_title">嵌入式编辑模式</string>
     <string-array name="keyboard__inline_entries">
@@ -274,4 +273,8 @@
     <string name="pref_clipboard_summary">收藏夹和草稿箱也在这里管理</string>
     <string name="a_regular_expression_per_line">一行一条正则表达式</string>
     <string name="keyboard__custom_key_sound">使用自定义按键音</string>
+
+    <string name="pref_keyboard__landscape">橫屏模式</string>
+    <string name="keyboard__split_title">轉換到橫屏鍵盤</string>
+    <string name="keyboard__split_space_title">自動分割鍵盤比例</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -74,9 +74,9 @@
     </string-array>
     <string-array name="keyboard__split_entries">
         <item>永不</item>
-        <item>只在橫屏時</item>
-        <item>在闊螢幕或橫屏時</item>
-        <item>永遠都是</item>
+        <item>只在横屏时</item>
+        <item>在阔萤幕或横屏时</item>
+        <item>永远都是</item>
     </string-array>
     <string-array name="other__ui_mode_entries" >
         <item name="auto">系统默认</item>
@@ -274,7 +274,7 @@
     <string name="a_regular_expression_per_line">一行一条正则表达式</string>
     <string name="keyboard__custom_key_sound">使用自定义按键音</string>
 
-    <string name="pref_keyboard__landscape">橫屏模式</string>
-    <string name="keyboard__split_title">轉換到橫屏鍵盤</string>
-    <string name="keyboard__split_space_title">自動分割鍵盤比例</string>
+    <string name="pref_keyboard__landscape">横屏模式</string>
+    <string name="keyboard__split_title">转换到横屏键盘</string>
+    <string name="keyboard__split_space_title">自动分割键盘比例</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -68,7 +68,6 @@
     <string name="keyboard__long_click_delete_candidate_title">長按刪除候選詞</string>
     <string name="keyboard__show_switches_title">在候選欄中顯示狀態</string>
     <string name="keyboard__show_key_popup_title">按鍵時彈出顯示字符</string>
-    <string name="keyboard__split_title">分割鍵盤</string>
     <string name="keyboard__show_window_title">顯示懸浮窗</string>
     <string name="keyboard__inline_preedit_title">嵌入式編輯模式</string>
     <string-array name="keyboard__inline_entries">
@@ -275,4 +274,8 @@
     <string name="pref_clipboard_summary">收藏夾和草稿箱也在這裡管理</string>
     <string name="a_regular_expression_per_line">一行一條正則表示式</string>
     <string name="keyboard__custom_key_sound">使用自訂按鍵音</string>
+
+    <string name="pref_keyboard__landscape">橫向模式</string>
+    <string name="keyboard__split_title">轉換到橫屏鍵盤</string>
+    <string name="keyboard__split_space_title">自動分割鍵盤比例</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -68,6 +68,7 @@
     <string name="keyboard__long_click_delete_candidate_title">長按刪除候選詞</string>
     <string name="keyboard__show_switches_title">在候選欄中顯示狀態</string>
     <string name="keyboard__show_key_popup_title">按鍵時彈出顯示字符</string>
+    <string name="keyboard__split_title">分割鍵盤</string>
     <string name="keyboard__show_window_title">顯示懸浮窗</string>
     <string name="keyboard__inline_preedit_title">嵌入式編輯模式</string>
     <string-array name="keyboard__inline_entries">
@@ -75,6 +76,12 @@
         <item>編碼</item>
         <item>輸入碼</item>
         <item>無</item>
+    </string-array>
+    <string-array name="keyboard__split_entries">
+        <item>永不</item>
+        <item>只在橫屏時</item>
+        <item>在闊螢幕或橫屏時</item>
+        <item>永遠都是</item>
     </string-array>
     <string-array name="other__ui_mode_entries" >
         <item name="auto">系統預設</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -25,6 +25,12 @@
         <item>input</item>
         <item>none</item>
     </string-array>
+    <string-array name="keyboard__split_values">
+        <item>never</item>
+        <item>landscape</item>
+        <item>auto</item>
+        <item>always</item>
+    </string-array>
     <string-array name="other__ui_mode_values">
         <item>auto</item>
         <item>light</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,7 +70,6 @@
     <string name="keyboard__long_click_delete_candidate_title">Long click to delete candidate</string>
     <string name="keyboard__show_switches_title">Show switches in candidate bar</string>
     <string name="keyboard__show_key_popup_title">Popup on key press</string>
-    <string name="keyboard__split_title">Split keyboard</string>
     <string name="keyboard__show_window_title">Show floating window when composing</string>
     <string name="keyboard__inline_preedit_title">Composing text in editor</string>
     <string-array name="keyboard__inline_entries">
@@ -278,4 +277,8 @@
     <string name="pref_clipboard_summary">Collection and draft are also managed here</string>
     <string name="a_regular_expression_per_line">A regular expression per line</string>
     <string name="keyboard__custom_key_sound">Use custom key sound</string>
+
+    <string name="pref_keyboard__landscape">Landscape Mode</string>
+    <string name="keyboard__split_title">Change to Landscape keyboard</string>
+    <string name="keyboard__split_space_title">Auto Split Keyboard Space Ratio</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="keyboard__long_click_delete_candidate_title">Long click to delete candidate</string>
     <string name="keyboard__show_switches_title">Show switches in candidate bar</string>
     <string name="keyboard__show_key_popup_title">Popup on key press</string>
+    <string name="keyboard__split_title">Split keyboard</string>
     <string name="keyboard__show_window_title">Show floating window when composing</string>
     <string name="keyboard__inline_preedit_title">Composing text in editor</string>
     <string-array name="keyboard__inline_entries">
@@ -77,6 +78,12 @@
         <item>Composition</item>
         <item>Input</item>
         <item>None</item>
+    </string-array>
+    <string-array name="keyboard__split_entries">
+        <item>Never</item>
+        <item>Only in landscape mode</item>
+        <item>Auto (In wide screen or landscape mode)</item>
+        <item>Always</item>
     </string-array>
     <string-array name="other__ui_mode_entries" >
         <item name="auto">System Default</item>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -28,6 +28,11 @@
             android:key="keyboard__show_key_popup"
             android:title="@string/keyboard__show_key_popup_title"
             app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="@string/pref_keyboard__landscape">
         <ListPreference
             android:defaultValue="never"
             android:entries="@array/keyboard__split_entries"
@@ -35,6 +40,18 @@
             android:key="keyboard__split"
             android:title="@string/keyboard__split_title"
             app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
+
+        <com.osfans.trime.ui.components.DialogSeekBarPreference
+            android:defaultValue="80"
+            android:key="keyboard__split_space"
+            android:title="@string/keyboard__split_space_title"
+            app:allowDividerAbove="false"
+            app:iconSpaceReserved="false"
+            app:max="200"
+            app:min="0"
+            app:seekBarIncrement="10"
+            app:unit="%"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -28,6 +28,14 @@
             android:key="keyboard__show_key_popup"
             android:title="@string/keyboard__show_key_popup_title"
             app:iconSpaceReserved="false" />
+        <ListPreference
+            android:defaultValue="never"
+            android:entries="@array/keyboard__split_entries"
+            android:entryValues="@array/keyboard__split_values"
+            android:key="keyboard__split"
+            android:title="@string/keyboard__split_title"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/doc/Keyboard.md
+++ b/doc/Keyboard.md
@@ -1,0 +1,39 @@
+# Liquid Keyboard 參數
+
+(3.2.17), 只有使用 `single_width` 。其餘的還未有作用。
+
+- `single_width` : 在 `SINGLE` 類別中，每項的闊度 (和高度相等)。
+
+# 藍芽鍵盤問題
+https://github.com/osfans/trime/issues/1058#issuecomment-1672635413
+
+# 橫屏鍵盤
+
+(3.2.17) 新增兩個參數到 `preset_keyboards` :
+
+- `landscape_keyboard`: 橫屏時轉用的 keyboard id。當判定需顯示橫屏鍵盤時，會顯示此值代表的鍵盤。該 id 需包含在 `style/keyboards`中。
+- `landscape_split_percent`:  0 - 200。此值只在橫屏時生效，優先等級高於「鍵盤設定」>「自動分割鍵盤比例」。此值代表鍵盤自動分割時中間的空白闊度比例。如：
+	- `100` 代表 100%，即空白的闊度與鍵盤的總闊度比例為 1:1。
+	- `150` 的話，代表空白的闊度與鍵盤的總闊度比例為 1.5:1。
+	- `0` 代表不做自動分割。
+
+例：
+```
+patch:
+  "style/keyboard": [my_keyboard, my_landscape_keyboard, mini, .....]
+  "preset_keyboards/my_keyboard":
+    name: My Keyboard
+    landscape_keyboard: my_landscape_keyboard
+    ...
+    keys:
+      - ......
+  "preset_keyboards/my_landscape_keyboard":
+    name: My Landscape Keyboard
+    landscape_split_percent: 0
+    ...
+    keys:
+      - ......
+```
+以上例子代表：
+直屏時使用 `my_keyboard` 
+橫屏時使用 `my_landscape_keyboard`，並且不做自動分割。若 `landscape_split_percent` > 0，則會分割顯示。


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #1038
Fixes #1111
Refs #1148

#### Feature

- Add "Landscape Keyboard" related options in "Setting"
- Allow manually appoint "Landscape Keyboard" in Theme file (`trime.custom.yaml")
- Allow auto-split keyboard

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

@cabins @IsPoto If possible, please help to test and comment.  Thanks.
