### PR TITLE
ci: upgrade action to v4

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -34,7 +34,7 @@ jobs:
           brew install coreutils clang-format
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 17
@@ -47,7 +47,7 @@ jobs:
             ./gradlew :app:calculateNativeCacheHash
 
       - name: Fetch JNI cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: jni-cache
         with:
           path: "app/prebuilt"
@@ -77,7 +77,7 @@ jobs:
         run: cp -R app/build/intermediates/stripped_native_libs/debug/out/lib app/prebuilt
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trime-${{ matrix.os }}
           path: app/build/outputs/apk/debug/
@@ -85,7 +85,7 @@ jobs:
           retention-days: 90
 
       - name: Upload APK artifact (ARM64_V8A only)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trime-arm64-v8a-${{ matrix.os }}
           path: app/build/outputs/apk/debug/*arm64-v8a-*.apk
@@ -93,7 +93,7 @@ jobs:
           retention-days: 90
 
       - name: Upload JNI artifact (librime_jni.so)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: librime_jni
           path: app/build/intermediates/stripped_native_libs/debug/out/lib/*

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 21
@@ -31,7 +31,7 @@ jobs:
             ./gradlew :app:calculateNativeCacheHash
 
       - name: Fetch JNI cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: jni-cache
         with:
           path: "app/prebuilt"

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -41,7 +41,7 @@ jobs:
           brew install coreutils clang-format
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 17
@@ -54,7 +54,7 @@ jobs:
             ./gradlew :app:calculateNativeCacheHash
 
       - name: Fetch JNI cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: jni-cache
         with:
           path: "app/prebuilt"
@@ -84,7 +84,7 @@ jobs:
         run: cp -R app/build/intermediates/stripped_native_libs/debug/out/lib app/prebuilt
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trime-${{ matrix.os }}
           path: app/build/outputs/apk/debug/

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 21
@@ -30,7 +30,7 @@ jobs:
             ./gradlew :app:calculateNativeCacheHash
 
       - name: Fetch JNI cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: jni-cache
         with:
           path: "app/prebuilt"


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

This will dismiss the warning of deprecated Node.js 16

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-java@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

