### PR TITLE
Enhance Event and Color Management 

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -108,40 +108,43 @@ style:
     default: Enter   # 定义默认Enter键的文本
 
 fallback_colors:
-  candidate_text_color: text_color
-  comment_text_color: candidate_text_color
-  border_color: back_color
-  candidate_separator_color: border_color
-  hilited_text_color: text_color
-  hilited_back_color: back_color
-  hilited_candidate_text_color: hilited_text_color
-  hilited_candidate_back_color: hilited_back_color
-  hilited_comment_text_color: comment_text_color
-  hilited_key_back_color: hilited_candidate_back_color
-  hilited_key_text_color: hilited_candidate_text_color
-  hilited_key_symbol_color: hilited_comment_text_color
-  hilited_off_key_back_color: hilited_key_back_color
-  hilited_on_key_back_color: hilited_key_back_color
-  hilited_off_key_text_color: hilited_key_text_color
-  hilited_on_key_text_color: hilited_key_text_color
-  key_back_color: back_color
-  key_border_color: border_color
-  key_text_color: candidate_text_color
-  key_symbol_color: comment_text_color
-  label_color: candidate_text_color
-  off_key_back_color: key_back_color
-  off_key_text_color: key_text_color
-  on_key_back_color: hilited_key_back_color
-  on_key_text_color: hilited_key_text_color
-  preview_back_color: key_text_color
-  preview_text_color: key_back_color
-  shadow_color: border_color
-  root_background: back_color # 整个键盘区+候选栏的背景图/色
-  candidate_background: back_color #候选栏的整体背景图/色
-  keyboard_back_color: border_color #键盘区的背景图/色
-  liquid_keyboard_background: keyboard_back_color # liquidKeyboard的背景图/色
-  text_back_color: back_color #编码区背景，即悬浮窗背景
-  long_text_back_color: key_back_color #长文本按键的背景(剪贴板）
+# 以下值是程序内置的，你也可以在这里自定义，这会覆盖默认值
+#
+#  candidate_text_color: text_color
+#  comment_text_color: candidate_text_color
+#  border_color: back_color
+#  candidate_separator_color: border_color
+#  hilited_text_color: text_color
+#  hilited_back_color: back_color
+#  hilited_candidate_text_color: hilited_text_color
+#  hilited_candidate_back_color: hilited_back_color
+#  hilited_label_color: hilited_candidate_text_color # 高亮候选序号 颜色
+#  hilited_comment_text_color: comment_text_color
+#  hilited_key_back_color: hilited_candidate_back_color
+#  hilited_key_text_color: hilited_candidate_text_color
+#  hilited_key_symbol_color: hilited_comment_text_color
+#  hilited_off_key_back_color: hilited_key_back_color
+#  hilited_on_key_back_color: hilited_key_back_color
+#  hilited_off_key_text_color: hilited_key_text_color
+#  hilited_on_key_text_color: hilited_key_text_color
+#  key_back_color: back_color
+#  key_border_color: border_color
+#  key_text_color: candidate_text_color
+#  key_symbol_color: comment_text_color
+#  label_color: candidate_text_color
+#  off_key_back_color: key_back_color
+#  off_key_text_color: key_text_color
+#  on_key_back_color: hilited_key_back_color
+#  on_key_text_color: hilited_key_text_color
+#  preview_back_color: key_back_color
+#  preview_text_color: key_text_color
+#  shadow_color: border_color
+#  root_background: back_color # 整个键盘区+候选栏的背景图/色
+#  candidate_background: back_color #候选栏的整体背景图/色
+#  keyboard_back_color: border_color #键盘区的背景图/色
+#  liquid_keyboard_background: keyboard_back_color # liquidKeyboard的背景图/色
+#  text_back_color: back_color #编码区背景，即悬浮窗背景
+#  long_text_back_color: key_back_color #长文本按键的背景(剪贴板）
 
 #颜色
 colors:

--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -105,41 +105,43 @@ style:
     default: Enter   # 定义默认Enter键的文本
 
 fallback_colors:
-  candidate_text_color: text_color
-  comment_text_color: candidate_text_color
-  border_color: back_color
-  candidate_separator_color: border_color
-  hilited_text_color: text_color
-  hilited_back_color: back_color
-  hilited_candidate_text_color: hilited_text_color
-  hilited_candidate_back_color: hilited_back_color
-  hilited_label_color: hilited_candidate_text_color # 高亮候选序号 颜色
-  hilited_comment_text_color: comment_text_color
-  hilited_key_back_color: hilited_candidate_back_color
-  hilited_key_text_color: hilited_candidate_text_color
-  hilited_key_symbol_color: hilited_comment_text_color
-  hilited_off_key_back_color: hilited_key_back_color
-  hilited_on_key_back_color: hilited_key_back_color
-  hilited_off_key_text_color: hilited_key_text_color
-  hilited_on_key_text_color: hilited_key_text_color
-  key_back_color: back_color
-  key_border_color: border_color
-  key_text_color: candidate_text_color
-  key_symbol_color: comment_text_color
-  label_color: candidate_text_color
-  off_key_back_color: key_back_color
-  off_key_text_color: key_text_color
-  on_key_back_color: hilited_key_back_color
-  on_key_text_color: hilited_key_text_color
-  preview_back_color: key_back_color
-  preview_text_color: key_text_color
-  shadow_color: border_color
-  root_background: back_color # 整个键盘区+候选栏的背景图/色
-  candidate_background: back_color #候选栏的整体背景图/色
-  keyboard_back_color: border_color #键盘区的背景图/色
-  liquid_keyboard_background: keyboard_back_color # liquidKeyboard的背景图/色
-  text_back_color: back_color #编码区背景，即悬浮窗背景
-  long_text_back_color: key_back_color #长文本按键的背景(剪贴板）
+# 以下值是程序内置的，你也可以在这里自定义，这会覆盖默认值
+#
+#  candidate_text_color: text_color
+#  comment_text_color: candidate_text_color
+#  border_color: back_color
+#  candidate_separator_color: border_color
+#  hilited_text_color: text_color
+#  hilited_back_color: back_color
+#  hilited_candidate_text_color: hilited_text_color
+#  hilited_candidate_back_color: hilited_back_color
+#  hilited_label_color: hilited_candidate_text_color # 高亮候选序号 颜色
+#  hilited_comment_text_color: comment_text_color
+#  hilited_key_back_color: hilited_candidate_back_color
+#  hilited_key_text_color: hilited_candidate_text_color
+#  hilited_key_symbol_color: hilited_comment_text_color
+#  hilited_off_key_back_color: hilited_key_back_color
+#  hilited_on_key_back_color: hilited_key_back_color
+#  hilited_off_key_text_color: hilited_key_text_color
+#  hilited_on_key_text_color: hilited_key_text_color
+#  key_back_color: back_color
+#  key_border_color: border_color
+#  key_text_color: candidate_text_color
+#  key_symbol_color: comment_text_color
+#  label_color: candidate_text_color
+#  off_key_back_color: key_back_color
+#  off_key_text_color: key_text_color
+#  on_key_back_color: hilited_key_back_color
+#  on_key_text_color: hilited_key_text_color
+#  preview_back_color: key_back_color
+#  preview_text_color: key_text_color
+#  shadow_color: border_color
+#  root_background: back_color # 整个键盘区+候选栏的背景图/色
+#  candidate_background: back_color #候选栏的整体背景图/色
+#  keyboard_back_color: border_color #键盘区的背景图/色
+#  liquid_keyboard_background: keyboard_back_color # liquidKeyboard的背景图/色
+#  text_back_color: back_color #编码区背景，即悬浮窗背景
+#  long_text_back_color: key_back_color #长文本按键的背景(剪贴板）
 
 preset_color_schemes:
   default:

