### PR TITLE
fix: use `/` as path separator for all OS

### DIFF
--- a/build-logic/convention/src/main/kotlin/DataChecksumsPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DataChecksumsPlugin.kt
@@ -99,7 +99,7 @@ class DataChecksumsPlugin : Plugin<Project> {
                     ?: mutableMapOf()
 
             fun File.allParents(): List<File> =
-                if (parentFile == null || parentFile.path in map) {
+                if (parentFile == null || parentFile.invariantSeparatorsPath in map) {
                     listOf()
                 } else {
                     listOf(parentFile) + parentFile.allParents()
@@ -110,7 +110,7 @@ class DataChecksumsPlugin : Plugin<Project> {
                 }
                 logger.log(LogLevel.DEBUG, "${change.changeType}: ${change.normalizedPath}")
                 val relativeFile = change.file.relativeTo(file.parentFile)
-                val key = relativeFile.path
+                val key = relativeFile.invariantSeparatorsPath
                 if (change.changeType == ChangeType.REMOVED) {
                     map.remove(key)
                 } else {
@@ -120,7 +120,7 @@ class DataChecksumsPlugin : Plugin<Project> {
             // calculate dirs
             inputDir.asFileTree.forEach {
                 it.relativeTo(file.parentFile).allParents().forEach { p ->
-                    map[p.path] = ""
+                    map[p.invariantSeparatorsPath] = ""
                 }
             }
             serialize(map.toSortedMap())


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Refs #1391

#### Feature
Use "/" as the standard path separator for all OS

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

