### PR TITLE
Custom liquid keyboard fixed key bar

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -881,6 +881,15 @@ liquid_keyboard:
   single_width: 60    #single类型的按键宽度
   vertical_gap: 8     #纵向按键间隙
   margin_x: 2       #左右按键间隙的1/2
+  fixed_key_bar: # 固定按键条
+    position: bottom  # 摆放位置（在滚动区域的……） top|bottom|left|right
+    keys: # 按键（显示名称为对应的label，不能放太多）
+      - liquid_keyboard_exit
+      - space1
+      - BackSpace
+      - Return2
+      - liquid_keyboard_clipboard
+      - liquid_keyboard_tabs
   keyboards: [emoji, math, ascii, cn, history, clipboard, collection, draft, symbollist, list, ids, symbol, tabs, pinyin, script_symbols, jp, grease, rusa, korea, lation, yinbiao, unit, yanwenzi, combing, emoji_full, candidate]  #tab列表
   tabs:
     name: 更多
@@ -3920,6 +3929,7 @@ preset_keys:
   Shift_L: {label: Shift, preview: '⇪', functional: false, send: Shift_L}
   Return: { label: enter_labels, preview: '↩', functional: false, send: Return }
   Return1: {label: Enter, preview: '↩', functional: false, send: Return}
+  Return2: {label: 回车, send: Return }
   Hide: {label: 隐藏, send: BACK}
   BackSpace: {label: 退格, preview: '⇦', repeatable: true, functional: false, send: BackSpace}
   space: {repeatable: false, preview: ' ', functional: false, label: '_______', send: space}
@@ -3969,8 +3979,10 @@ preset_keys:
   Keyboard_next: { label: 后退, functional: false, send: Eisu_toggle, select: .next }
   Keyboard_last: { label: 后退, functional: false, send: Eisu_toggle, select: .last }
   Keyboard_last_lock: { label: 返回, send: Eisu_toggle, select: .last_lock } #直接切換到下一键盘
+  liquid_keyboard_exit: {label: 返回, send: function, command: liquid_keyboard, option: "-1"}  #退出liquidkeyboard
   liquid_keyboard_switch: { label: 更多, send: function, command: liquid_keyboard, option: "特殊" }
   liquid_keyboard_switch2: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 更多 ] }
+  liquid_keyboard_tabs: { label: 更多, send: function, command: liquid_keyboard, option: "更多" }
   liquid_keyboard_emoji: { label: 🙂, send: function, command: liquid_keyboard, option: "emoji" }
   liquid_keyboard_clipboard: { label: 剪贴, send: function, command: liquid_keyboard, option: "剪贴" }
   # rime状态

--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -700,6 +700,15 @@ liquid_keyboard:
   single_width: 60    #single类型的按键宽度
   vertical_gap: 1     #纵向按键间隙
   margin_x: 0.5         #左右按键间隙的1/2
+  fixed_key_bar:  # 固定按键条
+    position: bottom  # 摆放位置（在滚动区域的……） top|bottom|left|right
+    keys:  # 按键（显示名称为对应的label，不能放太多）
+      - liquid_keyboard_exit
+      - space1
+      - BackSpace
+      - Return2
+      - liquid_keyboard_clipboard
+      - liquid_keyboard_switch
   keyboards: [emoji, math, ascii, cn, history, clipboard, collection, draft, symbollist, list, ids, symbol, tabs, pinyin, script_symbols, jp, grease, rusa, korea, lation, yinbiao, unit, yanwenzi, combing, emoji_full, candidate]  #tab列表
   tabs:
     name: 更多
@@ -887,9 +896,11 @@ preset_keys:
   Shift_L: {label: Shift, send: Shift_L, shift_lock: ascii_long}
   Return: {label: enter_labels, send: Return}
   Return1: {label: Enter, send: Return }
+  Return2: {label: 回车, send: Return }
   Hide: {label: 隱藏, send: BACK}
   BackSpace: {label: 退格, repeatable: true, send: BackSpace}
   space: {repeatable: false, functional: false, send: space}
