### PR TITLE
fix: crash on showing toast in LogActivity on some custom ROMs

### DIFF
--- a/app/src/main/java/com/osfans/trime/ui/main/LogActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/LogActivity.kt
@@ -55,7 +55,7 @@ class LogActivity : AppCompatActivity() {
                                 it.write(logView.currentLog)
                             }
                         }
-                    }?.toast()
+                    }?.let { toast(it) }
                 }
             }
     }

--- a/app/src/main/java/com/osfans/trime/util/Toast.kt
+++ b/app/src/main/java/com/osfans/trime/util/Toast.kt
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2015 - 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Adapted from https://github.com/fcitx5-android/fcitx5-android/blob/59558c5b624359455911082b10750f4dcbd10fe8/app/src/main/java/org/fcitx/fcitx5/android/utils/Toast.kt
+package com.osfans.trime.util
+
+import android.content.Context
+import android.widget.Toast
+import androidx.annotation.StringRes
+import com.osfans.trime.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+fun Context.toast(
+    string: String,
+    duration: Int = Toast.LENGTH_SHORT,
+) {
+    Toast.makeText(this, string, duration).show()
+}
+
+fun Context.toast(
+    @StringRes resId: Int,
+    duration: Int = Toast.LENGTH_SHORT,
+) {
+    Toast.makeText(this, resId, duration).show()
+}
+
+fun Context.toast(
+    t: Throwable,
+    duration: Int = Toast.LENGTH_SHORT,
+) {
+    toast(t.localizedMessage ?: t.stackTraceToString(), duration)
+}
+
+suspend fun <T> Context.toast(
+    result: Result<T>,
+    duration: Int = Toast.LENGTH_SHORT,
+) {
+    withContext(Dispatchers.Main.immediate) {
+        result
+            .onSuccess { toast(R.string.setup__done, duration) }
+            .onFailure { toast(it, duration) }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/util/Utils.kt
+++ b/app/src/main/java/com/osfans/trime/util/Utils.kt
@@ -24,8 +24,6 @@ import com.hjq.permissions.Permission
 import com.hjq.permissions.XXPermissions
 import com.osfans.trime.R
 import com.osfans.trime.TrimeApplication
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import splitties.experimental.InternalSplittiesApi
 import splitties.resources.withResolvedThemeAttribute
 import java.io.Serializable
@@ -33,33 +31,8 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 
 val appContext: Context get() = TrimeApplication.getInstance().applicationContext
-
-@OptIn(ExperimentalContracts::class)
-inline fun <T : Any, U> Result<T?>.bindOnNotNull(block: (T) -> Result<U>): Result<U>? {
-    contract {
-        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
-    }
-    return when {
-        isSuccess && getOrThrow() != null -> block(getOrThrow()!!)
-        isSuccess && getOrThrow() == null -> null
-        else -> Result.failure(exceptionOrNull()!!)
-    }
-}
-
-suspend fun <T> Result<T>.toast() =
-    withContext(Dispatchers.Main.immediate) {
-        onSuccess {
-            ToastUtils.showShort(R.string.setup__done)
-        }
-        onFailure {
-            ToastUtils.showShort(it.message)
-        }
-    }
 
 @OptIn(InternalSplittiesApi::class)
 fun Context.styledFloat(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1354 
Fixes #1361 

ToastUtils of AndroidUtilCode may cause this issue, so I adapt the toast utils from fcitx5-android.

Ref: https://github.com/fcitx5-android/fcitx5-android/blob/59558c5b624359455911082b10750f4dcbd10fe8/app/src/main/java/org/fcitx/fcitx5/android/utils/Toast.kt

#### Feature
Describe features of this pull request

N/A

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

