### PR TITLE
Reveal the keyboard background when navigation bar is visible

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
         android:label="@string/trime_app_name"
         android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_app_icon_round"
-        android:theme="@style/PreferenceTheme">
+        android:theme="@style/Theme.TrimeAppTheme">
 
         <service
             android:name=".TrimeImeService"

--- a/app/src/main/java/com/osfans/trime/data/theme/Theme.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/Theme.kt
@@ -19,6 +19,7 @@ package com.osfans.trime.data.theme
 
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
+import androidx.annotation.ColorInt
 import androidx.core.math.MathUtils
 import com.osfans.trime.core.Rime
 import com.osfans.trime.data.AppPrefs
@@ -171,11 +172,13 @@ class Theme(private var isDarkMode: Boolean) {
         }
 
         // API 2.0
+        @ColorInt
         fun getColor(key: String?): Int? {
             val o = theme.currentColors[key]
             return if (o is Int) o else null
         }
 
+        @ColorInt
         fun getColor(
             m: Map<String, Any?>,
             key: String?,

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
+import android.widget.ImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -33,6 +34,7 @@ import splitties.views.dsl.constraintlayout.above
 import splitties.views.dsl.constraintlayout.below
 import splitties.views.dsl.constraintlayout.bottomOfParent
 import splitties.views.dsl.constraintlayout.centerHorizontally
+import splitties.views.dsl.constraintlayout.centerInParent
 import splitties.views.dsl.constraintlayout.constraintLayout
 import splitties.views.dsl.constraintlayout.endOfParent
 import splitties.views.dsl.constraintlayout.endToStartOf
@@ -41,10 +43,12 @@ import splitties.views.dsl.constraintlayout.startOfParent
 import splitties.views.dsl.constraintlayout.startToEndOf
 import splitties.views.dsl.constraintlayout.topOfParent
 import splitties.views.dsl.core.add
+import splitties.views.dsl.core.imageView
 import splitties.views.dsl.core.matchParent
 import splitties.views.dsl.core.view
 import splitties.views.dsl.core.withTheme
 import splitties.views.dsl.core.wrapContent
+import splitties.views.imageDrawable
 
 /**
  * Successor of the old InputRoot
@@ -55,6 +59,10 @@ class InputView(
     val rime: Rime,
     val theme: Theme,
 ) : ConstraintLayout(service) {
+    private val keyboardBackground =
+        imageView {
+            scaleType = ImageView.ScaleType.CENTER_CROP
+        }
     private val placeholderListener = OnClickListener { }
 
     private val leftPaddingSpace =
@@ -148,10 +156,18 @@ class InputView(
 
         liquidKeyboard.setKeyboardView(keyboardWindow.oldSymbolInputView.liquidKeyboardView)
 
+        keyboardBackground.imageDrawable = theme.colors.getDrawable("keyboard_background")
+            ?: theme.colors.getDrawable("keyboard_back_color")
+
         keyboardView =
             constraintLayout {
                 isMotionEventSplittingEnabled = true
-                background = theme.colors.getDrawable("root_background")
+                add(
+                    keyboardBackground,
+                    lParams {
+                        centerInParent()
+                    },
+                )
                 add(
                     quickBar.view,
                     lParams(matchParent, wrapContent) {

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.kt
@@ -492,7 +492,7 @@ open class Trime : LifecycleInputMethodService() {
             bindKeyboardToInputView()
             // if (!restarting) setNavBarColor();
             setCandidatesViewShown(!Rime.isEmpty) // 軟鍵盤出現時顯示候選欄
-            inputView?.startInput(attribute)
+            inputView?.startInput(attribute, restarting)
             when (attribute.inputType and InputType.TYPE_MASK_VARIATION) {
                 InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
                 InputType.TYPE_TEXT_VARIATION_PASSWORD,

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -18,7 +18,6 @@
 package com.osfans.trime.ime.keyboard
 
 import android.content.res.Configuration
-import android.graphics.drawable.Drawable
 import android.view.KeyEvent
 import com.blankj.utilcode.util.ScreenUtils
 import com.osfans.trime.data.AppPrefs.Companion.defaultInstance
@@ -54,9 +53,6 @@ class Keyboard() {
     var roundCorner: Float
         private set
 
-    /** 鍵盤背景  */
-    var background: Drawable?
-        private set
     // 鍵盤的Shift鍵是否按住
     // private boolean mShifted;
 
@@ -229,8 +225,6 @@ class Keyboard() {
         val keyboardHeight = getKeyboardHeight(theme, keyboardConfig)
         val keyboardKeyWidth = obtainFloat(keyboardConfig, "width", 0f)
         val maxColumns = if (columns == -1) Int.MAX_VALUE else columns
-        val background = theme.colors.getDrawable(keyboardConfig, "keyboard_back_color")
-        if (background != null) this.background = background
         var x = this.horizontalGap / 2
         var y = this.verticalGap
         var row = 0
@@ -659,7 +653,6 @@ class Keyboard() {
         mProximityThreshold = (keyWidth * SEARCH_DISTANCE).toInt()
         mProximityThreshold *= mProximityThreshold // Square it for comparison
         roundCorner = theme.style.getFloat("round_corner")
-        background = theme.colors.getDrawable("keyboard_back_color")
         mKeys = ArrayList()
         composingKeys = ArrayList()
     }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.kt
@@ -564,13 +564,11 @@ class KeyboardView(context: Context?, attrs: AttributeSet?) : View(context, attr
 
     private fun setKeyboardBackground() {
         if (mKeyboard == null) return
-        var d = mPreviewText.background
+        val d = mPreviewText.background
         if (d is GradientDrawable) {
             d.cornerRadius = mKeyboard!!.roundCorner
             mPreviewText.background = d
         }
-        d = mKeyboard!!.background
-        background = d
     }
 
     var keyboard: Keyboard?

--- a/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
@@ -31,6 +31,7 @@ import com.osfans.trime.util.isStorageAvailable
 import com.osfans.trime.util.progressBarDialogIndeterminate
 import com.osfans.trime.util.rimeActionWithResultDialog
 import kotlinx.coroutines.launch
+import splitties.views.topPadding
 
 class PrefMainActivity : AppCompatActivity() {
     private val viewModel: MainViewModel by viewModels()
@@ -67,17 +68,11 @@ class PrefMainActivity : AppCompatActivity() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
             val statusBars = windowInsets.getInsets(WindowInsetsCompat.Type.statusBars())
             val navBars = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            binding.prefToolbar.appBar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            binding.root.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 leftMargin = navBars.left
                 rightMargin = navBars.right
             }
-            binding.prefToolbar.toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                topMargin = statusBars.top
-            }
-            binding.navHostFragment.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                leftMargin = navBars.left
-                rightMargin = navBars.right
-            }
+            binding.prefToolbar.root.topPadding = statusBars.top
             windowInsets
         }
 

