### PR TITLE
fix: do not set zero-width non-clickable key with default width

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSizeCalculator.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSizeCalculator.kt
@@ -37,7 +37,7 @@ class KeyboardSizeCalculator(
         for (mk in lm) {
             val weight = obtainFloat(mk, "width", 0f)
             val keyWidthWeight =
-                if (weight == 0f) {
+                if (weight == 0f && mk.contains("click")) {
                     keyboardKeyWidth
                 } else {
                     weight


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fix the side effect of PR #1191

#### Feature
This patch will allow key without "click" attribute to have zero width instead of default width.

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

