### PR TITLE
Dynamically load and cache keyboard layout

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.kt
@@ -459,14 +459,13 @@ open class Trime : LifecycleInputMethodService() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         val config = resources.configuration
+        // 屏幕方向改变时会重置 inputView，不用在这里重置键盘
         if (config.orientation != newConfig.orientation) {
             // Clear composing text and candidates for orientation change.
             performEscape()
-            config.orientation = newConfig.orientation
         }
         super.onConfigurationChanged(newConfig)
         ThemeManager.onSystemNightModeChange(newConfig.isNightMode())
-        initKeyboard()
     }
 
     override fun onUpdateCursorAnchorInfo(cursorAnchorInfo: CursorAnchorInfo) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.kt
@@ -125,10 +125,10 @@ class Key(private val mKeyboard: Keyboard) {
                 val typeStr = type.toString().lowercase()
                 s = obtainString(mk, typeStr, "")
                 if (s.isNotEmpty()) {
-                    events[type.ordinal] = Event(mKeyboard, s)
+                    events[type.ordinal] = Event(s)
                     if (type.ordinal < KeyEventType.COMBO.ordinal) hasComposingKey = true
                 } else if (type == KeyEventType.CLICK) {
-                    events[type.ordinal] = Event(mKeyboard, "")
+                    events[type.ordinal] = Event("")
                 }
             }
             if (hasComposingKey) mKeyboard.composingKeys.add(this)
@@ -450,15 +450,15 @@ class Key(private val mKeyboard: Keyboard) {
         ) {
             label
         } else {
-            event!!.getLabel() // 中文狀態顯示標籤
+            event!!.getLabel(mKeyboard) // 中文狀態顯示標籤
         }
     }
 
     fun getPreviewText(type: Int): String {
         return if (type == KeyEventType.CLICK.ordinal) {
-            event!!.previewText
+            event!!.getPreviewText(mKeyboard)
         } else {
-            getEvent(type)!!.previewText
+            getEvent(type)!!.getPreviewText(mKeyboard)
         }
     }
 
