### PR TITLE
ci: use m1 macos 14 runner

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-13
+          - macos-14
           - windows-2022
     env:
       BUILD_ABI: armeabi-v7a,arm64-v8a,x86,x86_64

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install macOS utils
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install coreutils clang-format
+          brew update && brew install coreutils clang-format python
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install macOS utils
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install coreutils clang-format
+          brew update && brew install coreutils clang-format python
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-13
+          - macos-14
           - windows-2022
     env:
       BUILD_ABI: armeabi-v7a,arm64-v8a,x86,x86_64


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request
Use macos 14 runner: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

> The macOS 14 runner image is now available for GitHub hosted runners. Workflows executed on this image will run exclusively on the 3 vCPU M1 runner announced earlier today. To use the runner, simply update the runs-on: key in your YAML workflow file to macos-14, macos-14-xlarge, or macos-14-large.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [x] `make sytle-lint`

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