--- a/app/src/main/java/com/osfans/trime/util/Activity.kt
+++ b/app/src/main/java/com/osfans/trime/util/Activity.kt
@@ -1,0 +1,20 @@
+package com.osfans.trime.util
+
+import android.app.Activity
+import android.graphics.Color
+import android.os.Build
+import androidx.core.view.WindowCompat
+
+fun Activity.applyTranslucentSystemBars() {
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    // windowLightNavigationBar is available for 27+
+    window.navigationBarColor =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Color.TRANSPARENT
+        } else {
+            // com.android.internal.R.color.system_bar_background_semi_transparent
+            0x66000000
+        }
+    WindowCompat.getInsetsController(window, window.decorView)
+        .isAppearanceLightNavigationBars = !resources.configuration.isNightMode()
+}

--- a/app/src/main/java/com/osfans/trime/util/ColorUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ColorUtils.kt
@@ -34,4 +34,11 @@ object ColorUtils {
             null
         }
     }
+
+    fun isDark(color: Int): Boolean {
+        val r = Color.red(color)
+        val g = Color.green(color)
+        val b = Color.blue(color)
+        return (r * 0.299 + g * 0.587 + b * 0.114) < 128
+    }
 }

--- a/app/src/main/java/com/osfans/trime/util/Utils.kt
+++ b/app/src/main/java/com/osfans/trime/util/Utils.kt
@@ -1,9 +1,7 @@
 package com.osfans.trime.util
 
