### PR TITLE
fix: Page Up/Down symbol text size

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
@@ -65,7 +65,7 @@ class Candidate(context: Context?, attrs: AttributeSet?) : View(context, attrs) 
     private val symbolPaint =
         Paint().apply {
             typeface = symbolFont
-            theme.generalStyle.symbolTextSize.toFloat().takeIf { it > 0 }?.let { textSize = sp(it) }
+            theme.generalStyle.candidateTextSize.toFloat().takeIf { it > 0 }?.let { textSize = sp(it) }
             isAntiAlias = true
             strokeWidth = 0f
         }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1343 
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

