### PR TITLE
Correctly copy assets files & folders when "reset to default" is clicked.

### DIFF
--- a/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
@@ -209,18 +209,20 @@ class ProfileFragment :
                         lifecycleScope.withLoadingDialog(context) {
                             withContext(Dispatchers.IO) {
                                 res =
-                                    items.fold(true) { acc, asset ->
-                                        ResourceUtils.copyFiles("$rimeFolder/$asset", DataManager.sharedDataDir, "$rimeFolder/").fold({
-                                            acc and true // on success
-                                        }, {
-                                            acc and false // on failure
-                                        })
-                                    }
+                                    items.filterIndexed { index, _ -> checkedItems[index] }
+                                        .fold(true) { acc, asset ->
+                                            ResourceUtils.copyFiles(
+                                                "$rimeFolder/$asset",
+                                                DataManager.sharedDataDir,
+                                                "$rimeFolder/",
+                                            )
+                                                .fold({ acc and true }, { acc and false })
+                                        }
                             }
+                            ToastUtils.showShort(
+                                if (res) R.string.reset_success else R.string.reset_failure,
+                            )
                         }
-                        ToastUtils.showShort(
-                            if (res) R.string.reset_success else R.string.reset_failure,
-                        )
                     }.show()
                 true
             }

--- a/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
@@ -195,7 +195,8 @@ class ProfileFragment :
                 true
             }
             get<Preference>("profile_reset")?.setOnPreferenceClickListener {
-                val items = appContext.assets.list("rime")!!
+                val rimeFolder = "rime"
+                val items = appContext.assets.list(rimeFolder)!!
                 val checkedItems = items.map { false }.toBooleanArray()
                 AlertDialog.Builder(context)
                     .setTitle(R.string.profile_reset)
@@ -209,7 +210,7 @@ class ProfileFragment :
                             withContext(Dispatchers.IO) {
                                 res =
                                     items.fold(true) { acc, asset ->
-                                        ResourceUtils.copyFile(asset, DataManager.sharedDataDir).fold({
+                                        ResourceUtils.copyFiles("$rimeFolder/$asset", DataManager.sharedDataDir, "$rimeFolder/").fold({
                                             acc and true // on success
                                         }, {
                                             acc and false // on failure

--- a/app/src/main/java/com/osfans/trime/util/ResourceUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ResourceUtils.kt
@@ -4,6 +4,7 @@
 
 package com.osfans.trime.util
 
+import timber.log.Timber
 import java.io.File
 
 object ResourceUtils {
@@ -18,5 +19,28 @@ object ResourceUtils {
                 .outputStream()
                 .use { o -> i.copyTo(o) }
         }
+    }.onFailure { Timber.e(it, "Caught a error in copying assets") }
+
+    fun copyFiles(
+        assetPath: String,
+        destFile: File,
+        removedPrefix: String = "",
+    ): Result<Long> {
+        return runCatching {
+            val formattedDestPath = assetPath.removePrefix(removedPrefix)
+            val files = appContext.assets.list(assetPath)
+            if (files?.isNotEmpty() == true) {
+                files.fold(0L) { acc, file ->
+                    acc + copyFiles("$assetPath/$file", File(destFile, formattedDestPath), file).getOrDefault(0L)
+                }
+            } else {
+                appContext.assets.open(assetPath).use { i ->
+                    File(destFile, formattedDestPath.split(File.pathSeparator).last())
+                        .also { it.parentFile?.mkdirs() }
+                        .outputStream()
+                        .use { o -> i.copyTo(o) }
+                }
+            }
+        }.onFailure { Timber.e(it, "Caught a error in copying assets") }
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1390

#### Feature
Correctly copy assets files & folders when "reset to default" is clicked.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

