### PR TITLE
fix: error key label in parseAction

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.kt
@@ -53,6 +53,7 @@ class Event(var s: String) {
     private fun parseAction(s: String): Boolean {
         var result = false
         val strs = s.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        var l = ""
         for (str in strs) {
             val set = str.split("=".toRegex(), limit = 2).toTypedArray()
             if (set.size != 2) continue
@@ -61,10 +62,18 @@ class Event(var s: String) {
                 result = true
             } else if (set[0] == "label") {
                 label = set[1]
+                l = label
                 result = true
             } else if (set[0] == "text") {
                 text = set[1]
                 result = true
+            }
+        }
+        if (l.isNullOrEmpty()) {
+            if (commit.isNotEmpty()) {
+                label = commit
+            } else if (text.isNotEmpty()) {
+                label = text
             }
         }
         Timber.d("<Event> text=$text, commit=$commit, label=$label, s=$s")

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Event.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Event.kt
@@ -50,34 +50,24 @@ class Event(var s: String) {
     var isSticky = false
 
     // 快速把字符串解析为event, 暂时只处理了comment类型 不能完全正确处理=，
-    private fun parseAction(s: String): Boolean {
-        var result = false
-        val strs = s.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        var l = ""
-        for (str in strs) {
-            val set = str.split("=".toRegex(), limit = 2).toTypedArray()
-            if (set.size != 2) continue
-            if (set[0] == "commit") {
-                commit = set[1]
-                result = true
-            } else if (set[0] == "label") {
-                label = set[1]
-                l = label
-                result = true
-            } else if (set[0] == "text") {
-                text = set[1]
-                result = true
+    private fun parseAction(raw: String): Boolean {
+        val pairs =
+            raw.split(',')
+                .filter { it.isNotBlank() }
+                .map { it.split('=', limit = 2) }
+                .associate { it.first() to (it.getOrNull(1) ?: "") }
+
+        val (commit, label, text) =
+            pairs.run {
+                arrayOf(get("commit") ?: "", get("label") ?: "", get("text") ?: "")
             }
-        }
-        if (l.isNullOrEmpty()) {
-            if (commit.isNotEmpty()) {
-                label = commit
-            } else if (text.isNotEmpty()) {
-                label = text
-            }
-        }
-        Timber.d("<Event> text=$text, commit=$commit, label=$label, s=$s")
-        return result
+
+        this.commit = commit
+        this.text = text
+        this.label = label.ifEmpty { commit }.ifEmpty { text }
+
+        Timber.d("parseAction: raw=$raw: text=$text, commit=$commit, label=$label")
+        return commit.isNotBlank() || text.isNotBlank() || label.isNotBlank()
     }
 
     private fun adjustCase(

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -201,7 +201,7 @@ class Keyboard() {
             keyboardConfig!!["keys"]!!.configList
                 .map {
                     it!!.configMap.entries.associate { (k, v) ->
-                        k to v!!.configValue.getString()
+                        k to v!!
                     }
                 }
         horizontalGap =
@@ -438,7 +438,7 @@ class Keyboard() {
                 Configuration.ORIENTATION_LANDSCAPE -> keyboardHeightLand.takeIf { it > 0 } ?: keyboardHeight
                 else -> keyboardHeight
             }
-        return appContext.dp(value).toInt()
+        return appContext.dp(value)
     }
 
     private fun getKeyboardHeightFromKeyboardConfig(keyboardConfig: Map<String, Any?>?): Int {

--- a/app/src/main/java/com/osfans/trime/util/CollectionUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/CollectionUtils.kt
@@ -1,7 +1,5 @@
 package com.osfans.trime.util
 
-import com.osfans.trime.util.config.ConfigValue
-
 object CollectionUtils {
     @JvmStatic
     fun <K, V> getOrDefault(
@@ -38,10 +36,7 @@ object CollectionUtils {
     ): String {
         if (map.isNullOrEmpty() || key.isEmpty()) return defValue
         val v = obtainValue(map, key)
-        return when (v) {
-            is ConfigValue? -> v?.getString()
-            else -> v?.toString()
-        } ?: defValue
+        return v?.toString() ?: defValue
     }
 
     @JvmStatic

--- a/app/src/main/java/com/osfans/trime/util/config/ConfigTypes.kt
+++ b/app/src/main/java/com/osfans/trime/util/config/ConfigTypes.kt
@@ -52,7 +52,7 @@ abstract class ConfigItem(val node: YamlNode) {
         item: ConfigItem,
         expectedType: String,
     ): Nothing {
-        throw IllegalArgumentException("Expected element to be $expectedType bus is ${item::class.simpleName}")
+        throw IllegalArgumentException("Expected element to be $expectedType but is ${item::class.simpleName}")
     }
 }
 
@@ -71,6 +71,8 @@ class ConfigValue(private val scalar: YamlScalar) : ConfigItem(scalar) {
     override fun isEmpty() = scalar.content.isEmpty()
 
     override fun contentToString(): String = scalar.contentToString()
+
+    override fun toString(): String = scalar.content
 }
 
 /** The wrapper of [YamlList] */
@@ -107,6 +109,9 @@ class ConfigList(private val list: YamlList) : ConfigItem(list), List<ConfigItem
     override fun indexOf(element: ConfigItem?): Int = items.indexOf(element)
 
     fun getValue(index: Int) = get(index)?.configValue
+
+    // just like other Java / Kotlin collection type
+    override fun toString(): String = items.joinToString(prefix = "[", postfix = "]")
 }
 
 class ConfigMap(private val map: YamlMap) : ConfigItem(map), Map<String, ConfigItem?> {
@@ -136,4 +141,7 @@ class ConfigMap(private val map: YamlMap) : ConfigItem(map), Map<String, ConfigI
     override operator fun get(key: String): ConfigItem? = entries.firstOrNull { it.key == key }?.value
 
     fun getValue(key: String): ConfigValue? = get(key)?.configValue
+
+    // just like other Java / Kotlin map type
+    override fun toString(): String = entries.joinToString(prefix = "{", postfix = "}") { (key, value) -> "$key=$value" }
 }


### PR DESCRIPTION
## Pull request
fix error key label (key popup preview) in parseAction(), just like this swipe up key preview
`      - {click: x, swipe_up:  {commit: '"'}, swipe_down:   {commit: "'"}, long_click: cut2, hint: "\"'"}`

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

