### PR TITLE
fix: apply correct unit for the text size of `Paint`s

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabView.kt
@@ -35,6 +35,7 @@ import com.osfans.trime.ime.enums.SymbolKeyboardType
 import com.osfans.trime.util.GraphicUtils.drawText
 import com.osfans.trime.util.GraphicUtils.measureText
 import com.osfans.trime.util.dp2px
+import com.osfans.trime.util.sp
 import timber.log.Timber
 import kotlin.math.abs
 
@@ -67,10 +68,9 @@ class TabView(context: Context?, attrs: AttributeSet?) : View(context, attrs) {
         candidateTextColor = theme.colors.getColor("candidate_text_color")!!
         hilitedCandidateTextColor = theme.colors.getColor("hilited_candidate_text_color")!!
         commentHeight = dp2px(theme.style.getFloat("comment_height")).toInt()
-        val candidateTextSize = dp2px(theme.style.getFloat("candidate_text_size")).toInt()
         candidateViewHeight = dp2px(theme.style.getFloat("candidate_view_height")).toInt()
         candidateFont = FontManager.getTypeface("candidate_font")
-        candidatePaint.textSize = candidateTextSize.toFloat()
+        candidatePaint.textSize = sp(theme.style.getFloat("candidate_text_size"))
         candidatePaint.setTypeface(candidateFont)
         isCommentOnTop = theme.style.getBoolean("comment_on_top")
         shouldCandidateUseCursor = theme.style.getBoolean("candidate_use_cursor")

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
@@ -34,6 +34,7 @@ import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.core.Trime
 import com.osfans.trime.util.GraphicUtils.drawText
 import com.osfans.trime.util.GraphicUtils.measureText
+import com.osfans.trime.util.sp
 import splitties.dimensions.dp
 import java.lang.ref.WeakReference
 import kotlin.math.max
@@ -71,21 +72,21 @@ class Candidate(context: Context?, attrs: AttributeSet?) : View(context, attrs) 
     private val candidatePaint =
         Paint().apply {
             typeface = candidateFont
-            theme.style.getFloat("candidate_text_size").takeIf { it > 0 }?.let { textSize = it }
+            theme.style.getFloat("candidate_text_size").takeIf { it > 0 }?.let { textSize = sp(it) }
             isAntiAlias = true
             strokeWidth = 0f
         }
     private val symbolPaint =
         Paint().apply {
             typeface = symbolFont
-            theme.style.getFloat("candidate_text_size").takeIf { it > 0 }?.let { textSize = it }
+            theme.style.getFloat("candidate_text_size").takeIf { it > 0 }?.let { textSize = sp(it) }
             isAntiAlias = true
             strokeWidth = 0f
         }
     private val commentPaint =
         Paint().apply {
             typeface = commentFont
-            theme.style.getFloat("comment_text_size").takeIf { it > 0 }?.let { textSize = it }
+            theme.style.getFloat("comment_text_size").takeIf { it > 0 }?.let { textSize = sp(it) }
             isAntiAlias = true
             strokeWidth = 0f
         }

--- a/app/src/main/java/com/osfans/trime/ime/text/Composition.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/Composition.kt
@@ -42,6 +42,7 @@ import com.osfans.trime.ime.core.Trime
 import com.osfans.trime.ime.keyboard.Event
 import com.osfans.trime.ime.keyboard.KeyboardSwitcher
 import com.osfans.trime.util.CollectionUtils
+import com.osfans.trime.util.sp
 import splitties.dimensions.dp
 import timber.log.Timber
 
@@ -260,7 +261,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
         compositionPos[0] = start
         compositionPos[1] = end
         ss!!.setSpan(CompositionSpan(), start, end, 0)
-        val textSize = theme.style.getInt("text_size")
+        val textSize = sp(theme.style.getInt("text_size"))
         ss!!.setSpan(AbsoluteSizeSpan(textSize), start, end, 0)
         CollectionUtils.obtainFloat(m, "letter_spacing").takeIf { it > 0 }
             ?.let { ss?.setSpan(LetterSpacingSpan(it), start, end, 0) }
@@ -368,7 +369,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                     end,
                     0,
                 )
-                val labelTextSize = theme.style.getInt("label_text_size")
+                val labelTextSize = sp(theme.style.getInt("label_text_size"))
                 ss!!.setSpan(AbsoluteSizeSpan(labelTextSize), start, end, 0)
             }
             start = ss!!.length
@@ -388,7 +389,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                 end,
                 0,
             )
-            val candidateTextSize = theme.style.getInt("candidate_text_size")
+            val candidateTextSize = sp(theme.style.getInt("candidate_text_size"))
             ss!!.setSpan(AbsoluteSizeSpan(candidateTextSize), start, end, 0)
             if (showComment && commentFormat.isNotEmpty() && o.comment.isNotEmpty()) {
                 val comment = String.format(commentFormat, o.comment)
@@ -408,7 +409,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                     end,
                     0,
                 )
-                val commentTextSize = theme.style.getInt("comment_text_size")
+                val commentTextSize = sp(theme.style.getInt("comment_text_size"))
                 ss!!.setSpan(AbsoluteSizeSpan(commentTextSize), start, end, 0)
                 lineLength += comment.length
             }
@@ -445,7 +446,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
         end = ss!!.length
         ss!!.setSpan(getAlign(m), start, end, 0)
         ss!!.setSpan(EventSpan(e), start, end, 0)
-        ss!!.setSpan(AbsoluteSizeSpan(keyTextSize), start, end, 0)
+        ss!!.setSpan(AbsoluteSizeSpan(sp(keyTextSize)), start, end, 0)
         val suffix = CollectionUtils.obtainString(m, "end")
         if (suffix.isNotEmpty()) ss!!.append(suffix)
     }

--- a/app/src/main/java/com/osfans/trime/util/Dimensions.kt
+++ b/app/src/main/java/com/osfans/trime/util/Dimensions.kt
@@ -2,7 +2,10 @@
 
 package com.osfans.trime.util
 
+import android.content.Context
 import android.content.res.Resources
+import android.util.TypedValue
+import android.view.View
 
 /**
  * Value of dp to value of px.
@@ -35,3 +38,15 @@ inline fun sp2px(value: Float): Float = value * Resources.getSystem().displayMet
  * @return value of px
  */
 inline fun sp2px(value: Int): Int = (value * Resources.getSystem().displayMetrics.scaledDensity).toInt()
+
+/** Converts Scaled Pixels to pixels. Returns an `Int` or a `Float` based on [value]'s type. */
+inline fun Context.sp(value: Int) = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, value.toFloat(), resources.displayMetrics).toInt()
+
+/** Converts Scaled Pixels to pixels. Returns an `Int` or a `Float` based on [value]'s type. */
+inline fun Context.sp(value: Float) = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, value, resources.displayMetrics)
+
+/** Converts Scaled Pixels to pixels. Returns an `Int` or a `Float` based on [value]'s type. */
+inline fun View.sp(value: Int) = context.sp(value)
+
+/** Converts Scaled Pixels to pixels. Returns an `Int` or a `Float` based on [value]'s type. */
+inline fun View.sp(value: Float) = context.sp(value)


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1252 

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

