### PR TITLE
Enhance color management

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
@@ -106,7 +106,7 @@ object ThemeManager {
     fun onSystemNightModeChange(isNight: Boolean) {
         if (isNightMode == isNight) return
         isNightMode = isNight
-        _activeTheme.systemChangeColor(isNightMode)
+        _activeTheme.switchDarkMode(isNightMode)
         fireChange()
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.kt
@@ -385,7 +385,7 @@ open class Trime : LifecycleInputMethodService() {
         inputView!!.switchUiByState(KeyboardWindow.State.Main)
         loadConfig()
         val theme = ThemeManager.activeTheme
-        theme.fireChangeColor()
+        theme.refreshColorValues()
         SoundThemeManager.switchSound(theme.colors.getString("sound"))
         resetCandidate()
         KeyboardSwitcher.newOrReset()

--- a/app/src/main/java/com/osfans/trime/ui/main/Pickers.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/Pickers.kt
@@ -42,9 +42,6 @@ suspend fun Context.themePicker(
                 ThemeManager.setNormalTheme(if (this == "trime") this else "$this.trime")
                 TabManager.updateSelf()
             }
-            launch {
-                Trime.getServiceOrNull()?.initKeyboard()
-            }
         }
     }.create()
 }
@@ -52,21 +49,20 @@ suspend fun Context.themePicker(
 suspend fun Context.colorPicker(
     @StyleRes themeResId: Int = 0,
 ): AlertDialog {
-    val prefs by lazy { AppPrefs.defaultInstance() }
     return CoroutineChoiceDialog(this, themeResId).apply {
         title = getString(R.string.looks__selected_color_title)
         initDispatcher = Dispatchers.Default
         val all by lazy { ThemeManager.activeTheme.getPresetColorSchemes() }
         onInit {
             items = all.map { it.second }.toTypedArray()
-            val current = prefs.theme.selectedColor
+            val current = ThemeManager.activeTheme.currentColorSchemeId
             val schemeIds = all.map { it.first }
             checkedItem = schemeIds.indexOf(current).takeIf { it > -1 } ?: 1
         }
         postiveDispatcher = Dispatchers.Default
         onOKButton {
             val schemeIds = all.map { it.first }
-            prefs.theme.selectedColor = schemeIds[checkedItem]
+            ThemeManager.activeTheme.setColorScheme(schemeIds[checkedItem])
             launch {
                 Trime.getServiceOrNull()?.initKeyboard() // 立刻重初始化键盘生效
             }


### PR DESCRIPTION
## Pull request

- 记住当前主题上次 dark/light 配色。（有多个 light 配色对应一个 dark 配色，从 dark 可以切回上次使用的 light 配色）
- 修复切换深色模式后，配色选项与实际配色不符
- 修复系统在亮色模式无法切换到 dark 配色

#### Issue tracker
Fixes will automatically close the related issues

Fixes #1213
Fixes #1215

#### Feature
Describe features of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