-import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
-import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -12,7 +10,6 @@ import android.util.TypedValue
 import android.view.View
 import androidx.annotation.AttrRes
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.preference.Preference
@@ -94,18 +91,6 @@ fun iso8601UTCDateTime(timeMillis: Long? = null): String = iso8601DateFormat.for
 inline fun CharSequence.startsWithAsciiChar(): Boolean {
     val firstCodePoint = this.toString().codePointAt(0)
     return firstCodePoint in 0x20 until 0x80
-}
-
-fun Activity.applyTranslucentSystemBars() {
-    WindowCompat.setDecorFitsSystemWindows(window, false)
-    // windowLightNavigationBar is available for 27+
-    window.navigationBarColor =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
-            Color.TRANSPARENT
-        } else {
-            // com.android.internal.R.color.system_bar_background_semi_transparent
-            0x66000000
-        }
 }
 
 fun RecyclerView.applyNavBarInsetsBottomPadding() {

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="toolbarForegroundColor">#FFFFFF</color>  <!-- 工具栏前景色 -->
-    <color name="windowBackground">#202020</color>
+    <color name="colorOnSurface">#000000</color>
+    <color name="colorBackground">#1E2B38</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,11 +9,11 @@
     <color name="grey_700">#616161</color>
 
     <!-- 本色彩方案取自 Rime 官网（https://rime.im） -->
-    <color name="colorPrimary">#3F4144</color> <!-- 浅主题色 -->
-    <color name="colorPrimaryDark">#37393D</color> <!-- 深主题色 -->
+    <color name="colorPrimary">#2C3E50</color> <!-- 浅主题色 -->
+    <color name="colorPrimaryDark">#1E2B38</color> <!-- 深主题色 -->
     <color name="colorAccent">#009BD1</color>  <!-- 浅强调色 -->
-    <color name="colorAccentDark">#1976D2</color> <!-- 深强调色 -->
+    <color name="colorAccentDark">#006C92</color> <!-- 深强调色 -->
+    <color name="colorBackground">#FAFAFA</color>
     <color name="toolbarForegroundColor">#FFFFFF</color>  <!-- 工具栏前景色 -->
-    
-    <color name="windowBackground">#FAFAFA</color>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="PreferenceTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="Theme.TrimeAppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:colorAccent" tools:targetApi="lollipop">@color/colorAccent</item>
-
-        <item name="android:windowBackground">@color/windowBackground</item>
-        <item name="android:colorBackground">@color/windowBackground</item>
+        <item name="colorOnSurface">@color/colorOnSurface</item>
+        <item name="android:colorBackground">@color/colorBackground</item>
+        <item name="android:colorAccent" >@color/colorAccent</item>
     </style>
 </resources>


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1212 (partially)
Fixes #293 (reopened)
Fixes #519 (reopened)

#### Feature
Describe features of this pull request

We did the similar thing in the past (#492), but the solution is not perfect and then it was reverted. 

**Known issue**

A little of the bottom part of the keyboard view will be masked by the navigation bar after changing theme or color scheme in place on Android 9 due to a bug from the latter. There seems to be no any reliable way to fix it.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

**Before**

<img src="https://github.com/osfans/trime/assets/47623588/ef2feecc-439d-45c6-a78c-df17635d7b9e" width=240px />

<img src="https://github.com/osfans/trime/assets/47623588/bc23f433-dd04-4ece-b996-1be94dfe901b" width=240px />

**After**

<img src="https://github.com/osfans/trime/assets/47623588/01d41e70-ed0e-4099-824f-7302e358a2d8" width=240px />

<img src="https://github.com/osfans/trime/assets/47623588/321d31af-db27-4829-925f-10f925de2f9d" width=240px />


