### PR TITLE
fix: calculate scaled vertical gap to fit all keyboard height

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -231,13 +231,8 @@ class Keyboard() {
         keyboardHeight = getKeyboardHeight(theme, keyboardConfig)
         val keyboardKeyWidth = obtainFloat(keyboardConfig, "width", 0f)
         val maxColumns = if (columns == -1) Int.MAX_VALUE else columns
-        var x = this.horizontalGap / 2
-        var y = this.verticalGap
-        var row = 0
-        var column = 0
-        minWidth = 0
         val isSplit = KeyboardPrefs().isLandscapeMode() && isLandscapeSplit
-        val (rowWidthTotalWeight, oneWeightWidthPx, multiplier, height1) =
+        val (rowWidthTotalWeight, oneWeightWidthPx, multiplier, scaledHeight, scaledVerticalGap) =
             KeyboardSizeCalculator(
                 name,
                 isSplit,
@@ -251,6 +246,12 @@ class Keyboard() {
                 verticalGap,
                 autoHeightIndex,
             ).calc(lm)
+
+        var x = this.horizontalGap / 2
+        var y = scaledVerticalGap
+        var row = 0
+        var column = 0
+        minWidth = 0
 
         try {
             var rowWidthWeight = 0f
@@ -266,7 +267,7 @@ class Keyboard() {
                     // new row
                     rowWidthWeight = 0f
                     x = gap / 2
-                    y += this.verticalGap + rowHeight
+                    y += scaledVerticalGap + rowHeight
                     column = 0
                     row++
                     if (mKeys.size > 0) mKeys[mKeys.size - 1].edgeFlags = mKeys[mKeys.size - 1].edgeFlags or EDGE_RIGHT
@@ -296,7 +297,7 @@ class Keyboard() {
                 if (column == 0) {
                     rowHeight =
                         if (keyboardHeight > 0) {
-                            height1[row]
+                            scaledHeight[row]
                         } else {
                             val heightK = appContext.sp(obtainFloat(mk, "height", 0f)).toInt()
                             if (heightK > 0) heightK else defaultHeight
@@ -418,7 +419,7 @@ class Keyboard() {
                 }
             }
             if (mKeys.size > 0) mKeys[mKeys.size - 1].edgeFlags = mKeys[mKeys.size - 1].edgeFlags or EDGE_RIGHT
-            this.height = y + rowHeight + this.verticalGap
+            this.height = y + rowHeight + scaledVerticalGap
             for (key in mKeys) {
                 if (key.column == 0) key.edgeFlags = key.edgeFlags or EDGE_LEFT
                 if (key.row == 0) key.edgeFlags = key.edgeFlags or EDGE_TOP

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSize.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardSize.kt
@@ -4,5 +4,6 @@ data class KeyboardSize(
     val rowWidthTotalWeight: Map<Int, Float>,
     val defaultWidth: Float,
     val multiplier: Float,
-    val height: List<Int>,
+    val scaledHeight: List<Int>,
+    val scaledVerticalGap: Int,
 )


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1250
Fixes #

#### Feature
Use the scaled vertical gap in arranging `Key` in `Keyboard`, so that the keyboard's height will remain the same for all keyboard.

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [ ] `make sytle-lint`
- [ ] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

