### PR TITLE
Fix 1206 - Adjust InitializationUi

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/InitializationUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/InitializationUi.kt
@@ -31,7 +31,7 @@ import splitties.views.textResource
  * TODO: Add a help or info button to show what's problem is behind the scene.
  */
 class InitializationUi(override val ctx: Context) : Ui {
-    private val initial =
+    val initial =
         constraintLayout {
             backgroundColor = color(R.color.colorPrimaryDark)
             val textView =


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1206

#### Feature
Use `InitializationUi` to compute the inset before creating `keyboardView` 

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