@@ -466,7 +466,7 @@ class Key(private val mKeyboard: Keyboard) {
         get() {
             if (labelSymbol!!.isEmpty()) {
                 val longClick = longClick
-                if (longClick != null) return longClick.getLabel()
+                if (longClick != null) return longClick.getLabel(mKeyboard)
             }
             return labelSymbol
         }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -640,10 +640,12 @@ class Keyboard() {
         val keyboardSidePaddingLandscape = theme.style.getInt("keyboard_padding_land")
 
         val keyboardSidePaddingPx =
-            when (appContext.resources.configuration.orientation) {
-                Configuration.ORIENTATION_LANDSCAPE -> keyboardSidePaddingLandscape
-                else -> keyboardSidePadding
-            }.apply { appContext.dp(this) }
+            appContext.dp(
+                when (appContext.resources.configuration.orientation) {
+                    Configuration.ORIENTATION_LANDSCAPE -> keyboardSidePaddingLandscape
+                    else -> keyboardSidePadding
+                },
+            )
 
         mDisplayWidth = ScreenUtils.getAppScreenWidth() - 2 * keyboardSidePaddingPx
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -154,16 +154,26 @@ class Keyboard() {
         height = y + keyHeight
     }
 
-    constructor(name: String?) : this() {
+    private fun getKeyboardConfig(name: String): Map<String, Any?>? {
         val theme = ThemeManager.activeTheme
-        val keyboardConfig: Map<String, Any?>?
-        val v = theme.keyboards.getObject(name!!)
-        keyboardConfig =
+        val v = theme.keyboards.getObject(name)
+        val keyboardConfig =
             if (v != null) {
                 v as Map<String, Any?>?
             } else {
                 theme.keyboards.getObject("default") as Map<String, Any?>?
             }
+        val importPreset = keyboardConfig?.get("import_preset") as String?
+        if (importPreset != null) {
+            return getKeyboardConfig(importPreset)
+        }
+        return keyboardConfig
+    }
+
+    constructor(name: String) : this() {
+        val theme = ThemeManager.activeTheme
+        val keyboardConfig = getKeyboardConfig(name)
+
         mLabelTransform = obtainString(keyboardConfig, "label_transform", "none")
         mAsciiMode = obtainInt(keyboardConfig, "ascii_mode", 1)
         if (mAsciiMode == 0) asciiKeyboard = obtainString(keyboardConfig, "ascii_keyboard", "")
@@ -195,18 +205,24 @@ class Keyboard() {
         horizontalGap =
             sp2px(
                 obtainFloat(
-                    keyboardConfig, "horizontal_gap", theme.style.getFloat("horizontal_gap"),
+                    keyboardConfig,
+                    "horizontal_gap",
+                    theme.style.getFloat("horizontal_gap"),
                 ),
             ).toInt()
         verticalGap =
             sp2px(
                 obtainFloat(
-                    keyboardConfig, "vertical_gap", theme.style.getFloat("vertical_gap"),
+                    keyboardConfig,
+                    "vertical_gap",
+                    theme.style.getFloat("vertical_gap"),
                 ),
             ).toInt()
         roundCorner =
             obtainFloat(
-                keyboardConfig, "round_corner", theme.style.getFloat("round_corner"),
+                keyboardConfig,
+                "round_corner",
+                theme.style.getFloat("round_corner"),
             )
         val horizontalGap = horizontalGap
         val verticalGap = verticalGap
@@ -361,13 +377,17 @@ class Keyboard() {
                 key.key_symbol_offset_x =
                     sp2px(
                         obtainFloat(
-                            mk, "key_symbol_offset_x", defaultKeySymbolOffsetX.toFloat(),
+                            mk,
+                            "key_symbol_offset_x",
+                            defaultKeySymbolOffsetX.toFloat(),
                         ),
                     ).toInt()
                 key.key_symbol_offset_y =
                     sp2px(
                         obtainFloat(
-                            mk, "key_symbol_offset_y", defaultKeySymbolOffsetY.toFloat(),
+                            mk,
+                            "key_symbol_offset_y",
+                            defaultKeySymbolOffsetY.toFloat(),
                         ),
                     ).toInt()
                 key.key_hint_offset_x =

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -143,7 +143,7 @@ class Keyboard() {
             key.width = keyWidth
             key.height = keyHeight
             key.gap = horizontalGap
-            key.events[0] = Event(this, element.toString())
+            key.events[0] = Event(element.toString())
             column++
             x += key.width + key.gap
             mKeys.add(key)

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSwitcher.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSwitcher.kt
@@ -44,6 +44,7 @@ object KeyboardSwitcher {
     }
 
     fun switchKeyboard(name: String?) {
+        if (name == null) return
         val currentIdx = theme.allKeyboardIds.indexOf(currentKeyboardId)
         var mappedName =
             when (name) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSwitcher.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSwitcher.kt
@@ -16,7 +16,6 @@ object KeyboardSwitcher {
     private var currentKeyboardId = ".default"
     private var lastKeyboardId = ".default"
     private var lastLockKeyboardId = ".default"
-    private var currentDisplayWidth: Int = 0
     private val keyboardPrefs = KeyboardPrefs()
 
     lateinit var currentKeyboard: Keyboard
@@ -40,7 +39,6 @@ object KeyboardSwitcher {
         currentKeyboardId = ".default"
         lastKeyboardId = ".default"
         lastLockKeyboardId = ".default"
-        currentDisplayWidth = 0
         keyboardCache.clear()
         switchKeyboard(currentKeyboardId)
     }
@@ -137,14 +135,5 @@ object KeyboardSwitcher {
 
         Timber.d("Could not find keyboard layout $layout, fallback to default")
         return "default"
-    }
-
-    /**
-     * Change current display width when e.g. rotate the screen.
-     */
-    fun resize(displayWidth: Int) {
-        if (displayWidth == currentDisplayWidth) return
-        currentDisplayWidth = displayWidth
-        newOrReset()
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/text/Composition.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Composition.java
@@ -47,6 +47,7 @@ import com.osfans.trime.data.theme.Theme;
 import com.osfans.trime.data.theme.ThemeManager;
 import com.osfans.trime.ime.core.Trime;
 import com.osfans.trime.ime.keyboard.Event;
+import com.osfans.trime.ime.keyboard.KeyboardSwitcher;
 import com.osfans.trime.util.CollectionUtils;
 import com.osfans.trime.util.DimensionsKt;
 import java.util.ArrayList;
@@ -491,7 +492,7 @@ public class Composition extends AppCompatTextView {
     final String label;
     final Event e = new Event(CollectionUtils.obtainString(m, "click", ""));
     if (m.containsKey("label")) label = CollectionUtils.obtainString(m, "label", "");
-    else label = e.getLabel();
+    else label = e.getLabel(KeyboardSwitcher.currentKeyboard);
     int start, end;
     String sep = null;
     if (m.containsKey("start")) sep = CollectionUtils.obtainString(m, "start", "");

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -199,10 +199,8 @@ class TextInputManager private constructor() :
                     }
                 }
 
-            KeyboardSwitcher.run {
-                // Select a keyboard based on the input type of the editing field.
-                switchKeyboard(keyboardType)
-            }
+            // Select a keyboard based on the input type of the editing field.
+            KeyboardSwitcher.switchKeyboard(keyboardType)
             Rime.getInstance()
 
             // style/reset_ascii_mode指定了弹出键盘时是否重置ASCII状态。

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -287,8 +287,8 @@ class TextInputManager private constructor() :
                 activeEditorInstance.commitText(event.commit, true)
                 return
             }
-            if (event.getText().isNotEmpty()) {
-                onText(event.getText())
+            if (event.getText(KeyboardSwitcher.currentKeyboard).isNotEmpty()) {
+                onText(event.getText(KeyboardSwitcher.currentKeyboard))
                 return
             }
             when (event.code) {

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -200,7 +200,6 @@ class TextInputManager private constructor() :
                 }
 
             KeyboardSwitcher.run {
-                resize(trime.maxWidth)
                 // Select a keyboard based on the input type of the editing field.
                 switchKeyboard(keyboardType)
             }


### PR DESCRIPTION
## Pull request

动态加载并缓存键盘布局，废弃 `style/keyboards` 选项。

优点：
- 方便
- 减少内存占用
- 加快主题加载、切换速度
- 加快配色切换速度（基本秒切

缺点：
- 第一次切换到未使用过的布局会慢一点（感觉不出来

其他待办：
- [x] 修复 `import_preset` 失效
- [x] 修复 `keyboard_padding` 启用后键盘宽度溢出

#### Issue tracker
Fixes will automatically close the related issues

Fixes #1164 
Fixes #1226

#### Feature
Describe features of pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