--- a/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
@@ -100,6 +100,7 @@ object ColorManager {
     }
 
     fun onSystemNightModeChange(isNight: Boolean) {
+        if (!prefs.autoDark) return
         if (isNightMode == isNight) return
         isNightMode = isNight
         switchNightMode(isNightMode)

--- a/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
@@ -27,6 +27,45 @@ object ColorManager {
     private var lastDarkColorSchemeId: String? = null // 上一个 dark 配色
     private var isNightMode = false
 
+    private val defaultFallbackColors =
+        hashMapOf(
+            "candidate_text_color" to "text_color",
+            "comment_text_color" to "candidate_text_color",
+            "border_color" to "back_color",
+            "candidate_separator_color" to "border_color",
+            "hilited_text_color" to "text_color",
+            "hilited_back_color" to "back_color",
+            "hilited_candidate_text_color" to "hilited_text_color",
+            "hilited_candidate_back_color" to "hilited_back_color",
+            "hilited_label_color" to "hilited_candidate_text_color",
+            "hilited_comment_text_color" to "comment_text_color",
+            "hilited_key_back_color" to "hilited_candidate_back_color",
+            "hilited_key_text_color" to "hilited_candidate_text_color",
+            "hilited_key_symbol_color" to "hilited_comment_text_color",
+            "hilited_off_key_back_color" to "hilited_key_back_color",
+            "hilited_on_key_back_color" to "hilited_key_back_color",
+            "hilited_off_key_text_color" to "hilited_key_text_color",
+            "hilited_on_key_text_color" to "hilited_key_text_color",
+            "key_back_color" to "back_color",
+            "key_border_color" to "border_color",
+            "key_text_color" to "candidate_text_color",
+            "key_symbol_color" to "comment_text_color",
+            "label_color" to "candidate_text_color",
+            "off_key_back_color" to "key_back_color",
+            "off_key_text_color" to "key_text_color",
+            "on_key_back_color" to "hilited_key_back_color",
+            "on_key_text_color" to "hilited_key_text_color",
+            "preview_back_color" to "key_back_color",
+            "preview_text_color" to "key_text_color",
+            "shadow_color" to "border_color",
+            "root_background" to "back_color",
+            "candidate_background" to "back_color",
+            "keyboard_back_color" to "border_color",
+            "liquid_keyboard_background" to "keyboard_back_color",
+            "text_back_color" to "back_color",
+            "long_text_back_color" to "key_back_color",
+        )
+
     // 遍历当前配色方案的值、fallback的值，从而获得当前方案的全部配色Map
     private val currentColors: MutableMap<String, Any> = hashMapOf()
 
@@ -150,21 +189,26 @@ object ColorManager {
     private fun refreshColorValues() {
         currentColors.clear()
         val colorMap = theme.presetColorSchemes[selectedColor] as Map<String, Any>
-        for ((key, value) in colorMap) {
+        colorMap.forEach { (key, value) ->
             when (key) {
-                "name", "author", "light_scheme", "dark_scheme", "sound" -> continue
+                "name", "author", "light_scheme", "dark_scheme", "sound" -> {}
                 else -> currentColors[key] = value
             }
         }
-        for ((key, value) in theme.fallbackColors!!) {
+        theme.fallbackColors?.forEach { (key, value) ->
             if (!currentColors.containsKey(key)) {
                 if (value != null) currentColors[key] = value
+            }
+        }
+        defaultFallbackColors.forEach { (key, value) ->
+            if (!currentColors.containsKey(key)) {
+                currentColors[key] = value
             }
         }
 
         // 先遍历一次，处理一下颜色和图片
         // 防止回退时获取到错误值
-        for ((key, value) in currentColors) {
+        currentColors.forEach { (key, value) ->
             val parsedValue = parseColorValue(value)
             if (parsedValue != null) {
                 currentColors[key] = parsedValue
@@ -172,8 +216,8 @@ object ColorManager {
         }
 
         // fallback
-        for ((key, value) in currentColors) {
-            if (value is Int || value is Drawable) continue
+        currentColors.forEach { (key, value) ->
+            if (value is Int || value is Drawable) return@forEach
             val parsedValue = getColorValue(value)
             if (parsedValue != null) {
                 currentColors[key] = parsedValue

--- a/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
@@ -95,6 +95,7 @@ object ColorManager {
         Timber.d("switch color scheme from %s to %s", selectedColor, colorSchemeId)
         selectedColor = colorSchemeId
         // 刷新配色
+        val isFirst = currentColors.isEmpty()
         refreshColorValues()
         if (isNightMode) {
             lastDarkColorSchemeId = colorSchemeId
@@ -110,7 +111,7 @@ object ColorManager {
             }
         }
         prefs.selectedColor = colorSchemeId
-        fireChange()
+        if (!isFirst) fireChange()
     }
 
     /** 切换深色/亮色模式 */

--- a/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
@@ -1,0 +1,321 @@
+package com.osfans.trime.data.theme
+
+import android.content.res.Configuration
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import androidx.annotation.ColorInt
+import androidx.core.math.MathUtils
+import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.DataManager
+import com.osfans.trime.data.sound.SoundEffectManager
+import com.osfans.trime.util.ColorUtils
+import com.osfans.trime.util.WeakHashSet
+import com.osfans.trime.util.bitmapDrawable
+import com.osfans.trime.util.dp2px
+import com.osfans.trime.util.isNightMode
+import timber.log.Timber
+import java.io.File
+import java.lang.IllegalArgumentException
+
+object ColorManager {
+    private val theme get() = ThemeManager.activeTheme
+    private val prefs = AppPrefs.defaultInstance().theme
+    private val backgroundFolder get() = theme.style.getString("background_folder")
+
+    var selectedColor = "default" // 当前配色 id
+    private var lastLightColorSchemeId: String? = null // 上一个 light 配色
+    private var lastDarkColorSchemeId: String? = null // 上一个 dark 配色
+    private var isNightMode = false
+
+    // 遍历当前配色方案的值、fallback的值，从而获得当前方案的全部配色Map
+    private val currentColors: MutableMap<String, Any> = hashMapOf()
+
+    /** 获取当前主题所有配色 */
+    fun getPresetColorSchemes(): List<Pair<String, String>> {
+        return theme.presetColorSchemes.map { (key, value) ->
+            Pair(key, value!!["name"] as String)
+        }
+    }
+
+    fun interface OnColorChangeListener {
+        fun onColorChange()
+    }
+
+    private val onChangeListeners = WeakHashSet<OnColorChangeListener>()
+
+    fun addOnChangedListener(listener: OnColorChangeListener) {
+        onChangeListeners.add(listener)
+    }
+
+    fun removeOnChangedListener(listener: OnColorChangeListener) {
+        onChangeListeners.remove(listener)
+    }
+
+    private fun fireChange() {
+        onChangeListeners.forEach { it.onColorChange() }
+    }
+
+    fun init(configuration: Configuration) {
+        isNightMode = configuration.isNightMode()
+        ThemeManager.init()
+    }
+
+    fun onSystemNightModeChange(isNight: Boolean) {
+        if (isNightMode == isNight) return
+        isNightMode = isNight
+        switchNightMode(isNightMode)
+    }
+
+    /** 每次切换主题后，都要调用此函数，初始化配色 */
+    fun refresh() {
+        lastDarkColorSchemeId = null
+        lastLightColorSchemeId = null
+
+        var colorScheme = prefs.selectedColor
+        if (!theme.presetColorSchemes.containsKey(colorScheme)) colorScheme = theme.style.getString("color_scheme") // 主題中指定的配色
+        if (!theme.presetColorSchemes.containsKey(colorScheme)) colorScheme = "default" // 主題中的default配色
+        // 配色表中没有这个 id
+        if (!theme.presetColorSchemes.containsKey(colorScheme)) {
+            Timber.e("Color scheme %s not found", colorScheme)
+            throw IllegalArgumentException("Color scheme $colorScheme not found!")
+        }
+        selectedColor = colorScheme
+        switchNightMode(isNightMode)
+    }
+
+    /**
+     * 切换到指定配色，切换成功后写入 AppPrefs
+     * @param colorSchemeId 配色 id
+     * */
+    fun setColorScheme(colorSchemeId: String) {
+        if (!theme.presetColorSchemes.containsKey(colorSchemeId)) {
+            Timber.w("Color scheme %s not found", colorSchemeId)
+            return
+        }
+        Timber.d("switch color scheme from %s to %s", selectedColor, colorSchemeId)
+        selectedColor = colorSchemeId
+        // 刷新配色
+        refreshColorValues()
+        if (isNightMode) {
+            lastDarkColorSchemeId = colorSchemeId
+        } else {
+            lastLightColorSchemeId = colorSchemeId
+        }
+        // 切换音效
+        currentColors["sound"].let {
+            if (it is String) {
+                Timber.d("Setting sound from color ...")
+                SoundEffectManager.switchSound(it)
+                Timber.d("Initialization finished")
+            }
+        }
+        prefs.selectedColor = colorSchemeId
+        fireChange()
+    }
+
+    /** 切换深色/亮色模式 */
+    private fun switchNightMode(isNightMode: Boolean) {
+        this.isNightMode = isNightMode
+        val newId = getColorSchemeId()
+        if (newId != null) setColorScheme(newId)
+        Timber.d(
+            "System changing color, current ColorScheme: $selectedColor, isDarkMode=$isNightMode",
+        )
+    }
+
+    /**
+     * @return 切换深色/亮色模式后配色的 id
+     */
+    private fun getColorSchemeId(): String? {
+        val colorMap = theme.presetColorSchemes[selectedColor] as Map<String, Any>
+        if (isNightMode) {
+            if (colorMap.containsKey("dark_scheme")) {
+                return colorMap["dark_scheme"] as String?
+            }
+            if (lastDarkColorSchemeId != null) {
+                return lastDarkColorSchemeId
+            }
+        } else {
+            if (colorMap.containsKey("light_scheme")) {
+                return colorMap["light_scheme"] as String?
+            }
+            if (lastLightColorSchemeId != null) {
+                return lastLightColorSchemeId
+            }
+        }
+        return selectedColor
+    }
+
+    private fun refreshColorValues() {
+        currentColors.clear()
+        val colorMap = theme.presetColorSchemes[selectedColor] as Map<String, Any>
+        for ((key, value) in colorMap) {
+            when (key) {
+                "name", "author", "light_scheme", "dark_scheme", "sound" -> continue
+                else -> currentColors[key] = value
+            }
+        }
+        for ((key, value) in theme.fallbackColors!!) {
+            if (!currentColors.containsKey(key)) {
+                if (value != null) currentColors[key] = value
+            }
+        }
+
+        // 先遍历一次，处理一下颜色和图片
+        // 防止回退时获取到错误值
+        for ((key, value) in currentColors) {
+            val parsedValue = parseColorValue(value)
+            if (parsedValue != null) {
+                currentColors[key] = parsedValue
+            }
+        }
+
+        // fallback
+        for ((key, value) in currentColors) {
+            if (value is Int || value is Drawable) continue
+            val parsedValue = getColorValue(value)
+            if (parsedValue != null) {
+                currentColors[key] = parsedValue
+            } else {
+                Timber.w("Cannot parse color key: %s, value: %s", key, value)
+            }
+        }
+
+        // sound
+        if (colorMap.containsKey("sound")) currentColors["sound"] = colorMap["sound"]!!
+    }
+
+    /** 获取参数的真实value，如果是色彩返回int，如果是背景图返回drawable，都不是则进行 fallback
+     * @return Int/Drawable/null
+     * */
+    private fun getColorValue(value: Any?): Any? {
+        val parsedValue = parseColorValue(value)
+        if (parsedValue != null) {
+            return parsedValue
+        }
+        var newKey = value
+        var newValue: Any?
+        val limit = currentColors.size
+        for (i in 0 until limit) {
+            newValue = currentColors[newKey]
+            if (newValue !is String) return newValue
+            // fallback
+            val parsedNewValue = parseColorValue(newValue)
+            if (parsedNewValue != null) {
+                return parsedNewValue
+            }
+            newKey = newValue
+        }
+        return null
+    }
+
+    /** 获取参数的真实value，如果是色彩返回int，如果是背景图返回drawable，如果处理失败返回null
+     * @return Int/Drawable/null
+     * */
+    private fun parseColorValue(value: Any?): Any? {
+        if (value !is String) return null
+        if (isFileString(value)) {
+            // 获取图片的真实地址
+            val fullPath = joinToFullImagePath(value)
+            if (File(fullPath).exists()) {
+                return bitmapDrawable(fullPath)
+            }
+        }
+        // 只对不包含下划线的字符串进行颜色解析
+        if (!value.contains("_")) {
+            return ColorUtils.parseColor(value)
+        }
+        return null
+    }
+
+    private fun joinToFullImagePath(value: String): String {
+        val defaultPath = File(DataManager.userDataDir, "backgrounds/$backgroundFolder/$value")
+        if (!defaultPath.exists()) {
+            val fallbackPath = File(DataManager.userDataDir, "backgrounds/$value")
+            if (fallbackPath.exists()) return fallbackPath.path
+        }
+        return defaultPath.path
+    }
+
+    private fun isFileString(str: String?): Boolean {
+        return str?.contains(Regex("""\.[a-z]{3,4}$""")) == true
+    }
+
+    // API 2.0
+    @ColorInt
+    fun getColor(key: String?): Int? {
+        val o = currentColors[key]
+        return if (o is Int) o else null
+    }
+
+    @ColorInt
+    fun getColor(
+        m: Map<String, Any?>,
+        key: String?,
+    ): Int? {
+        val value = getColorValue(m[key] as String?)
+        return if (value is Int) value else null
+    }
+
+    //  返回drawable。  Config 2.0
+    //  参数可以是颜色或者图片。如果参数缺失，返回null
+    fun getDrawable(key: String): Drawable? {
+        val o = currentColors[key]
+        if (o is Int) {
+            return GradientDrawable().apply { setColor(o) }
+        } else if (o is Drawable) {
+            return o
+        }
+        return null
+    }
+
+    // API 2.0
+    fun getDrawable(
+        m: Map<String, Any?>,
+        key: String,
+    ): Drawable? {
+        val value = getColorValue(m[key] as String?)
+        if (value is Int) {
+            return GradientDrawable().apply { setColor(value) }
+        } else if (value is Drawable) {
+            return value
+        }
+        return null
+    }
+
+    //  返回图片或背景的drawable,支持null参数。 Config 2.0
+    fun getDrawable(
+        key: String?,
+        borderKey: String?,
+        borderColorKey: String?,
+        roundCornerKey: String,
+        alphaKey: String?,
+    ): Drawable? {
+        val value = getColorValue(key)
+        if (value is Drawable) {
+            if (!alphaKey.isNullOrEmpty() && theme.style.getObject(alphaKey) != null) {
+                value.alpha = MathUtils.clamp(theme.style.getInt(alphaKey), 0, 255)
+            }
+            return value
+        }
+
+        if (value is Int) {
+            val gradient = GradientDrawable().apply { setColor(value) }
+            if (roundCornerKey.isNotEmpty()) {
+                gradient.cornerRadius = theme.style.getFloat(roundCornerKey)
+            }
+            if (!borderColorKey.isNullOrEmpty() && !borderKey.isNullOrEmpty()) {
+                val border = dp2px(theme.style.getFloat(borderKey))
+                val stroke = getColor(borderColorKey)
+                if (stroke != null && border > 0) {
+                    gradient.setStroke(border.toInt(), stroke)
+                }
+            }
+            if (!alphaKey.isNullOrEmpty() && theme.style.getObject(alphaKey) != null) {
+                gradient.alpha = MathUtils.clamp(theme.style.getInt(alphaKey), 0, 255)
+            }
+            return gradient
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/osfans/trime/data/theme/EventManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/EventManager.kt
@@ -15,7 +15,5 @@ object EventManager {
         return event
     }
 
-    fun clearCache() {
-        eventCache.clear()
-    }
+    fun refresh() = eventCache.clear()
 }

--- a/app/src/main/java/com/osfans/trime/data/theme/EventManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/EventManager.kt
@@ -1,0 +1,21 @@
+package com.osfans.trime.data.theme
+
+import com.osfans.trime.ime.keyboard.Event
+
+object EventManager {
+    private var eventCache = mutableMapOf<String, Event>()
+
+    @JvmStatic
+    fun getEvent(eventId: String): Event {
+        if (eventCache.containsKey(eventId)) {
+            return eventCache[eventId]!!
+        }
+        val event = Event(eventId)
+        eventCache[eventId] = event
+        return event
+    }
+
+    fun clearCache() {
+        eventCache.clear()
+    }
+}

--- a/app/src/main/java/com/osfans/trime/data/theme/FontManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/FontManager.kt
@@ -17,7 +17,7 @@ object FontManager {
         private set
     private val typefaceCache = mutableMapOf<String, Typeface>()
 
-    fun reload() {
+    fun refresh() {
         typefaceCache.clear()
         fontFamiliyCache.clear()
         hanBFont = getTypefaceOrDefault("hanb_font")

--- a/app/src/main/java/com/osfans/trime/data/theme/Theme.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/Theme.kt
@@ -17,78 +17,44 @@
  */
 package com.osfans.trime.data.theme
 
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.GradientDrawable
-import androidx.annotation.ColorInt
-import androidx.core.math.MathUtils
 import com.osfans.trime.core.Rime
 import com.osfans.trime.data.AppPrefs
-import com.osfans.trime.data.DataManager.userDataDir
-import com.osfans.trime.data.sound.SoundEffectManager
-import com.osfans.trime.ime.keyboard.Key
 import com.osfans.trime.util.CollectionUtils
-import com.osfans.trime.util.ColorUtils
-import com.osfans.trime.util.bitmapDrawable
-import com.osfans.trime.util.dp2px
 import timber.log.Timber
-import java.io.File
-import java.lang.IllegalArgumentException
 import java.util.Objects
 import kotlin.system.measureTimeMillis
 
 /** 主题和样式配置  */
-class Theme(private var isDarkMode: Boolean) {
+class Theme() {
     private var generalStyle: Map<String, Any?>? = null
-    private var fallbackColors: Map<String, String>? = null
-    private var presetColorSchemes: Map<String, Map<String, Any>?>? = null
     private var presetKeyboards: Map<String, Any?>? = null
     private var liquidKeyboard: Map<String, Any?>? = null
-    lateinit var allKeyboardIds: List<String>
 
-    // 当前配色 id
-    lateinit var currentColorSchemeId: String
+    var presetKeys: Map<String, Map<String, Any?>?>? = null
+        private set
+    var fallbackColors: Map<String, String?>? = null
+        private set
+    lateinit var presetColorSchemes: Map<String, Map<String, Any>?>
+        private set
+    var allKeyboardIds: List<String> = listOf()
+        private set
 
-    // 遍历当前配色方案的值、fallback的值，从而获得当前方案的全部配色Map
-    private val currentColors: MutableMap<String, Any> = hashMapOf()
-
-    // 上一个 light 配色
-    private var lastLightColorSchemeId: String? = null
-
-    // 上一个 dark 配色
-    private var lastDarkColorSchemeId: String? = null
-
-    @JvmField
     val style = Style(this)
-
-    @JvmField
     val liquid = Liquid(this)
-
-    @JvmField
-    val colors = Colors(this)
-
-    @JvmField
     val keyboards = Keyboards(this)
 
     companion object {
+        private val prefs = AppPrefs.defaultInstance().theme
         private const val VERSION_KEY = "config_version"
-        private val appPrefs = AppPrefs.defaultInstance()
-
         private const val DEFAULT_THEME_NAME = "trime"
-
-        fun isFileString(str: String?): Boolean {
-            return str?.contains(Regex("""\.[a-z]{3,4}$""")) == true
-        }
     }
 
     init {
         init()
-        Timber.d("Setting sound from color ...")
-        SoundEffectManager.switchSound(colors.getString("sound"))
-        Timber.d("Initialization finished")
     }
 
     fun init() {
-        val active = appPrefs.theme.selectedTheme
+        val active = prefs.selectedTheme
         Timber.i("Initializing theme, currentThemeName=%s ...", active)
         runCatching {
             val themeFileName = "$active.yaml"
@@ -105,26 +71,21 @@ class Theme(private var isDarkMode: Boolean) {
                 Objects.requireNonNull(fullThemeConfigMap, "The theme file cannot be empty!")
                 Timber.d("Fetching done")
                 generalStyle = fullThemeConfigMap!!["style"] as Map<String, Any?>?
-                fallbackColors = fullThemeConfigMap!!["fallback_colors"] as Map<String, String>?
-                Key.presetKeys = fullThemeConfigMap!!["preset_keys"] as Map<String, Map<String, Any?>?>?
-                presetColorSchemes = fullThemeConfigMap!!["preset_color_schemes"] as Map<String, Map<String, Any>?>?
+                fallbackColors = fullThemeConfigMap!!["fallback_colors"] as Map<String, String?>?
+                presetKeys = fullThemeConfigMap!!["preset_keys"] as Map<String, Map<String, Any?>?>?
+                presetColorSchemes = fullThemeConfigMap!!["preset_color_schemes"] as Map<String, Map<String, Any>?>
                 presetKeyboards = fullThemeConfigMap!!["preset_keyboards"] as Map<String, Any?>?
                 liquidKeyboard = fullThemeConfigMap!!["liquid_keyboard"] as Map<String, Any?>?
                 // 将 presetKeyboards 的所有 key 转为 allKeyboardIds
-                allKeyboardIds = presetKeyboards!!.keys.toList()
+                allKeyboardIds = presetKeyboards?.keys?.toList()!!
             }.also {
                 Timber.d("Setting up all theme config map takes $it ms")
-            }
-            measureTimeMillis {
-                initColorScheme()
-            }.also {
-                Timber.d("Initializing cache takes $it ms")
             }
             Timber.i("The theme is initialized")
         }.getOrElse {
             Timber.e("Failed to parse the theme: ${it.message}")
-            if (appPrefs.theme.selectedTheme != DEFAULT_THEME_NAME) {
-                appPrefs.theme.selectedTheme = DEFAULT_THEME_NAME
+            if (prefs.selectedTheme != DEFAULT_THEME_NAME) {
+                prefs.selectedTheme = DEFAULT_THEME_NAME
                 init()
             }
         }
@@ -166,267 +127,9 @@ class Theme(private var isDarkMode: Boolean) {
         }
     }
 
-    class Colors(private val theme: Theme) {
-        fun getString(key: String): String {
-            return CollectionUtils.obtainString(theme.presetColorSchemes, key, "")
-        }
-
-        // API 2.0
-        @ColorInt
-        fun getColor(key: String?): Int? {
-            val o = theme.currentColors[key]
-            return if (o is Int) o else null
-        }
-
-        @ColorInt
-        fun getColor(
-            m: Map<String, Any?>,
-            key: String?,
-        ): Int? {
-            val value = theme.getColorValue(m[key] as String?)
-            return if (value is Int) value else null
-        }
-
-        //  返回drawable。  Config 2.0
-        //  参数可以是颜色或者图片。如果参数缺失，返回null
-        fun getDrawable(key: String): Drawable? {
-            val o = theme.currentColors[key]
-            if (o is Int) {
-                return GradientDrawable().apply { setColor(o) }
-            } else if (o is Drawable) {
-                return o
-            }
-            return null
-        }
-
-        // API 2.0
-        fun getDrawable(
-            m: Map<String, Any?>,
-            key: String,
-        ): Drawable? {
-            val value = theme.getColorValue(m[key] as String?)
-            if (value is Int) {
-                return GradientDrawable().apply { setColor(value) }
-            } else if (value is Drawable) {
-                return value
-            }
-            return null
-        }
-
-        //  返回图片或背景的drawable,支持null参数。 Config 2.0
-        fun getDrawable(
-            key: String?,
-            borderKey: String?,
-            borderColorKey: String?,
-            roundCornerKey: String,
-            alphaKey: String?,
-        ): Drawable? {
-            val value = theme.getColorValue(key)
-            if (value is Drawable) {
-                if (!alphaKey.isNullOrEmpty() && theme.style.getObject(alphaKey) != null) {
-                    value.alpha = MathUtils.clamp(theme.style.getInt(alphaKey), 0, 255)
-                }
-                return value
-            }
-
-            if (value is Int) {
-                val gradient = GradientDrawable().apply { setColor(value) }
-                if (roundCornerKey.isNotEmpty()) {
-                    gradient.cornerRadius = theme.style.getFloat(roundCornerKey)
-                }
-                if (!borderColorKey.isNullOrEmpty() && !borderKey.isNullOrEmpty()) {
-                    val border = dp2px(theme.style.getFloat(borderKey))
-                    val stroke = getColor(borderColorKey)
-                    if (stroke != null && border > 0) {
-                        gradient.setStroke(border.toInt(), stroke)
-                    }
-                }
-                if (!alphaKey.isNullOrEmpty() && theme.style.getObject(alphaKey) != null) {
-                    gradient.alpha = MathUtils.clamp(theme.style.getInt(alphaKey), 0, 255)
-                }
-                return gradient
-            }
-            return null
-        }
-    }
-
     class Keyboards(private val theme: Theme) {
         fun getObject(key: String): Any? {
             return CollectionUtils.obtainValue(theme.presetKeyboards, key)
         }
-    }
-
-    /**
-     * 第一次载入主题，初始化默认配色
-     * */
-    private fun initColorScheme() {
-        var colorScheme = appPrefs.theme.selectedColor
-        if (!presetColorSchemes!!.containsKey(colorScheme)) colorScheme = style.getString("color_scheme") // 主題中指定的配色
-        if (!presetColorSchemes!!.containsKey(colorScheme)) colorScheme = "default" // 主題中的default配色
-        currentColorSchemeId = colorScheme
-        // 配色表中没有这个 id
-        if (!presetColorSchemes!!.containsKey(currentColorSchemeId)) {
-            Timber.e("Color scheme %s not found", currentColorSchemeId)
-            throw IllegalArgumentException("Color scheme $currentColorSchemeId not found!")
-        }
-        switchDarkMode(isDarkMode)
-    }
-
-    /**
-     * 切换到指定配色，切换成功后写入 AppPrefs
-     * @param colorSchemeId 配色 id
-     * */
-    fun setColorScheme(colorSchemeId: String) {
-        if (!presetColorSchemes!!.containsKey(colorSchemeId)) {
-            Timber.w("Color scheme %s not found", colorSchemeId)
-            return
-        }
-        if (currentColorSchemeId == colorSchemeId && currentColors.isNotEmpty()) return
-        Timber.d("switch color scheme from %s to %s", currentColorSchemeId, colorSchemeId)
-        currentColorSchemeId = colorSchemeId
-        refreshColorValues()
-        if (isDarkMode) {
-            lastDarkColorSchemeId = colorSchemeId
-        } else {
-            lastLightColorSchemeId = colorSchemeId
-        }
-        AppPrefs.defaultInstance().theme.selectedColor = colorSchemeId
-    }
-
-    /**
-     * 切换深色/亮色模式
-     * */
-    fun switchDarkMode(isDarkMode: Boolean) {
-        this.isDarkMode = isDarkMode
-        val newId = getColorSchemeId()
-        if (newId != null) setColorScheme(newId)
-        Timber.d(
-            "System changing color, current ColorScheme: $currentColorSchemeId, isDarkMode=$isDarkMode",
-        )
-    }
-
-    /**
-     * @return 切换深色/亮色模式后配色的 id
-     */
-    private fun getColorSchemeId(): String? {
-        val colorMap = presetColorSchemes!![currentColorSchemeId] as Map<String, Any>
-        if (isDarkMode) {
-            if (colorMap.containsKey("dark_scheme")) {
-                return colorMap["dark_scheme"] as String?
-            }
-            if (lastDarkColorSchemeId != null) {
-                return lastDarkColorSchemeId
-            }
-        } else {
-            if (colorMap.containsKey("light_scheme")) {
-                return colorMap["light_scheme"] as String?
-            }
-            if (lastLightColorSchemeId != null) {
-                return lastLightColorSchemeId
-            }
-        }
-        return currentColorSchemeId
-    }
-
-    private fun joinToFullImagePath(value: String): String {
-        val defaultPath = File(userDataDir, "backgrounds/${style.getString("background_folder")}/$value")
-        if (!defaultPath.exists()) {
-            val fallbackPath = File(userDataDir, "backgrounds/$value")
-            if (fallbackPath.exists()) return fallbackPath.path
-        }
-        return defaultPath.path
-    }
-
-    fun getPresetColorSchemes(): List<Pair<String, String>> {
-        return if (presetColorSchemes == null) {
-            arrayListOf()
-        } else {
-            presetColorSchemes!!.map { (key, value) ->
-                Pair(key, value!!["name"] as String)
-            }
-        }
-    }
-
-    private fun refreshColorValues() {
-        currentColors.clear()
-        val colorMap = presetColorSchemes!![currentColorSchemeId]
-        if (colorMap == null) {
-            Timber.w("Color scheme id not found: %s", currentColorSchemeId)
-            return
-        }
-
-        for ((key, value) in colorMap) {
-            if (key == "name" || key == "author" || key == "light_scheme" || key == "dark_scheme") continue
-            currentColors[key] = value
-        }
-        for ((key, value) in fallbackColors!!) {
-            if (!currentColors.containsKey(key)) {
-                currentColors[key] = value
-            }
-        }
-
-        // 先遍历一次，处理一下颜色和图片
-        // 防止回退时获取到错误值
-        for ((key, value) in currentColors) {
-            val parsedValue = parseColorValue(value)
-            if (parsedValue != null) {
-                currentColors[key] = parsedValue
-            }
-        }
-
-        // fallback
-        for ((key, value) in currentColors) {
-            if (value is Int || value is Drawable) continue
-            val parsedValue = getColorValue(value)
-            if (parsedValue != null) {
-                currentColors[key] = parsedValue
-            } else {
-                Timber.w("Cannot parse color key: %s, value: %s", key, value)
-            }
-        }
-        Timber.d("Refresh color scheme, current color scheme: $currentColorSchemeId")
-    }
-
-    /** 获取参数的真实value，如果是色彩返回int，如果是背景图返回drawable，都不是则进行 fallback
-     * @return Int/Drawable/null
-     * */
-    private fun getColorValue(value: Any?): Any? {
-        val parsedValue = parseColorValue(value)
-        if (parsedValue != null) {
-            return parsedValue
-        }
-        var newKey = value
-        var newValue: Any?
-        val limit = currentColors.size
-        for (i in 0 until limit) {
-            newValue = currentColors[newKey]
-            if (newValue !is String) return newValue
-            // fallback
-            val parsedNewValue = parseColorValue(newValue)
-            if (parsedNewValue != null) {
-                return parsedNewValue
-            }
-            newKey = newValue
-        }
-        return null
-    }
-
-    /** 获取参数的真实value，如果是色彩返回int，如果是背景图返回drawable，如果处理失败返回null
-     * @return Int/Drawable/null
-     * */
-    private fun parseColorValue(value: Any?): Any? {
-        if (value !is String) return null
-        if (isFileString(value)) {
-            // 获取图片的真实地址
-            val fullPath = joinToFullImagePath(value)
-            if (File(fullPath).exists()) {
-                return bitmapDrawable(fullPath)
-            }
-        }
-        // 只对不包含下划线的字符串进行颜色解析
-        if (!value.contains("_")) {
-            return ColorUtils.parseColor(value)
-        }
-        return null
     }
 }

--- a/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
@@ -62,6 +62,7 @@ object ThemeManager {
             _activeTheme = value
             fireChange()
             FontManager.reload()
+            EventManager.clearCache()
         }
 
     private var isNightMode = false

--- a/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
@@ -1,11 +1,9 @@
 package com.osfans.trime.data.theme
 
-import android.content.res.Configuration
 import androidx.annotation.Keep
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.DataManager
-import com.osfans.trime.util.WeakHashSet
-import com.osfans.trime.util.isNightMode
+import com.osfans.trime.ime.symbol.TabManager
 import java.io.File
 
 object ThemeManager {
@@ -37,7 +35,6 @@ object ThemeManager {
 
     private val userThemes: MutableList<String> = listThemes(DataManager.userDataDir)
 
-    @JvmStatic
     fun getAllThemes(): List<String> {
         if (DataManager.sharedDataDir.absolutePath == DataManager.userDataDir.absolutePath) {
             return userThemes
@@ -52,68 +49,26 @@ object ThemeManager {
         userThemes.addAll(listThemes(DataManager.userDataDir))
     }
 
-    private lateinit var _activeTheme: Theme
-
-    @JvmStatic
-    var activeTheme: Theme
-        get() = _activeTheme
-        private set(value) {
-            if (_activeTheme == value) return
-            _activeTheme = value
-            fireChange()
-            FontManager.reload()
-            EventManager.clearCache()
-        }
-
-    private var isNightMode = false
-
-    private val onChangeListeners = WeakHashSet<OnThemeChangeListener>()
-
-    @JvmStatic
-    fun addOnChangedListener(listener: OnThemeChangeListener) {
-        onChangeListeners.add(listener)
-    }
-
-    @JvmStatic
-    fun removeOnChangedListener(listener: OnThemeChangeListener) {
-        onChangeListeners.remove(listener)
-    }
-
-    private fun fireChange() {
-        onChangeListeners.forEach { it.onThemeChange(_activeTheme) }
-    }
-
     val prefs = AppPrefs.defaultInstance().theme
 
-    fun setNormalTheme(name: String) {
-        AppPrefs.defaultInstance().theme.selectedTheme = name
-        activeTheme = evalActiveTheme()
-    }
+    // 在初始化 ColorManager 时会被赋值
+    lateinit var activeTheme: Theme
+        private set
 
-    fun setColorScheme(name: String) {
-        _activeTheme.setColorScheme(name)
-        fireChange()
-    }
+    fun init() = setNormalTheme()
 
-    private fun evalActiveTheme(): Theme {
-        return if (prefs.autoDark) {
-            Theme(isNightMode)
-        } else {
-            Theme(false)
+    fun setNormalTheme(name: String = "") {
+        if (name.isNotEmpty()) prefs.selectedTheme = name
+        Theme().let {
+            if (::activeTheme.isInitialized) {
+                if (it == activeTheme) return
+            }
+            activeTheme = it
+            // 由于这里的顺序不能打乱，不适合使用 listener
+            EventManager.refresh()
+            FontManager.refresh()
+            ColorManager.refresh()
+            TabManager.refresh()
         }
-    }
-
-    @JvmStatic
-    fun init(configuration: Configuration) {
-        isNightMode = configuration.isNightMode()
-        _activeTheme = evalActiveTheme()
-    }
-
-    @JvmStatic
-    fun onSystemNightModeChange(isNight: Boolean) {
-        if (isNightMode == isNight) return
-        isNightMode = isNight
-        _activeTheme.switchDarkMode(isNightMode)
-        fireChange()
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.ViewAnimator
 import com.osfans.trime.core.Rime
-import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.databinding.CandidateBarBinding
 import com.osfans.trime.databinding.TabBarBinding
 import com.osfans.trime.ime.core.Trime
@@ -20,7 +20,6 @@ import splitties.views.dsl.core.matchParent
 class QuickBar : KoinComponent {
     private val context: Context by inject()
     private val service: Trime by inject()
-    private val theme: Theme by inject()
 
     val oldCandidateBar by lazy {
         CandidateBarBinding.inflate(LayoutInflater.from(context)).apply {
@@ -58,7 +57,7 @@ class QuickBar : KoinComponent {
     val view by lazy {
         ViewAnimator(context).apply {
             background =
-                theme.colors.getDrawable(
+                ColorManager.getDrawable(
                     "candidate_background",
                     "candidate_border",
                     "candidate_border_color",

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -19,7 +19,9 @@ import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
 import com.osfans.trime.core.Rime
 import com.osfans.trime.core.RimeNotification
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.bar.QuickBar
 import com.osfans.trime.ime.keyboard.KeyboardWindow
 import com.osfans.trime.ime.symbol.LiquidKeyboard
@@ -60,8 +62,8 @@ import splitties.views.imageDrawable
 class InputView(
     val service: Trime,
     val rime: Rime,
-    val theme: Theme,
 ) : ConstraintLayout(service), KoinComponent {
+    private val theme get() = ThemeManager.activeTheme
     private var shouldUpdateNavbarForeground = false
     private var shouldUpdateNavbarBackground = false
 
@@ -178,8 +180,8 @@ class InputView(
 
         liquidKeyboard.setKeyboardView(keyboardWindow.oldSymbolInputView.liquidKeyboardView)
 
-        keyboardBackground.imageDrawable = theme.colors.getDrawable("keyboard_background")
-            ?: theme.colors.getDrawable("keyboard_back_color")
+        keyboardBackground.imageDrawable = ColorManager.getDrawable("keyboard_background")
+            ?: ColorManager.getDrawable("keyboard_back_color")
 
         keyboardView =
             constraintLayout {
@@ -283,7 +285,7 @@ class InputView(
         if (!restarting) {
             if (shouldUpdateNavbarForeground || shouldUpdateNavbarBackground) {
                 service.window.window!!.also {
-                    val backColor = theme.colors.getColor("back_color") ?: Color.BLACK
+                    val backColor = ColorManager.getColor("back_color") ?: Color.BLACK
                     if (shouldUpdateNavbarForeground) {
                         WindowCompat.getInsetsController(it, it.decorView)
                             .isAppearanceLightNavigationBars = ColorUtils.isContrastedDark(backColor)

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.kt
@@ -314,10 +314,8 @@ open class Trime : LifecycleInputMethodService() {
         loadConfig()
         KeyboardSwitcher.newOrReset()
         if (textInputManager != null) {
-            // setNavBarColor();
             textInputManager!!.shouldUpdateRimeOption = true // 不能在Rime.onMessage中調用set_option，會卡死
             bindKeyboardToInputView()
-            // loadBackground(); // reset()调用过resetCandidate()，resetCandidate()一键调用过loadBackground();
             updateComposing() // 切換主題時刷新候選
         }
         setInputView(inputView!!)
@@ -554,10 +552,12 @@ open class Trime : LifecycleInputMethodService() {
     }
 
     fun bindKeyboardToInputView() {
-        if (mainKeyboardView != null) {
+        if (mainKeyboardView == null) return
+        KeyboardSwitcher.currentKeyboard.let {
             // Bind the selected keyboard to the input view.
-            val sk = KeyboardSwitcher.currentKeyboard
-            mainKeyboardView!!.keyboard = sk
+            if (it != mainKeyboardView!!.keyboard) {
+                mainKeyboardView!!.keyboard = it
+            }
             dispatchCapsStateToInputView()
         }
     }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.kt
@@ -21,6 +21,7 @@ import android.view.KeyEvent
 import com.osfans.trime.core.Rime
 import com.osfans.trime.core.RimeKeyMapping
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.enums.Keycode
 import com.osfans.trime.util.CollectionUtils.obtainBoolean
 import com.osfans.trime.util.CollectionUtils.obtainString
@@ -163,10 +164,10 @@ class Event(var s: String) {
             if (parseAction(label)) return
             s = label
         }
+        val theme = ThemeManager.activeTheme
         // 预设按键，如 Return BackSpace
-        if (Key.presetKeys!!.containsKey(s)) {
-            // todo 把presetKeys缓存为presetKeyEvents，减少重新载入
-            val presetKey = Key.presetKeys!![s]
+        if (theme.presetKeys!!.containsKey(s)) {
+            val presetKey = theme.presetKeys!![s]
             command = obtainString(presetKey, "command", "")
             option = obtainString(presetKey, "option", "")
             select = obtainString(presetKey, "select", "")

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.kt
@@ -26,8 +26,8 @@ import com.osfans.trime.core.Rime.Companion.hasMenu
 import com.osfans.trime.core.Rime.Companion.isAsciiMode
 import com.osfans.trime.core.Rime.Companion.isComposing
 import com.osfans.trime.core.Rime.Companion.showAsciiPunch
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.EventManager
-import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.enums.KeyEventType
 import com.osfans.trime.util.CollectionUtils.obtainBoolean
 import com.osfans.trime.util.CollectionUtils.obtainFloat
@@ -67,14 +67,13 @@ class Key(private val mKeyboard: Keyboard) {
     var hint: String? = null
         private set
     private lateinit var keyConfig: Map<String, Any?>
-    private val theme get() = ThemeManager.activeTheme
-    private val key_back_color get() = theme.colors.getDrawable(keyConfig, "key_back_color")
-    private val hilited_key_back_color get() = theme.colors.getDrawable(keyConfig, "hilited_key_back_color")
+    private val key_back_color get() = ColorManager.getDrawable(keyConfig, "key_back_color")
+    private val hilited_key_back_color get() = ColorManager.getDrawable(keyConfig, "hilited_key_back_color")
 
-    private val key_text_color get() = theme.colors.getColor(keyConfig, "key_text_color")
-    private val key_symbol_color get() = theme.colors.getColor(keyConfig, "key_symbol_color")
-    private val hilited_key_text_color get() = theme.colors.getColor(keyConfig, "hilited_key_text_color")
-    private val hilited_key_symbol_color get() = theme.colors.getColor(keyConfig, "hilited_key_symbol_color")
+    private val key_text_color get() = ColorManager.getColor(keyConfig, "key_text_color")
+    private val key_symbol_color get() = ColorManager.getColor(keyConfig, "key_symbol_color")
+    private val hilited_key_text_color get() = ColorManager.getColor(keyConfig, "hilited_key_text_color")
+    private val hilited_key_symbol_color get() = ColorManager.getColor(keyConfig, "hilited_key_symbol_color")
 
     var key_text_size: Int? = null
         private set
@@ -512,8 +511,6 @@ class Key(private val mKeyboard: Keyboard) {
                 KEY_STATE_NORMAL, // 5         "key_back_color"              按键背景
             )
 
-        @JvmField
-        var presetKeys: Map<String, Map<String, Any?>?>? = null
         private val EVENT_NUM = KeyEventType.entries.size
 
         @JvmField

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Key.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Key.kt
@@ -26,6 +26,7 @@ import com.osfans.trime.core.Rime.Companion.hasMenu
 import com.osfans.trime.core.Rime.Companion.isAsciiMode
 import com.osfans.trime.core.Rime.Companion.isComposing
 import com.osfans.trime.core.Rime.Companion.showAsciiPunch
+import com.osfans.trime.data.theme.EventManager
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.enums.KeyEventType
 import com.osfans.trime.util.CollectionUtils.obtainBoolean
@@ -65,13 +66,16 @@ class Key(private val mKeyboard: Keyboard) {
     private var label: String? = null
     var hint: String? = null
         private set
-    private var key_back_color: Drawable? = null
-    private var hilited_key_back_color: Drawable? = null
+    private lateinit var keyConfig: Map<String, Any?>
+    private val theme get() = ThemeManager.activeTheme
+    private val key_back_color get() = theme.colors.getDrawable(keyConfig, "key_back_color")
+    private val hilited_key_back_color get() = theme.colors.getDrawable(keyConfig, "hilited_key_back_color")
 
-    private var key_text_color: Int? = null
-    private var key_symbol_color: Int? = null
-    private var hilited_key_text_color: Int? = null
-    private var hilited_key_symbol_color: Int? = null
+    private val key_text_color get() = theme.colors.getColor(keyConfig, "key_text_color")
+    private val key_symbol_color get() = theme.colors.getColor(keyConfig, "key_symbol_color")
+    private val hilited_key_text_color get() = theme.colors.getColor(keyConfig, "hilited_key_text_color")
+    private val hilited_key_symbol_color get() = theme.colors.getColor(keyConfig, "hilited_key_symbol_color")
+
     var key_text_size: Int? = null
         private set
     var symbol_text_size: Int? = null
@@ -118,17 +122,17 @@ class Key(private val mKeyboard: Keyboard) {
      */
     constructor(parent: Keyboard, mk: Map<String, Any?>) : this(parent) {
         var s: String
-        val theme = ThemeManager.activeTheme
         run {
+            keyConfig = mk
             var hasComposingKey = false
             for (type in KeyEventType.entries) {
                 val typeStr = type.toString().lowercase()
                 s = obtainString(mk, typeStr, "")
                 if (s.isNotEmpty()) {
-                    events[type.ordinal] = Event(s)
+                    events[type.ordinal] = EventManager.getEvent(s)
                     if (type.ordinal < KeyEventType.COMBO.ordinal) hasComposingKey = true
                 } else if (type == KeyEventType.CLICK) {
-                    events[type.ordinal] = Event("")
+                    events[type.ordinal] = EventManager.getEvent("")
                 }
             }
             if (hasComposingKey) mKeyboard.composingKeys.add(this)
@@ -144,12 +148,6 @@ class Key(private val mKeyboard: Keyboard) {
         mKeyboard.setModiferKey(this.code, this)
         key_text_size = sp2px(obtainFloat(mk, "key_text_size", 0f)).toInt()
         symbol_text_size = sp2px(obtainFloat(mk, "symbol_text_size", 0f)).toInt()
-        key_text_color = theme.colors.getColor(mk, "key_text_color")
-        hilited_key_text_color = theme.colors.getColor(mk, "hilited_key_text_color")
-        key_back_color = theme.colors.getDrawable(mk, "key_back_color")
-        hilited_key_back_color = theme.colors.getDrawable(mk, "hilited_key_back_color")
-        key_symbol_color = theme.colors.getColor(mk, "key_symbol_color")
-        hilited_key_symbol_color = theme.colors.getColor(mk, "hilited_key_symbol_color")
         round_corner = obtainFloat(mk, "round_corner", 0f)
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -21,6 +21,7 @@ import android.content.res.Configuration
 import android.view.KeyEvent
 import com.blankj.utilcode.util.ScreenUtils
 import com.osfans.trime.data.AppPrefs.Companion.defaultInstance
+import com.osfans.trime.data.theme.EventManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.util.CollectionUtils.obtainBoolean
@@ -139,7 +140,7 @@ class Keyboard() {
             key.width = keyWidth
             key.height = keyHeight
             key.gap = horizontalGap
-            key.events[0] = Event(element.toString())
+            key.events[0] = EventManager.getEvent(element.toString())
             column++
             x += key.width + key.gap
             mKeys.add(key)

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSwitcher.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSwitcher.kt
@@ -47,7 +47,7 @@ object KeyboardSwitcher {
         val currentIdx = theme.allKeyboardIds.indexOf(currentKeyboardId)
         var mappedName =
             when (name) {
-                ".default" -> autoMatch(name)
+                ".default" -> autoMatch()
                 ".prior" ->
                     try {
                         theme.allKeyboardIds[currentIdx - 1]
@@ -108,7 +108,7 @@ object KeyboardSwitcher {
     /**
      * .default 自动匹配键盘布局
      * */
-    private fun autoMatch(name: String): String {
+    private fun autoMatch(): String {
         // 主题的布局中包含方案id，直接采用
         val currentSchemaId = Rime.getCurrentRimeSchema()
         if (currentSchemaId in allKeyboardIds) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.kt
@@ -43,6 +43,7 @@ import android.widget.TextView
 import com.osfans.trime.R
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.AppPrefs.Companion.defaultInstance
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.data.theme.ThemeManager
@@ -336,9 +337,9 @@ class KeyboardView(context: Context?, attrs: AttributeSet?) : View(context, attr
 
     fun reset() {
         val theme = ThemeManager.activeTheme
-        key_symbol_color = theme.colors.getColor("key_symbol_color")!!
-        hilited_key_symbol_color = theme.colors.getColor("hilited_key_symbol_color")!!
-        mShadowColor = theme.colors.getColor("shadow_color")!!
+        key_symbol_color = ColorManager.getColor("key_symbol_color")!!
+        hilited_key_symbol_color = ColorManager.getColor("hilited_key_symbol_color")!!
+        mShadowColor = ColorManager.getColor("shadow_color")!!
         mSymbolSize = sp2px(theme.style.getFloat("symbol_text_size")).toInt()
         mKeyTextSize = sp2px(theme.style.getFloat("key_text_size")).toInt()
         mVerticalCorrection = dp2px(theme.style.getFloat("vertical_correction")).toInt()
@@ -351,27 +352,27 @@ class KeyboardView(context: Context?, attrs: AttributeSet?) : View(context, attr
         mShadowRadius = theme.style.getFloat("shadow_radius")
         val mRoundCorner = theme.style.getFloat("round_corner")
         mKeyBackColor = StateListDrawable()
-        mKeyBackColor!!.addState(Key.KEY_STATE_ON_PRESSED, theme.colors.getDrawable("hilited_on_key_back_color"))
-        mKeyBackColor!!.addState(Key.KEY_STATE_ON_NORMAL, theme.colors.getDrawable("on_key_back_color"))
-        mKeyBackColor!!.addState(Key.KEY_STATE_OFF_PRESSED, theme.colors.getDrawable("hilited_off_key_back_color"))
-        mKeyBackColor!!.addState(Key.KEY_STATE_OFF_NORMAL, theme.colors.getDrawable("off_key_back_color"))
-        mKeyBackColor!!.addState(Key.KEY_STATE_PRESSED, theme.colors.getDrawable("hilited_key_back_color"))
-        mKeyBackColor!!.addState(Key.KEY_STATE_NORMAL, theme.colors.getDrawable("key_back_color"))
+        mKeyBackColor!!.addState(Key.KEY_STATE_ON_PRESSED, ColorManager.getDrawable("hilited_on_key_back_color"))
+        mKeyBackColor!!.addState(Key.KEY_STATE_ON_NORMAL, ColorManager.getDrawable("on_key_back_color"))
+        mKeyBackColor!!.addState(Key.KEY_STATE_OFF_PRESSED, ColorManager.getDrawable("hilited_off_key_back_color"))
+        mKeyBackColor!!.addState(Key.KEY_STATE_OFF_NORMAL, ColorManager.getDrawable("off_key_back_color"))
+        mKeyBackColor!!.addState(Key.KEY_STATE_PRESSED, ColorManager.getDrawable("hilited_key_back_color"))
+        mKeyBackColor!!.addState(Key.KEY_STATE_NORMAL, ColorManager.getDrawable("key_back_color"))
         mKeyTextColor =
             ColorStateList(
                 Key.KEY_STATES,
                 intArrayOf(
-                    theme.colors.getColor("hilited_on_key_text_color")!!,
-                    theme.colors.getColor("on_key_text_color")!!,
-                    theme.colors.getColor("hilited_off_key_text_color")!!,
-                    theme.colors.getColor("off_key_text_color")!!,
-                    theme.colors.getColor("hilited_key_text_color")!!,
-                    theme.colors.getColor("key_text_color")!!,
+                    ColorManager.getColor("hilited_on_key_text_color")!!,
+                    ColorManager.getColor("on_key_text_color")!!,
+                    ColorManager.getColor("hilited_off_key_text_color")!!,
+                    ColorManager.getColor("off_key_text_color")!!,
+                    ColorManager.getColor("hilited_key_text_color")!!,
+                    ColorManager.getColor("key_text_color")!!,
                 ),
             )
-        val color = theme.colors.getColor("preview_text_color")
+        val color = ColorManager.getColor("preview_text_color")
         if (color != null) mPreviewText.setTextColor(color)
-        val previewBackColor = theme.colors.getColor("preview_back_color")
+        val previewBackColor = ColorManager.getColor("preview_back_color")
         if (previewBackColor != null) {
             val background = GradientDrawable()
             background.setColor(previewBackColor)

--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.kt
@@ -11,6 +11,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView
 import com.osfans.trime.core.CandidateListItem
 import com.osfans.trime.core.Rime
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.databinding.LiquidEntryViewBinding
@@ -95,19 +96,19 @@ class CandidateAdapter(private val theme: Theme) : RecyclerView.Adapter<Candidat
             this.text = text
             textSize = theme.style.getFloat("candidate_text_size").coerceAtLeast(1f)
             typeface = FontManager.getTypeface("candidate_font")
-            theme.colors.getColor("candidate_text_color")?.let { setTextColor(it) }
+            ColorManager.getColor("candidate_text_color")?.let { setTextColor(it) }
         }
         holder.comment.apply {
             this.text = comment
             textSize = theme.style.getFloat("comment_text_size").coerceAtLeast(1f)
             typeface = FontManager.getTypeface("comment_font")
-            theme.colors.getColor("comment_text_color")?.let { setTextColor(it) }
+            ColorManager.getColor("comment_text_color")?.let { setTextColor(it) }
         }
 
         //  点击前后必须使用相同类型的背景，或者全部为背景图，或者都为背景色
         // 如果直接使用background，会造成滚动时部分内容的背景填充错误的问题
         holder.itemView.background =
-            theme.colors.getDrawable(
+            ColorManager.getDrawable(
                 "key_back_color",
                 "key_border",
                 "key_border_color",
@@ -120,7 +121,7 @@ class CandidateAdapter(private val theme: Theme) : RecyclerView.Adapter<Candidat
 
         // 点击时产生背景变色效果
         holder.itemView.setOnTouchListener { _, motionEvent: MotionEvent ->
-            val hilited = theme.colors.getColor("hilited_candidate_text_color")
+            val hilited = ColorManager.getColor("hilited_candidate_text_color")
             if (motionEvent.action == MotionEvent.ACTION_DOWN) {
                 hilited?.let { holder.candidate.setTextColor(it) }
             }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/FlexibleAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/FlexibleAdapter.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.osfans.trime.R
 import com.osfans.trime.data.db.CollectionHelper
 import com.osfans.trime.data.db.DatabaseBean
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.databinding.SimpleKeyItemBinding
@@ -79,8 +80,8 @@ class FlexibleAdapter(
                 text = bean.text
                 typeface = FontManager.getTypeface("long_text_font")
                 (
-                    theme.colors.getColor("long_text_color")
-                        ?: theme.colors.getColor("key_text_color")
+                    ColorManager.getColor("long_text_color")
+                        ?: ColorManager.getColor("key_text_color")
                 )
                     ?.let { setTextColor(it) }
 
@@ -91,7 +92,7 @@ class FlexibleAdapter(
             simpleKeyPin.visibility = if (bean.pinned) View.VISIBLE else View.INVISIBLE
 
             itemView.background =
-                theme.colors.getDrawable(
+                ColorManager.getDrawable(
                     "long_text_back_color",
                     "key_border",
                     "key_long_text_border",

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -72,10 +72,6 @@ class LiquidKeyboard : KoinComponent, ClipboardHelper.OnClipboardUpdateListener 
         CandidateAdapter(theme)
     }
 
-    init {
-        TabManager.init(theme)
-    }
-
     fun setKeyboardView(view: RecyclerView) {
         keyboardView =
             view.apply {

--- a/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.databinding.SimpleItemOneBinding
@@ -55,12 +56,12 @@ class SimpleAdapter(private val theme: Theme, private val columnSize: Int) : Rec
             holder.wrappers[i].tag = i
             textView.apply {
                 theme.style.getFloat("label_text_size").takeIf { it > 0f }?.let { textSize = it }
-                theme.colors.getColor("key_text_color")?.let { setTextColor(it) }
+                ColorManager.getColor("key_text_color")?.let { setTextColor(it) }
                 typeface = FontManager.getTypeface("key_font")
                 gravity = Gravity.CENTER
                 ellipsize = TextUtils.TruncateAt.MARQUEE
                 background =
-                    theme.colors.getDrawable(
+                    ColorManager.getDrawable(
                         "key_back_color",
                         "key_border",
                         "key_border_color",

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.kt
@@ -1,7 +1,7 @@
 package com.osfans.trime.ime.symbol
 
 import com.osfans.trime.data.schema.SchemaManager
-import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.enums.KeyCommandType
 import com.osfans.trime.ime.enums.SymbolKeyboardType
 import com.osfans.trime.util.CollectionUtils.getOrDefault
@@ -12,6 +12,7 @@ object TabManager {
         private set
     private var tabSwitchPosition = 0
 
+    val theme get() = ThemeManager.activeTheme
     val tabTags = arrayListOf<TabTag>()
     val tabSwitchData = mutableListOf<SimpleKeyBean>()
     private val keyboards = mutableListOf<List<SimpleKeyBean>>()
@@ -38,7 +39,7 @@ object TabManager {
         return i
     }
 
-    fun init(theme: Theme) {
+    fun refresh() {
         val available = theme.liquid.getObject("keyboards") as List<String>? ?: return
         for (id in available) {
             Timber.d("preparing data for tab #$id")

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabView.kt
@@ -27,6 +27,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.core.view.updateLayoutParams
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.core.Trime
@@ -60,13 +61,13 @@ class TabView(context: Context?, attrs: AttributeSet?) : View(context, attrs) {
     // private final Rect[] tabGeometries = new Rect[MAX_CANDIDATE_COUNT + 2];
     fun reset() {
         val theme = ThemeManager.activeTheme
-        candidateHighlight = PaintDrawable(theme.colors.getColor("hilited_candidate_back_color")!!)
+        candidateHighlight = PaintDrawable(ColorManager.getColor("hilited_candidate_back_color")!!)
         candidateHighlight!!.setCornerRadius(theme.style.getFloat("layout/round_corner"))
-        separatorPaint.color = theme.colors.getColor("candidate_separator_color")!!
+        separatorPaint.color = ColorManager.getColor("candidate_separator_color")!!
         candidateSpacing = dp2px(theme.style.getFloat("candidate_spacing")).toInt()
         candidatePadding = dp2px(theme.style.getFloat("candidate_padding")).toInt()
-        candidateTextColor = theme.colors.getColor("candidate_text_color")!!
-        hilitedCandidateTextColor = theme.colors.getColor("hilited_candidate_text_color")!!
+        candidateTextColor = ColorManager.getColor("candidate_text_color")!!
+        hilitedCandidateTextColor = ColorManager.getColor("hilited_candidate_text_color")!!
         commentHeight = dp2px(theme.style.getFloat("comment_height")).toInt()
         candidateViewHeight = dp2px(theme.style.getFloat("candidate_view_height")).toInt()
         candidateFont = FontManager.getTypeface("candidate_font")

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
@@ -29,6 +29,7 @@ import android.view.View
 import com.osfans.trime.core.CandidateListItem
 import com.osfans.trime.core.Rime
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.core.Trime
@@ -62,12 +63,12 @@ class Candidate(context: Context?, attrs: AttributeSet?) : View(context, attrs) 
     private var timeDown: Long = 0
     private var timeMove: Long = 0
     private val candidateHighlight =
-        PaintDrawable(theme.colors.getColor("hilited_candidate_back_color")!!).apply {
+        PaintDrawable(ColorManager.getColor("hilited_candidate_back_color")!!).apply {
             setCornerRadius(theme.style.getFloat("layout/round_corner"))
         }
     private val separatorPaint =
         Paint().apply {
-            color = theme.colors.getColor("candidate_separator_color")!!
+            color = ColorManager.getColor("candidate_separator_color")!!
         }
     private val candidatePaint =
         Paint().apply {
@@ -93,10 +94,10 @@ class Candidate(context: Context?, attrs: AttributeSet?) : View(context, attrs) 
     private val candidateFont = FontManager.getTypeface("candidate_font")
     private val symbolFont = FontManager.getTypeface("symbol_font")
     private val commentFont = FontManager.getTypeface("comment_font")
-    private val candidateTextColor = theme.colors.getColor("candidate_text_color")!!
-    private val hilitedCandidateTextColor = theme.colors.getColor("hilited_candidate_text_color")!!
-    private val commentTextColor = theme.colors.getColor("comment_text_color")!!
-    private val hilitedCommentTextColor = theme.colors.getColor("hilited_comment_text_color")!!
+    private val candidateTextColor = ColorManager.getColor("candidate_text_color")!!
+    private val hilitedCandidateTextColor = ColorManager.getColor("hilited_candidate_text_color")!!
+    private val commentTextColor = ColorManager.getColor("comment_text_color")!!
+    private val hilitedCommentTextColor = ColorManager.getColor("hilited_comment_text_color")!!
     private val candidateViewHeight = dp(theme.style.getInt("candidate_view_height"))
     private val commentHeight = dp(theme.style.getInt("comment_height"))
     private val candidateSpacing = dp(theme.style.getFloat("candidate_spacing")).toInt()

--- a/app/src/main/java/com/osfans/trime/ime/text/Composition.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/Composition.kt
@@ -36,6 +36,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.TextView
 import com.osfans.trime.core.Rime
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.EventManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.ThemeManager
@@ -54,7 +55,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
     private val textInputManager = TextInputManager.getInstance()
 
     private val keyTextSize = theme.style.getInt("key_text_size")
-    private val keyTextColor = theme.colors.getColor("key_text_color")!!
+    private val keyTextColor = ColorManager.getColor("key_text_color")!!
     private val candidateUseCursor = theme.style.getBoolean("candidate_use_cursor")
     private val movable = Movable.fromString(theme.style.getString("layout/movable"))
     private val showComment = !Rime.getOption("_hide_comment")
@@ -117,8 +118,8 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
     private inner class CompositionSpan : UnderlineSpan() {
         override fun updateDrawState(ds: TextPaint) {
             ds.typeface = FontManager.getTypeface("text_font")
-            ds.color = theme.colors.getColor("text_color")!!
-            ds.bgColor = theme.colors.getColor("back_color")!!
+            ds.color = ColorManager.getColor("text_color")!!
+            ds.bgColor = ColorManager.getColor("back_color")!!
         }
     }
 
@@ -154,7 +155,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
         override fun updateDrawState(ds: TextPaint) {
             ds.isUnderlineText = false
             ds.color = keyTextColor
-            ds.bgColor = theme.colors.getColor("key_back_color")!!
+            ds.bgColor = ColorManager.getColor("key_back_color")!!
         }
     }
 
@@ -268,8 +269,8 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
             ?.let { ss?.setSpan(LetterSpacingSpan(it), start, end, 0) }
         start = compositionPos[0] + r.selStartPos
         end = compositionPos[0] + r.selEndPos
-        ss!!.setSpan(ForegroundColorSpan(theme.colors.getColor("hilited_text_color")!!), start, end, 0)
-        ss!!.setSpan(BackgroundColorSpan(theme.colors.getColor("hilited_back_color")!!), start, end, 0)
+        ss!!.setSpan(ForegroundColorSpan(ColorManager.getColor("hilited_text_color")!!), start, end, 0)
+        ss!!.setSpan(BackgroundColorSpan(ColorManager.getColor("hilited_back_color")!!), start, end, 0)
         sep = CollectionUtils.obtainString(m, "end", "")
         if (sep.isNotEmpty()) ss!!.append(sep)
     }
@@ -329,7 +330,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
         var i = -1
         candidateNum = 0
         val maxLength = theme.style.getInt("layout/max_length")
-        val hilitedCandidateBackColor = theme.colors.getColor("hilited_candidate_back_color")!!
+        val hilitedCandidateBackColor = ColorManager.getColor("hilited_candidate_back_color")!!
         for (o in candidates) {
             var cand = o.text
             i++
@@ -362,9 +363,9 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                     CandidateSpan(
                         i,
                         FontManager.getTypeface("label_font"),
-                        theme.colors.getColor("hilited_label_color")!!,
+                        ColorManager.getColor("hilited_label_color")!!,
                         hilitedCandidateBackColor,
-                        theme.colors.getColor("label_color")!!,
+                        ColorManager.getColor("label_color")!!,
                     ),
                     start,
                     end,
@@ -382,9 +383,9 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                 CandidateSpan(
                     i,
                     FontManager.getTypeface("candidate_font"),
-                    theme.colors.getColor("hilited_candidate_text_color")!!,
+                    ColorManager.getColor("hilited_candidate_text_color")!!,
                     hilitedCandidateBackColor,
-                    theme.colors.getColor("candidate_text_color")!!,
+                    ColorManager.getColor("candidate_text_color")!!,
                 ),
                 start,
                 end,
@@ -402,9 +403,9 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                     CandidateSpan(
                         i,
                         FontManager.getTypeface("comment_font"),
-                        theme.colors.getColor("hilited_comment_text_color")!!,
+                        ColorManager.getColor("hilited_comment_text_color")!!,
                         hilitedCandidateBackColor,
-                        theme.colors.getColor("comment_text_color")!!,
+                        ColorManager.getColor("comment_text_color")!!,
                     ),
                     start,
                     end,

--- a/app/src/main/java/com/osfans/trime/ime/text/Composition.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/Composition.kt
@@ -36,6 +36,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.TextView
 import com.osfans.trime.core.Rime
+import com.osfans.trime.data.theme.EventManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.core.Trime
@@ -425,7 +426,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
             if (`when`.contentEquals("paging") && !Rime.hasLeft()) return
             if (`when`.contentEquals("has_menu") && !Rime.hasMenu()) return
         }
-        val e = Event(CollectionUtils.obtainString(m, "click"))
+        val e = EventManager.getEvent(CollectionUtils.obtainString(m, "click"))
         val label =
             if (m.containsKey("label")) {
                 CollectionUtils.obtainString(m, "label", "")

--- a/app/src/main/java/com/osfans/trime/ime/text/CompositionPopupWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/CompositionPopupWindow.kt
@@ -15,6 +15,7 @@ import android.view.inputmethod.CursorAnchorInfo
 import android.widget.PopupWindow
 import com.blankj.utilcode.util.BarUtils
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.databinding.CompositionRootBinding
@@ -60,7 +61,7 @@ class CompositionPopupWindow(
                     WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG
             }
             setBackgroundDrawable(
-                theme.colors.getDrawable(
+                ColorManager.getDrawable(
                     "text_back_color",
                     "layout/border",
                     "border_color",

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -13,6 +13,7 @@ import com.osfans.trime.core.RimeNotification
 import com.osfans.trime.core.SchemaListItem
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.schema.SchemaManager
+import com.osfans.trime.data.theme.EventManager
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.broadcast.IntentReceiver
 import com.osfans.trime.ime.core.EditorInstance
@@ -244,7 +245,7 @@ class TextInputManager private constructor() :
                         } else if (option.startsWith("_key_") && option.length > 5 && value) {
                             shouldUpdateRimeOption = false // 防止在 handleRimeNotification 中 setOption
                             val key = option.substring(5)
-                            onEvent(Event(key))
+                            onEvent(EventManager.getEvent(key))
                             shouldUpdateRimeOption = true
                         }
                 }
@@ -465,11 +466,11 @@ class TextInputManager private constructor() :
                     }
                     propertyGroupMatcher.matches() -> {
                         target = propertyGroupMatcher.group(1) ?: ""
-                        onEvent(Event(target))
+                        onEvent(EventManager.getEvent(target))
                     }
                     else -> {
                         target = textToParse.substring(0, 1)
-                        onEvent(Event(target))
+                        onEvent(EventManager.getEvent(target))
                     }
                 }
                 textToParse = textToParse.substring(target.length)

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -220,7 +220,7 @@ class TextInputManager private constructor() :
             if (notification is RimeNotification.SchemaNotification) {
                 SchemaManager.init(notification.schemaId)
                 Rime.updateStatus()
-                trime.recreateInputView(ThemeManager.activeTheme)
+                trime.recreateInputView()
             } else if (notification is RimeNotification.OptionNotification) {
                 Rime.updateContext() // 切換中英文、簡繁體時更新候選
                 val value = notification.value

--- a/app/src/main/java/com/osfans/trime/ui/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/KeyboardFragment.kt
@@ -9,7 +9,6 @@ import com.osfans.trime.R
 import com.osfans.trime.core.Rime
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.DataManager
-import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.core.Trime
 import com.osfans.trime.ui.components.PaddingPreferenceFragment
 import com.osfans.trime.ui.main.MainViewModel
@@ -47,7 +46,7 @@ class KeyboardFragment :
             "keyboard__show_window",
             "keyboard__inline_preedit", "keyboard__soft_cursor",
             -> {
-                Trime.getServiceOrNull()?.recreateInputView(ThemeManager.activeTheme)
+                Trime.getServiceOrNull()?.recreateInputView()
             }
             "keyboard__candidate_page_size" -> {
                 val pageSize = AppPrefs.defaultInstance().keyboard.candidatePageSize.toInt()

--- a/app/src/main/java/com/osfans/trime/ui/main/Pickers.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/Pickers.kt
@@ -11,9 +11,9 @@ import com.osfans.trime.core.SchemaListItem
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.sound.SoundEffect
 import com.osfans.trime.data.sound.SoundEffectManager
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.core.RimeWrapper
-import com.osfans.trime.ime.symbol.TabManager
 import com.osfans.trime.ui.components.CoroutineChoiceDialog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -39,7 +39,6 @@ suspend fun Context.themePicker(
         onOKButton {
             with(items[checkedItem].toString()) {
                 ThemeManager.setNormalTheme(if (this == "trime") this else "$this.trime")
-                TabManager.init(ThemeManager.activeTheme)
             }
         }
     }.create()
@@ -51,17 +50,17 @@ suspend fun Context.colorPicker(
     return CoroutineChoiceDialog(this, themeResId).apply {
         title = getString(R.string.looks__selected_color_title)
         initDispatcher = Dispatchers.Default
-        val all by lazy { ThemeManager.activeTheme.getPresetColorSchemes() }
+        val all by lazy { ColorManager.getPresetColorSchemes() }
         onInit {
             items = all.map { it.second }.toTypedArray()
-            val current = ThemeManager.activeTheme.currentColorSchemeId
+            val current = ColorManager.selectedColor
             val schemeIds = all.map { it.first }
             checkedItem = schemeIds.indexOf(current).takeIf { it > -1 } ?: 1
         }
         postiveDispatcher = Dispatchers.Default
         onOKButton {
             val schemeIds = all.map { it.first }
-            ThemeManager.setColorScheme(schemeIds[checkedItem])
+            ColorManager.setColorScheme(schemeIds[checkedItem])
         }
     }.create()
 }


### PR DESCRIPTION
## Pull request

- [x] 缓存主题用到的 event
- [x] 使用 ColorManager 管理配色
- [x] 只在切换配色时切换音效包（之前是在 recreateInputView 时）
- [x] 内置一个默认的 fallback_colors，当主题中定义缺少时会被采用

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