+  space1: {label: 空格, repeatable: false, functional: false, send: space}
   Escape: {label: Esc, send: Escape}
   Home: {label: 行首, send: Home}
   Insert: {label: 插入, send: Insert}
@@ -932,7 +943,7 @@ preset_keys:
   Keyboard_letter: {label: 字母, send: Eisu_toggle, select: default}
   Keyboard_default: {label: 返回, send: Eisu_toggle, select: .default}
   Keyboard_switch: {label: 鍵盤, send: Eisu_toggle, select: .next}
-  liquid_keyboard_switch: { label: 更多, send: function, command: liquid_keyboard, option: "符号表" }
+  liquid_keyboard_switch: { label: 更多, send: function, command: liquid_keyboard, option: "更多" }
   liquid_keyboard_exit: {label: 返回, send: function, command: liquid_keyboard, option: "-1"}  #退出liquidkeyboard
   liquid_keyboard_emoji: { label: 🙂, send: function, command: liquid_keyboard, option: "emoji" }
   liquid_keyboard_clipboard: { label: 剪贴, send: function, command: liquid_keyboard, option: "剪贴" }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidLayout.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidLayout.kt
@@ -16,8 +16,12 @@ import com.osfans.trime.ime.core.TrimeInputMethodService
 import splitties.dimensions.dp
 import splitties.views.backgroundColor
 import splitties.views.dsl.constraintlayout.above
+import splitties.views.dsl.constraintlayout.after
+import splitties.views.dsl.constraintlayout.before
 import splitties.views.dsl.constraintlayout.below
 import splitties.views.dsl.constraintlayout.bottomOfParent
+import splitties.views.dsl.constraintlayout.bottomToTopOf
+import splitties.views.dsl.constraintlayout.centerHorizontally
 import splitties.views.dsl.constraintlayout.centerVertically
 import splitties.views.dsl.constraintlayout.constraintLayout
 import splitties.views.dsl.constraintlayout.endOfParent
@@ -27,6 +31,7 @@ import splitties.views.dsl.constraintlayout.matchConstraints
 import splitties.views.dsl.constraintlayout.startOfParent
 import splitties.views.dsl.constraintlayout.startToEndOf
 import splitties.views.dsl.constraintlayout.topOfParent
+import splitties.views.dsl.constraintlayout.topToBottomOf
 import splitties.views.dsl.core.add
 import splitties.views.dsl.core.frameLayout
 import splitties.views.dsl.core.lParams
@@ -38,53 +43,76 @@ import splitties.views.gravityCenter
 import splitties.views.padding
 
 @SuppressLint("ViewConstructor")
