### PR TITLE
feat: add button to copy brief result logs to clipboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/util/DialogUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/DialogUtils.kt
@@ -4,6 +4,7 @@
 
 package com.osfans.trime.util
 
+import android.content.ClipData
 import android.content.Context
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.annotation.StringRes
@@ -18,6 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import splitties.dimensions.dp
+import splitties.systemservices.clipboardManager
 import splitties.views.dsl.core.add
 import splitties.views.dsl.core.horizontalMargin
 import splitties.views.dsl.core.lParams
@@ -98,6 +100,11 @@ suspend fun Context.briefResultLogDialog(
             .setTitle(R.string.setup__done)
             .setMessage(R.string.found_some_problems)
             .setView(logView)
+            .setNeutralButton(androidx.preference.R.string.copy) { _, _ ->
+                val logText = ClipData.newPlainText("log", log.joinToString("\n"))
+                clipboardManager.setPrimaryClip(logText)
+                this@briefResultLogDialog.toast(R.string.copy_done)
+            }
             .setPositiveButton(R.string.setup__skip_hint_yes, null)
             .show()
     } else {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Add button to copy brief result logs to clipboard.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

