### PR TITLE
feat: allow user to determine navigation bar background behavior

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -316,6 +316,7 @@ class AppPrefs(
             const val SELECTED_COLOR = "theme_selected_color"
             const val AUTO_DARK = "theme_auto_dark"
             const val USE_MINI_KEYBOARD = "theme_use_mini_keyboard"
+            const val NAVBAR_BACKGROUND = "navbar_background"
         }
 
         var selectedTheme: String
@@ -330,6 +331,16 @@ class AppPrefs(
         var useMiniKeyboard: Boolean = false
             get() = prefs.getPref(USE_MINI_KEYBOARD, false)
             private set
+
+        enum class NavbarBackground {
+            NONE,
+            COLOR_ONLY,
+            FULL,
+        }
+
+        var navbarBackground: NavbarBackground
+            get() = NavbarBackground.valueOf(prefs.getPref(NAVBAR_BACKGROUND, NavbarBackground.COLOR_ONLY.name))
+            set(value) = prefs.setPref(NAVBAR_BACKGROUND, value.name)
     }
 
     /**

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -277,4 +277,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="no_schema_to_enable">没有方案可启用。请确保您已在用户文件夹中放入了前置文件和方案文件。</string>
     <string name="schemata">方案</string>
     <string name="schemata_hint">选择当前方案或启用更多方案</string>
+    <string name="navbar_background">导航栏背景</string>
+    <string-array name="navbar_bkg_labels">
+        <item>无背景</item>
+        <item>跟随键盘背景色</item>
+        <item>键盘背景图片</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -278,4 +278,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="no_schema_to_enable">沒有方案可啟用。請確保您已在使用者資料夾中放入了前置檔案和方案檔案。</string>
     <string name="schemata">方案</string>
     <string name="schemata_hint">選擇當前方案或啓用更多方案</string>
+    <string name="navbar_background">導航欄背景</string>
+    <string-array name="navbar_bkg_labels">
+        <item>無背景</item>
+        <item>跟隨鍵盤背景色</item>
+        <item>鍵盤背景圖片</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -70,4 +70,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <item>50</item>
         <item>100</item>
     </string-array>
+    <string-array name="navbar_bkg_values">
+        <item>NONE</item>
+        <item>COLOR_ONLY</item>
+        <item>FULL</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -279,4 +279,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="no_schema_to_enable">No schema to enable. Make sure you have prelude and schema files in the user directory.</string>
     <string name="schemata">Schemata</string>
     <string name="schemata_hint">Select current schema or enable more schemata</string>
+    <string name="navbar_background">Navigation bar background</string>
+    <string-array name="navbar_bkg_labels">
+        <item>No background</item>
+        <item>Follow keyboard color</item>
+        <item>Keyboard background image</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/theme_color_preference.xml
+++ b/app/src/main/res/xml/theme_color_preference.xml
@@ -16,6 +16,13 @@ SPDX-License-Identifier: GPL-3.0-or-later
         app:iconSpaceReserved="false"
         android:title="@string/looks__selected_color_title"
         android:summary="@string/looks__selected_color_summary" />
+    <ListPreference android:key="navbar_background"
+        app:iconSpaceReserved="false"
+        android:title="@string/navbar_background"
+        android:defaultValue="COLOR_ONLY"
+        android:entryValues="@array/navbar_bkg_values"
+        android:entries="@array/navbar_bkg_labels"
+        app:useSimpleSummaryProvider="true"/>
     <SwitchPreferenceCompat android:key="theme_auto_dark"
         app:iconSpaceReserved="false"
         android:title="@string/keyboard__auto_dark_title"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1332 

#### Feature
Describe features of this pull request

For some reason, the keyboard may overlap with the navigation bar on some specific devices or ROMs. So just give users an option to determine the behavior.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