-class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Theme) : ConstraintLayout(context) {
+class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Theme) :
+    ConstraintLayout(context) {
     // TODO: 继承一个键盘视图嵌入到这里，而不是自定义一个视图
-    val operations =
+    private val fixedKeyBar =
         constraintLayout {
-            val btns =
-                Array(SimpleKeyDao.operations.size) {
-                    val operation = SimpleKeyDao.operations[it]
-                    val text =
-                        textView {
-                            text = operation.second
-                            textSize = theme.generalStyle.labelTextSize.toFloat()
-                            typeface = FontManager.getTypeface("key_font")
-                            ColorManager.getColor("key_text_color")?.let { color -> setTextColor(color) }
-                        }
-                    val root =
-                        frameLayout {
-                            add(
-                                text,
-                                lParams(matchParent, wrapContent) {
-                                    gravity = gravityCenter
-                                    padding = dp(5)
-                                },
-                            )
-                            ColorManager.getColor("key_back_color")?.let { bg -> backgroundColor = bg }
-                            setOnClickListener {
-                                // TODO: 这个方式不太优雅，还需打磨
-                                if (operation.first == "liquid_keyboard_exit") {
-                                    service.selectLiquidKeyboard(-1)
-                                } else {
-                                    val event = EventManager.getEvent(operation.first)
+            val operations = theme.liquid.getMap("fixed_key_bar")?.get("keys")?.configList
+            operations?.let {
+                val btns =
+                    Array(it.size) {
+                        val operation = operations.get(it)
+                        val text =
+                            textView {
+                                text =
+                                    theme.presetKeys?.get(operation.toString())?.configMap?.get("label")
+                                        .toString()
+                                textSize = theme.generalStyle.labelTextSize.toFloat()
+                                typeface = FontManager.getTypeface("key_font")
+                                ColorManager.getColor("key_text_color")
+                                    ?.let { color -> setTextColor(color) }
+                            }
+                        val root =
+                            frameLayout {
+                                add(
+                                    text,
+                                    lParams(matchParent, wrapContent) {
+                                        gravity = gravityCenter
+                                        padding = dp(5)
+                                    },
+                                )
+                                ColorManager.getColor("key_back_color")
+                                    ?.let { bg -> backgroundColor = bg }
+                                // todo 想办法实现退格键、空格键等 repeatable: true 长按连续触发
+                                setOnClickListener {
+                                    val event = EventManager.getEvent(operation.toString())
                                     service.textInputManager?.run {
                                         onPress(event.code)
                                         onEvent(event)
                                     }
                                 }
                             }
+                        return@Array root
+                    }
+                when (
+                    theme.liquid.getMap("fixed_key_bar")
+                        ?.get("position")?.configValue.toString()
+                ) {
+                    LEFT, RIGHT -> {
+                        btns.forEachIndexed { i, btn ->
+                            add(
+                                btn,
+                                lParams(wrapContent, matchConstraints) {
+                                    if (i == 0) topOfParent() else below(btns[i - 1])
+                                    if (i == btns.size - 1) bottomOfParent() else above(btns[i + 1])
+                                },
+                            )
                         }
-                    return@Array root
+                    }
+
+                    TOP, BOTTOM -> {
+                        btns.forEachIndexed { i, btn ->
+                            add(
+                                btn,
+                                lParams(wrapContent, matchConstraints) {
+                                    if (i == 0) startOfParent() else after(btns[i - 1])
+                                    if (i == btns.size - 1) endOfParent() else before(btns[i + 1])
+                                },
+                            )
+                        }
+                    }
                 }
-            btns.forEachIndexed { i, btn ->
-                add(
-                    btn,
-                    lParams(wrapContent, matchConstraints) {
-                        if (i == 0) topOfParent() else below(btns[i - 1])
-                        if (i == btns.size - 1) bottomOfParent() else above(btns[i + 1])
-                    },
-                )
             }
         }
 
@@ -98,21 +126,100 @@ class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Th
     val tabsUi = LiquidTabsUi(context, theme)
 
     init {
-        add(
-            boardView,
-            lParams {
-                centerVertically()
-                startOfParent()
-                endToStartOf(operations)
-            },
-        )
-        add(
-            operations,
-            lParams(wrapContent, matchConstraints) {
-                centerVertically()
-                startToEndOf(boardView)
-                endOfParent()
-            },
-        )
+        when (theme.liquid.getMap("fixed_key_bar")?.get("position")?.configValue.toString() ?: "") {
+            TOP -> {
+                add(
+                    boardView,
+                    lParams {
+                        centerHorizontally()
+                        topToBottomOf(fixedKeyBar)
+                        bottomOfParent()
+                    },
+                )
+                add(
+                    fixedKeyBar,
+                    lParams(wrapContent, wrapContent) {
+                        centerHorizontally()
+                        topOfParent()
+                        bottomToTopOf(boardView)
+                    },
+                )
+            }
+
+            BOTTOM -> {
+                add(
+                    boardView,
+                    lParams {
+                        centerHorizontally()
+                        topOfParent()
+                        bottomToTopOf(fixedKeyBar)
+                    },
+                )
+                add(
+                    fixedKeyBar,
+                    lParams(wrapContent, wrapContent) {
+                        centerHorizontally()
+                        topToBottomOf(boardView)
+                        bottomOfParent()
+                    },
+                )
+            }
+
+            LEFT -> {
+                add(
+                    boardView,
+                    lParams {
+                        centerVertically()
+                        startToEndOf(fixedKeyBar)
+                        endOfParent()
+                    },
+                )
+                add(
+                    fixedKeyBar,
+                    lParams(wrapContent, matchConstraints) {
+                        centerVertically()
+                        startOfParent()
+                        endToStartOf(boardView)
+                    },
+                )
+            }
+
+            RIGHT -> {
+                add(
+                    boardView,
+                    lParams {
+                        centerVertically()
+                        startOfParent()
+                        endToStartOf(fixedKeyBar)
+                    },
+                )
+                add(
+                    fixedKeyBar,
+                    lParams(wrapContent, matchConstraints) {
+                        centerVertically()
+                        startToEndOf(boardView)
+                        endOfParent()
+                    },
+                )
+            }
+
+            else -> {
+                add(
+                    boardView,
+                    lParams {
+                        centerVertically()
+                        startOfParent()
+                        endOfParent()
+                    },
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val TOP = "top"
+        private const val BOTTOM = "bottom"
+        private const val LEFT = "left"
+        private const val RIGHT = "right"
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidLayout.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidLayout.kt
@@ -6,6 +6,7 @@ package com.osfans.trime.ime.symbol
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.drawable.GradientDrawable
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.setPadding
 import com.osfans.trime.data.theme.ColorManager
@@ -14,7 +15,6 @@ import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.ime.core.TrimeInputMethodService
 import splitties.dimensions.dp
-import splitties.views.backgroundColor
 import splitties.views.dsl.constraintlayout.above
 import splitties.views.dsl.constraintlayout.after
 import splitties.views.dsl.constraintlayout.before
@@ -48,11 +48,11 @@ class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Th
     // TODO: 继承一个键盘视图嵌入到这里，而不是自定义一个视图
     private val fixedKeyBar =
         constraintLayout {
-            val operations = theme.liquid.getMap("fixed_key_bar")?.get("keys")?.configList
-            operations?.let {
+            val fixedKeys = theme.liquid.getMap("fixed_key_bar")?.get("keys")?.configList
+            fixedKeys?.let {
                 val btns =
-                    Array(it.size) {
-                        val operation = operations.get(it)
+                    Array(it.size) { index ->
+                        val operation = fixedKeys[index]
                         val text =
                             textView {
                                 text =
@@ -65,6 +65,13 @@ class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Th
                             }
                         val root =
                             frameLayout {
+                                background =
+                                    GradientDrawable().apply {
+                                        cornerRadius = theme.generalStyle.roundCorner.toFloat()
+                                        ColorManager.getColor("key_back_color")?.let { bg ->
+                                            setColor(bg)
+                                        }
+                                    }
                                 add(
                                     text,
                                     lParams(matchParent, wrapContent) {
@@ -72,8 +79,6 @@ class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Th
                                         padding = dp(5)
                                     },
                                 )
-                                ColorManager.getColor("key_back_color")
-                                    ?.let { bg -> backgroundColor = bg }
                                 // todo 想办法实现退格键、空格键等 repeatable: true 长按连续触发
                                 setOnClickListener {
                                     val event = EventManager.getEvent(operation.toString())
@@ -85,6 +90,7 @@ class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Th
                             }
                         return@Array root
                     }
+                val marginX = theme.liquid.getFloat("margin_x")
                 when (
                     theme.liquid.getMap("fixed_key_bar")
                         ?.get("position")?.configValue.toString()
@@ -94,8 +100,18 @@ class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Th
                             add(
                                 btn,
                                 lParams(wrapContent, matchConstraints) {
-                                    if (i == 0) topOfParent() else below(btns[i - 1])
-                                    if (i == btns.size - 1) bottomOfParent() else above(btns[i + 1])
+                                    if (i == 0) {
+                                        topOfParent()
+                                    } else {
+                                        topMargin = dp(marginX).toInt()
+                                        below(btns[i - 1])
+                                    }
+                                    if (i == btns.size - 1) {
+                                        bottomOfParent()
+                                    } else {
+                                        bottomMargin = dp(marginX).toInt()
+                                        above(btns[i + 1])
+                                    }
                                 },
                             )
                         }
@@ -106,8 +122,18 @@ class LiquidLayout(context: Context, service: TrimeInputMethodService, theme: Th
                             add(
                                 btn,
                                 lParams(wrapContent, matchConstraints) {
-                                    if (i == 0) startOfParent() else after(btns[i - 1])
-                                    if (i == btns.size - 1) endOfParent() else before(btns[i + 1])
+                                    if (i == 0) {
+                                        startOfParent()
+                                    } else {
+                                        leftMargin = dp(marginX).toInt()
+                                        after(btns[i - 1])
+                                    }
+                                    if (i == btns.size - 1) {
+                                        endOfParent()
+                                    } else {
+                                        rightMargin = dp(marginX).toInt()
+                                        before(btns[i + 1])
+                                    }
                                 },
                             )
                         }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/SimpleAdapter.kt
@@ -9,6 +9,7 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.osfans.trime.data.theme.ColorManager
@@ -18,7 +19,8 @@ import com.osfans.trime.databinding.SimpleItemOneBinding
 import com.osfans.trime.databinding.SimpleItemRowBinding
 import splitties.dimensions.dp
 
-class SimpleAdapter(theme: Theme, private val columnSize: Int) : RecyclerView.Adapter<SimpleAdapter.ViewHolder>() {
+class SimpleAdapter(theme: Theme, private val columnSize: Int) :
+    RecyclerView.Adapter<SimpleAdapter.ViewHolder>() {
     private val mBeans = mutableListOf<SimpleKeyBean>()
     private val mBeansByRows = mutableListOf<List<SimpleKeyBean>>()
     val beans get() = mBeans
@@ -42,6 +44,8 @@ class SimpleAdapter(theme: Theme, private val columnSize: Int) : RecyclerView.Ad
     }
 
     private val mSingleWidth = theme.liquid.getInt("single_width")
+    private val mSingleHeight = theme.liquid.getInt("key_height")
+    private val mStringMarginX = theme.liquid.getFloat("margin_x")
     private val mTextSize = theme.generalStyle.labelTextSize
     private val mTextColor = ColorManager.getColor("key_text_color")
     private val mTypeface = FontManager.getTypeface("key_font")
@@ -57,13 +61,18 @@ class SimpleAdapter(theme: Theme, private val columnSize: Int) : RecyclerView.Ad
         parent: ViewGroup,
         viewType: Int,
     ): ViewHolder {
-        val binding = SimpleItemRowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        val size = parent.dp(mSingleWidth)
+        val binding =
+            SimpleItemRowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val width = parent.dp(mSingleWidth)
+        val height = parent.dp(mSingleHeight)
+        val marginX = parent.dp(mStringMarginX).toInt()
         val bindings = mutableListOf<SimpleItemOneBinding>()
         for (i in 0 until columnSize) {
             val sub = SimpleItemOneBinding.inflate(LayoutInflater.from(parent.context), null, false)
             bindings.add(sub)
-            binding.wrapper.addView(sub.root, size, size)
+            val layoutParams = LinearLayout.LayoutParams(width, height)
+            layoutParams.setMargins(marginX, 0, marginX, 0)
+            binding.wrapper.addView(sub.root, layoutParams)
         }
         val holder = ViewHolder(binding, bindings)
 
@@ -81,7 +90,8 @@ class SimpleAdapter(theme: Theme, private val columnSize: Int) : RecyclerView.Ad
         return holder
     }
 
-    class ViewHolder(binding: SimpleItemRowBinding, views: List<SimpleItemOneBinding>) : RecyclerView.ViewHolder(binding.root) {
+    class ViewHolder(binding: SimpleItemRowBinding, views: List<SimpleItemOneBinding>) :
+        RecyclerView.ViewHolder(binding.root) {
         val simpleKeyTexts = views.map { it.root.getChildAt(0) as TextView }
         val wrappers = views.map { it.root.apply { getChildAt(1).visibility = View.GONE } }
     }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/SimpleKeyDao.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/SimpleKeyDao.kt
@@ -24,12 +24,4 @@ object SimpleKeyDao {
         }
         return list
     }
-
-    val operations =
-        arrayOf(
-            "liquid_keyboard_exit" to "返回",
-            "space" to "空格",
-            "BackSpace" to "退格",
-            "Return" to "回车",
-        )
 }

--- a/doc/Keyboard.md
+++ b/doc/Keyboard.md
@@ -10,6 +10,22 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 - `single_width` : 在 `SINGLE` 類別中，每項的闊度 (和高度相等)。
 
+新增一些参数 `fixed_key_bar:` 用于自定义液态键盘中的固定按键条：
+
+例：
+```yaml
+liquid_keyboard:
+  fixed_key_bar:  # 固定按键条
+    position: bottom  # 摆放位置（在滚动区域的……） top|bottom|left|right （上/下/左/右）
+    keys:  # 按键（显示名称为对应的label，不能放太多）
+      - liquid_keyboard_exit  # 返回键（在preset_keys内定义，同下）
+      - space1  # 空格键
+      - BackSpace  # 退格键
+      - Return2  # 回车键
+      - liquid_keyboard_clipboard  # “剪贴板”跳转按键
+      - liquid_keyboard_switch  # “更多”跳转按键
+```
+
 # 藍芽鍵盤問題
 https://github.com/osfans/trime/issues/1058#issuecomment-1672635413
 

--- a/doc/trime-schema.json
+++ b/doc/trime-schema.json
@@ -832,8 +832,14 @@
         "fixed_key_bar": {
           "type": "object",
           "properties": {
-            "position": {"type": "string", "description": "固定按键条摆放位置（相对滚动区域的方位） top|bottom|left|right （上/下/左/右）"},
-            "keys": {"type": "array", "description": "固定按键条的按键（显示名称为对应的label，不能放太多）"}
+            "position": {
+              "enum": ["top", "bottom", "left", "right"],
+              "description": "固定按键条摆放位置（相对滚动区域的上/下/左/右方位）"
+            },
+            "keys": {
+              "type": "array",
+              "description": "固定按键条的按键（显示名称为对应的label，不能放太多）"
+            }
           }
         },
         "keyboards": { "type": "array", "items": { "type": "string" } }

--- a/doc/trime-schema.json
+++ b/doc/trime-schema.json
@@ -829,6 +829,13 @@
         },
         "vertical_gap": { "type": "integer", "description": "纵向按键间隙" },
         "margin_x": { "type": "number", "description": "左右按键间隙的1/2" },
+        "fixed_key_bar": {
+          "type": "object",
+          "properties": {
+            "position": {"type": "string", "description": "固定按键条摆放位置（相对滚动区域的方位） top|bottom|left|right （上/下/左/右）"},
+            "keys": {"type": "array", "description": "固定按键条的按键（显示名称为对应的label，不能放太多）"}
+          }
+        },
         "keyboards": { "type": "array", "items": { "type": "string" } }
       }
     },


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
新增一些参数 `fixed_key_bar:` 用于自定义液态键盘中的固定按键条：

例：
```yaml
liquid_keyboard:
  fixed_key_bar:  # 固定按键条
    position: bottom  # 摆放位置（在滚动区域的……） top|bottom|left|right （上/下/左/右）
    keys:  # 按键（显示名称为对应的label，不能放太多）
      - liquid_keyboard_exit  # 返回键（在preset_keys内定义，同下）
      - space1  # 空格键
      - BackSpace  # 退格键
      - Return2  # 回车键
      - liquid_keyboard_clipboard  # “剪贴板”跳转按键
      - liquid_keyboard_switch  # “更多”跳转按键
```

效果如图：
![Screenshot_20240513_125609_in mfile_edit_381218676326204](https://github.com/osfans/trime/assets/31384673/f80b5d3a-8c4f-473b-bafc-74853c936a1d)
![Screenshot_20240513_125657_in mfile_edit_381203706518915](https://github.com/osfans/trime/assets/31384673/a40d221a-299e-414e-ac21-efcc3c1c334c)
![Screenshot_20240513_125737_in mfile_edit_381192033213708](https://github.com/osfans/trime/assets/31384673/674d0f6b-9bb8-41da-a4e6-108c23b773f7)



#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

