### PR TITLE
fix: work with the old synced asset files hierarchy

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
@@ -113,10 +113,10 @@ object DataManager {
                 when (it) {
                     is DataDiff.CreateFile,
                     is DataDiff.UpdateFile,
-                    -> ResourceUtils.copyFile(it.path, sharedDataDir)
+                    -> ResourceUtils.copyFile(it.path, sharedDataDir, "rime/")
                     is DataDiff.DeleteDir,
                     is DataDiff.DeleteFile,
-                    -> FileUtils.delete(sharedDataDir.resolve(it.path)).getOrThrow()
+                    -> FileUtils.delete(sharedDataDir.resolve(it.path.removePrefix("rime/"))).getOrThrow()
                 }
             }
 

--- a/app/src/main/java/com/osfans/trime/util/ResourceUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ResourceUtils.kt
@@ -10,9 +10,10 @@ object ResourceUtils {
     fun copyFile(
         filename: String,
         dest: File,
+        removedPrefix: String = "",
     ) = runCatching {
         appContext.assets.open(filename).use { i ->
-            File(dest, filename)
+            File(dest, filename.removePrefix(removedPrefix))
                 .also { it.parentFile?.mkdirs() }
                 .outputStream()
                 .use { o -> i.copyTo(o) }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

After #1359 , the assets will actually copy to `<shared_directory>/rime/...` while `<shared_directory>/...` is the original hierarchy. This PR is to fix to work with the old way.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

