### PR TITLE
fix: retain current scheme ID when changing day/night theme

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ColorManager.kt
@@ -122,19 +122,28 @@ object ColorManager {
     }
 
     /**
-     * 切换到指定配色，切换成功后写入 AppPrefs
+     * 切换到指定配色后，写入 AppPrefs
      * @param colorSchemeId 配色 id
      * */
     fun setColorScheme(colorSchemeId: String) {
+        switchColorScheme(colorSchemeId)
+        selectedColor = colorSchemeId
+        prefs.selectedColor = colorSchemeId
+    }
+
+    /**
+     * 切换到指定配色
+     * @param colorSchemeId 配色 id
+     * */
+    private fun switchColorScheme(colorSchemeId: String) {
         if (!presetColorSchemes.containsKey(colorSchemeId)) {
             Timber.w("Color scheme %s not found", colorSchemeId)
             return
         }
         Timber.d("switch color scheme from %s to %s", selectedColor, colorSchemeId)
-        selectedColor = colorSchemeId
         // 刷新配色
         val isFirst = currentColors.isEmpty()
-        refreshColorValues()
+        refreshColorValues(colorSchemeId)
         if (isNightMode) {
             lastDarkColorSchemeId = colorSchemeId
         } else {
@@ -148,7 +157,6 @@ object ColorManager {
                 Timber.d("Initialization finished")
             }
         }
-        prefs.selectedColor = colorSchemeId
         if (!isFirst) fireChange()
     }
 
@@ -156,7 +164,7 @@ object ColorManager {
     private fun switchNightMode(isNightMode: Boolean) {
         this.isNightMode = isNightMode
         val newId = getColorSchemeId()
-        if (newId != null) setColorScheme(newId)
+        if (newId != null) switchColorScheme(newId)
         Timber.d(
             "System changing color, current ColorScheme: $selectedColor, isDarkMode=$isNightMode",
         )
@@ -185,9 +193,9 @@ object ColorManager {
         return selectedColor
     }
 
-    private fun refreshColorValues() {
+    private fun refreshColorValues(colorSchemeId: String) {
         currentColors.clear()
-        val colorMap = presetColorSchemes[selectedColor]
+        val colorMap = presetColorSchemes[colorSchemeId]
         colorMap?.forEach { (key, value) ->
             when (key) {
                 "name", "author", "light_scheme", "dark_scheme", "sound" -> {}


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1071
Fixes #

#### Feature
Do not save dark/light schema ID when switching night theme in night mode.  So the theme will switch to light/night theme correctly when the system change light/night mode.

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

