### PR TITLE
fix: set key width to 0 if `width` not set

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -257,7 +257,7 @@ class Keyboard() {
             var rowWidthWeight = 0f
             for (mk in lm) {
                 val gap = this.horizontalGap
-                val keyWidth = obtainFloat(mk, "width", keyboardKeyWidth)
+                val keyWidth = obtainFloat(mk, "width", 0f)
                 var widthPx = (keyWidth * oneWeightWidthPx).toInt()
                 if (widthPx == 0 && mk.containsKey("click")) widthPx = defaultWidth
                 widthPx -= gap


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1309

#### Feature
將鍵闊預設為 0

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [X] `make sytle-lint`

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

