### PR TITLE
移除「外部儲存空間的權限和存取權」

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,9 +9,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name ="android.permission.WAKE_LOCK" />
@@ -22,7 +19,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
         android:allowBackup="true"
         android:icon="@mipmap/ic_app_icon"
         android:label="@string/trime_app_name"
-        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_app_icon_round"
         android:theme="@style/Theme.TrimeAppTheme">
 

--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -8,8 +8,6 @@ import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.base.DataManager
 import com.osfans.trime.data.opencc.OpenCCDictManager
 import com.osfans.trime.data.schema.SchemaManager
-import com.osfans.trime.util.appContext
-import com.osfans.trime.util.isStorageAvailable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -84,7 +82,7 @@ class Rime : RimeApi, RimeLifecycleOwner {
             Timber.w("Skip starting rime: not at stopped state!")
             return
         }
-        if (appContext.isStorageAvailable()) {
+        if (AppPrefs.defaultInstance().profile.isUserDataDirChosen()) {
             lifecycleImpl.emitState(RimeLifecycle.State.STARTING)
             dispatcher.start(fullCheck)
         }

--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -30,6 +30,9 @@ class Rime : RimeApi, RimeLifecycleOwner {
     override val isReady: Boolean
         get() = lifecycle.currentStateFlow.value == RimeLifecycle.State.READY
 
+    override val isStarting: Boolean
+        get() = lifecycle.currentStateFlow.value == RimeLifecycle.State.STARTING
+
     private val dispatcher =
         RimeDispatcher(
             object : RimeDispatcher.RimeLooper {

--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -37,8 +37,8 @@ class Rime : RimeApi, RimeLifecycleOwner {
                     DataManager.dirFireChange()
                     DataManager.sync()
 
-                    val sharedDataDir = AppPrefs.defaultInstance().profile.sharedDataDir
-                    val userDataDir = AppPrefs.defaultInstance().profile.userDataDir
+                    val sharedDataDir = AppPrefs.Profile.getAppShareDir()
+                    val userDataDir = AppPrefs.Profile.getAppUserDir()
                     Timber.i("Starting up Rime APIs ...")
                     startupRime(sharedDataDir, userDataDir, fullCheck)
 

--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -90,6 +90,8 @@ class Rime : RimeApi, RimeLifecycleOwner {
         ) {
             lifecycleImpl.emitState(RimeLifecycle.State.STARTING)
             dispatcher.start(fullCheck)
+        } else {
+            Timber.w("Skip starting rime: directory not yet ready")
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -82,7 +82,9 @@ class Rime : RimeApi, RimeLifecycleOwner {
             Timber.w("Skip starting rime: not at stopped state!")
             return
         }
-        if (AppPrefs.defaultInstance().profile.isUserDataDirChosen()) {
+        if (AppPrefs.defaultInstance().profile.isUserDataDirChosen() &&
+            AppPrefs.Profile.getAppPath().isNotBlank()
+        ) {
             lifecycleImpl.emitState(RimeLifecycle.State.STARTING)
             dispatcher.start(fullCheck)
         }

--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -40,8 +40,8 @@ class Rime : RimeApi, RimeLifecycleOwner {
                     DataManager.dirFireChange()
                     DataManager.sync()
 
-                    val sharedDataDir = AppPrefs.Profile.getAppShareDir()
-                    val userDataDir = AppPrefs.Profile.getAppUserDir()
+                    val sharedDataDir = AppPrefs.defaultInstance().profile.getAppShareDir()
+                    val userDataDir = AppPrefs.defaultInstance().profile.getAppUserDir()
                     Timber.i("Starting up Rime APIs ...")
                     startupRime(sharedDataDir, userDataDir, fullCheck)
 
@@ -86,7 +86,7 @@ class Rime : RimeApi, RimeLifecycleOwner {
             return
         }
         if (AppPrefs.defaultInstance().profile.isUserDataDirChosen() &&
-            AppPrefs.Profile.getAppPath().isNotBlank()
+            AppPrefs.Profile.isAppPathReady()
         ) {
             lifecycleImpl.emitState(RimeLifecycle.State.STARTING)
             dispatcher.start(fullCheck)

--- a/app/src/main/java/com/osfans/trime/core/RimeApi.kt
+++ b/app/src/main/java/com/osfans/trime/core/RimeApi.kt
@@ -13,6 +13,8 @@ interface RimeApi {
 
     val isReady: Boolean
 
+    val isStarting: Boolean
+
     suspend fun isEmpty(): Boolean
 
     suspend fun availableSchemata(): Array<SchemaListItem>

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -353,9 +353,17 @@ class AppPrefs(
                 return PathUtils.getExternalAppFilesPath()
             }
 
-            fun getAppUserDir() = getAppPath() + "/user"
+            fun isAppPathReady() = getAppPath().isNotBlank()
+        }
 
-            fun getAppShareDir() = getAppPath() + "/share"
+        fun getAppUserDir() = getAppPath() + "/user"
+
+        fun getAppShareDir(): String {
+            return if (sharedDataDir.isNotEmpty() && sharedDataDir != userDataDir) {
+                getAppPath() + "/share"
+            } else {
+                getAppUserDir()
+            }
         }
 
         var sharedDataDir: String

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -359,17 +359,17 @@ class AppPrefs(
         fun getAppUserDir() = getAppPath() + "/user"
 
         fun getAppShareDir(): String {
-            return if (sharedDataDir.isNotEmpty() && sharedDataDir != userDataDir) {
+            return if (sharedDataDirUri.isNotEmpty() && sharedDataDirUri != userDataDirUri) {
                 getAppPath() + "/share"
             } else {
                 getAppUserDir()
             }
         }
 
-        var sharedDataDir: String
+        var sharedDataDirUri: String
             get() = prefs.getPref(SHARED_DATA_DIR, "")
             set(v) = prefs.setPref(SHARED_DATA_DIR, v)
-        var userDataDir: String
+        var userDataDirUri: String
             get() = prefs.getPref(USER_DATA_DIR, "")
             set(v) = prefs.setPref(USER_DATA_DIR, v)
         var syncBackgroundEnabled: Boolean
@@ -388,7 +388,7 @@ class AppPrefs(
             get() = prefs.getPref(LAST_BACKGROUND_SYNC, "")
             set(v) = prefs.setPref(LAST_BACKGROUND_SYNC, v)
 
-        fun isUserDataDirChosen() = userDataDir.isNotBlank() && userDataDir.startsWith(URI_PREFIX)
+        fun isUserDataDirChosen() = userDataDirUri.isNotBlank() && userDataDirUri.startsWith(URI_PREFIX)
     }
 
     class Clipboard(private val prefs: AppPrefs) {

--- a/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/AppPrefs.kt
@@ -7,8 +7,8 @@ package com.osfans.trime.data
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
+import com.blankj.utilcode.util.PathUtils
 import com.osfans.trime.R
-import com.osfans.trime.data.base.DataManager
 import com.osfans.trime.ime.enums.FullscreenMode
 import com.osfans.trime.ime.enums.InlinePreeditMode
 import com.osfans.trime.ime.keyboard.KeyboardPrefs
@@ -347,13 +347,22 @@ class AppPrefs(
             const val TIMING_SYNC_TRIGGER_TIME = "profile_timing_sync_trigger_time"
             const val LAST_SYNC_STATUS = "profile_last_sync_status"
             const val LAST_BACKGROUND_SYNC = "profile_last_background_sync"
+            const val URI_PREFIX = "content://com.android.externalstorage.documents/"
+
+            fun getAppPath(): String {
+                return PathUtils.getExternalAppFilesPath()
+            }
+
+            fun getAppUserDir() = getAppPath() + "/user"
+
+            fun getAppShareDir() = getAppPath() + "/share"
         }
 
         var sharedDataDir: String
-            get() = prefs.getPref(SHARED_DATA_DIR, DataManager.defaultDataDirectory.path)
+            get() = prefs.getPref(SHARED_DATA_DIR, "")
             set(v) = prefs.setPref(SHARED_DATA_DIR, v)
         var userDataDir: String
-            get() = prefs.getPref(USER_DATA_DIR, DataManager.defaultDataDirectory.path)
+            get() = prefs.getPref(USER_DATA_DIR, "")
             set(v) = prefs.setPref(USER_DATA_DIR, v)
         var syncBackgroundEnabled: Boolean
             get() = prefs.getPref(SYNC_BACKGROUND_ENABLED, false)
@@ -370,6 +379,8 @@ class AppPrefs(
         var lastBackgroundSync: String
             get() = prefs.getPref(LAST_BACKGROUND_SYNC, "")
             set(v) = prefs.setPref(LAST_BACKGROUND_SYNC, v)
+
+        fun isUserDataDirChosen() = userDataDir.isNotBlank() && userDataDir.startsWith(URI_PREFIX)
     }
 
     class Clipboard(private val prefs: AppPrefs) {

--- a/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
@@ -50,8 +50,6 @@ object DataManager {
 
     private val prefs get() = AppPrefs.defaultInstance()
 
-    val defaultDataDirectory = File(Environment.getExternalStorageDirectory(), "rime")
-
     private val onDataDirChangeListeners = WeakHashSet<OnDataDirChangeListener>()
 
     fun interface OnDataDirChangeListener {
@@ -72,11 +70,11 @@ object DataManager {
 
     @JvmStatic
     val sharedDataDir
-        get() = File(prefs.profile.sharedDataDir)
+        get() = File(AppPrefs.Profile.getAppShareDir())
 
     @JvmStatic
     val userDataDir
-        get() = File(prefs.profile.userDataDir)
+        get() = File(AppPrefs.Profile.getAppUserDir())
 
     /**
      * Return the absolute path of the compiled config file

--- a/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
@@ -70,11 +70,11 @@ object DataManager {
 
     @JvmStatic
     val sharedDataDir
-        get() = File(AppPrefs.Profile.getAppShareDir())
+        get() = File(prefs.profile.getAppShareDir())
 
     @JvmStatic
     val userDataDir
-        get() = File(AppPrefs.Profile.getAppUserDir())
+        get() = File(prefs.profile.getAppUserDir())
 
     /**
      * Return the absolute path of the compiled config file

--- a/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
@@ -6,7 +6,6 @@ package com.osfans.trime.data.base
 
 import android.content.res.AssetManager
 import android.os.Build
-import android.os.Environment
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.util.FileUtils
 import com.osfans.trime.util.ResourceUtils
@@ -124,7 +123,7 @@ object DataManager {
             File(sharedDataDir, DEFAULT_CUSTOM_FILE_NAME).let {
                 if (!it.exists()) {
                     Timber.d("Creating empty default.custom.yaml")
-                    it.bufferedWriter().use { w -> w.write("") }
+                    it.also { it.parentFile?.mkdirs() }.bufferedWriter().use { w -> w.write("") }
                 }
             }
 

--- a/app/src/main/java/com/osfans/trime/data/storage/FolderExport.kt
+++ b/app/src/main/java/com/osfans/trime/data/storage/FolderExport.kt
@@ -1,0 +1,108 @@
+package com.osfans.trime.data.storage
+
+import android.content.Context
+import androidx.core.net.toUri
+import androidx.documentfile.provider.DocumentFile
+import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.util.appContext
+import timber.log.Timber
+import java.io.File
+
+class FolderExport(private val context: Context, private val docUriStr: String) {
+    suspend fun exportDir(dirPath: File) {
+        DocumentFile.fromTreeUri(appContext, docUriStr.toUri())?.runCatching {
+            val dirDoc = this.findFile(dirPath.name)?.takeIf { it.isDirectory && it.canWrite() } ?: this.createDirectory(dirPath.name)
+
+            dirDoc?.let {
+                recursiveExport(dirPath, dirDoc)
+            } ?: run {
+                Timber.e("Error, cannot create export folder, %s", dirPath.name)
+            }
+        }?.onFailure {
+            Timber.e(it)
+        }
+    }
+
+    suspend fun exportModifiedFiles(fileNames: Array<File>) {
+        DocumentFile.fromTreeUri(appContext, docUriStr.toUri())?.runCatching {
+            fileNames.forEach { fileName ->
+                export(fileName, this)
+            }
+        }
+    }
+
+    private suspend fun recursiveExport(
+        sourcePath: File,
+        targetDir: DocumentFile,
+    ) {
+        sourcePath.listFiles()?.forEach { file ->
+            if (file.isFile) {
+                export(file, targetDir)
+            } else if (file.isDirectory) {
+                targetDir.runCatching {
+                    val docFile =
+                        this.findFile(file.name)?.takeIf { it.isDirectory && it.canWrite() }
+                            ?: this.createDirectory(file.name)
+
+                    docFile?.let {
+                        recursiveExport(file, it)
+                    }
+                }.onFailure {
+                    Timber.e(it)
+                }
+            }
+        }
+    }
+
+    private suspend fun export(
+        fileName: File,
+        targetDir: DocumentFile,
+    ) {
+        runCatching {
+            val docFile =
+                targetDir.findFile(fileName.name)?.takeIf { it.isFile && it.canWrite() }
+                    ?: targetDir.createFile("*/*", fileName.name)
+            docFile?.let { doc ->
+                copyToUri(fileName, doc)
+            } ?: run {
+                Timber.e("Cannot export file: %s", fileName.name)
+            }
+        }.onFailure {
+            Timber.e(it, "Uri Error")
+        }
+    }
+
+    private fun copyToUri(
+        sourceFile: File,
+        targetDoc: DocumentFile,
+    ) {
+        val oss = context.contentResolver.openOutputStream(targetDoc.uri, "wt")
+        oss?.use {
+            sourceFile.inputStream().apply {
+                copyTo(oss)
+
+                close()
+            }
+        }
+    }
+
+    companion object {
+        suspend fun exportModifiedFiles() {
+            val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
+
+            val f1 = File(AppPrefs.Profile.getAppUserDir(), "default.custom.yaml")
+            val f2 = File(AppPrefs.Profile.getAppUserDir(), "user.yaml")
+
+            FolderExport(appContext, userDirUri).exportModifiedFiles(arrayOf(f1, f2))
+        }
+
+        suspend fun exportSyncDir() {
+            val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
+
+            val dir = "sync"
+            val dirFile = File(AppPrefs.Profile.getAppUserDir(), dir)
+
+            FolderExport(appContext, userDirUri).exportDir(dirFile)
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/data/storage/FolderExport.kt
+++ b/app/src/main/java/com/osfans/trime/data/storage/FolderExport.kt
@@ -97,19 +97,21 @@ class FolderExport(private val context: Context, private val docUriStr: String) 
 
     companion object {
         suspend fun exportModifiedFiles() {
-            val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
+            val profile = AppPrefs.defaultInstance().profile
+            val userDirUri = profile.userDataDir
 
-            val f1 = File(AppPrefs.Profile.getAppUserDir(), "default.custom.yaml")
-            val f2 = File(AppPrefs.Profile.getAppUserDir(), "user.yaml")
+            val f1 = File(profile.getAppUserDir(), "default.custom.yaml")
+            val f2 = File(profile.getAppUserDir(), "user.yaml")
 
             FolderExport(appContext, userDirUri).exportModifiedFiles(arrayOf(f1, f2))
         }
 
         suspend fun exportSyncDir(): Boolean {
-            val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
+            val profile = AppPrefs.defaultInstance().profile
+            val userDirUri = profile.userDataDir
 
             val dir = "sync"
-            val dirFile = File(AppPrefs.Profile.getAppUserDir(), dir)
+            val dirFile = File(profile.getAppUserDir(), dir)
 
             return FolderExport(appContext, userDirUri).exportDir(dirFile)
         }

--- a/app/src/main/java/com/osfans/trime/data/storage/FolderExport.kt
+++ b/app/src/main/java/com/osfans/trime/data/storage/FolderExport.kt
@@ -98,7 +98,7 @@ class FolderExport(private val context: Context, private val docUriStr: String) 
     companion object {
         suspend fun exportModifiedFiles() {
             val profile = AppPrefs.defaultInstance().profile
-            val userDirUri = profile.userDataDir
+            val userDirUri = profile.userDataDirUri
 
             val f1 = File(profile.getAppUserDir(), "default.custom.yaml")
             val f2 = File(profile.getAppUserDir(), "user.yaml")
@@ -108,7 +108,7 @@ class FolderExport(private val context: Context, private val docUriStr: String) 
 
         suspend fun exportSyncDir(): Boolean {
             val profile = AppPrefs.defaultInstance().profile
-            val userDirUri = profile.userDataDir
+            val userDirUri = profile.userDataDirUri
 
             val dir = "sync"
             val dirFile = File(profile.getAppUserDir(), dir)

--- a/app/src/main/java/com/osfans/trime/data/storage/FolderSync.kt
+++ b/app/src/main/java/com/osfans/trime/data/storage/FolderSync.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import com.osfans.trime.data.AppPrefs
-import com.osfans.trime.util.appContext
 import timber.log.Timber
 import java.io.File
 
@@ -108,13 +107,15 @@ class FolderSync(private val context: Context, private val docUriStr: String) {
     }
 
     companion object {
-        suspend fun exportModifiedFiles() {
+        suspend fun copyDir(context: Context) {
             val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
+            val shareDirUri = AppPrefs.defaultInstance().profile.sharedDataDir
 
-            val f1 = File(AppPrefs.Profile.getAppUserDir(), "default.custom.yaml")
-            val f2 = File(AppPrefs.Profile.getAppUserDir(), "user.yaml")
+            FolderSync(context, userDirUri).copyAll((AppPrefs.Profile.getAppUserDir()))
 
-            FolderExport(appContext, userDirUri).exportModifiedFiles(arrayOf(f1, f2))
+            if (shareDirUri != userDirUri && shareDirUri.isNotBlank()) {
+                FolderSync(context, shareDirUri).copyAll((AppPrefs.Profile.getAppShareDir()))
+            }
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/data/storage/FolderSync.kt
+++ b/app/src/main/java/com/osfans/trime/data/storage/FolderSync.kt
@@ -111,10 +111,12 @@ class FolderSync(private val context: Context, private val docUriStr: String) {
             val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
             val shareDirUri = AppPrefs.defaultInstance().profile.sharedDataDir
 
-            FolderSync(context, userDirUri).copyAll((AppPrefs.Profile.getAppUserDir()))
+            FolderSync(context, userDirUri)
+                .copyAll(AppPrefs.defaultInstance().profile.getAppUserDir())
 
             if (shareDirUri != userDirUri && shareDirUri.isNotBlank()) {
-                FolderSync(context, shareDirUri).copyAll((AppPrefs.Profile.getAppShareDir()))
+                FolderSync(context, shareDirUri)
+                    .copyAll(AppPrefs.defaultInstance().profile.getAppShareDir())
             }
         }
     }

--- a/app/src/main/java/com/osfans/trime/data/storage/StorageUtils.kt
+++ b/app/src/main/java/com/osfans/trime/data/storage/StorageUtils.kt
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2015 - 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.data.storage
+
+import android.content.Context
+import android.content.Intent
+import android.provider.DocumentsContract
+
+object StorageUtils {
+    private fun getDocumentsUiPackage(context: Context): String? {
+        // See android.permission.cts.ProviderPermissionTest.testManageDocuments()
+        val packageInfos =
+            context.packageManager.getPackagesHoldingPermissions(
+                arrayOf(android.Manifest.permission.MANAGE_DOCUMENTS),
+                0,
+            )
+        val packageInfo =
+            packageInfos.firstOrNull { it.packageName.endsWith(".documentsui") }
+                ?: packageInfos.firstOrNull()
+        return packageInfo?.packageName
+    }
+
+    fun getViewDirIntent(context: Context): Intent? {
+        val viewIntent =
+            Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(
+                    DocumentsContract.buildRootsUri("${context.packageName}.provider"),
+                    DocumentsContract.Document.MIME_TYPE_DIR,
+                )
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+//                    addCategory(Intent.CATEGORY_OPENABLE)
+                getDocumentsUiPackage(context)?.let { setPackage(it) }
+            }
+        return if (viewIntent.resolveActivity(context.packageManager) != null) {
+            viewIntent
+        } else {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/broadcast/ExternalStorageStateReceiver.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/ExternalStorageStateReceiver.kt
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2015 - 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.broadcast
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Environment
+import com.osfans.trime.data.AppPrefs
+
+class ExternalStorageStateReceiver(
+    private val context: Context,
+    private val mountedRunFunc: () -> Unit,
+) {
+    private val externalStorageStateReceiver: BroadcastReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                context: Context,
+                intent: Intent,
+            ) {
+                updateExternalStorageState(intent)
+            }
+        }
+
+    private fun updateExternalStorageState(intent: Intent) {
+        val state = Environment.getExternalStorageState()
+        if (Environment.MEDIA_MOUNTED == state) {
+            // SD card is mounted and ready for use
+            intent.data?.path?.let { path ->
+                if (AppPrefs.Profile.getAppPath().startsWith(path)) {
+                    mountedRunFunc()
+                    context.unregisterReceiver(externalStorageStateReceiver)
+                }
+            }
+        } else if (Environment.MEDIA_MOUNTED_READ_ONLY == state) {
+            // SD card is mounted, but it is read only
+        } else {
+            // SD card is unavailable
+        }
+    }
+
+    fun listenExternalStorageChangeState() {
+        val state = Environment.getExternalStorageState()
+        if (state != Environment.MEDIA_MOUNTED) {
+            context.registerReceiver(
+                externalStorageStateReceiver,
+                IntentFilter().apply {
+                    addAction(Intent.ACTION_MEDIA_MOUNTED)
+                    addDataScheme("file")
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/broadcast/IntentReceiver.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/IntentReceiver.kt
@@ -19,6 +19,7 @@ import com.osfans.trime.R
 import com.osfans.trime.core.Rime
 import com.osfans.trime.daemon.RimeDaemon
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.util.ShortcutUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -92,8 +93,7 @@ class IntentReceiver : BroadcastReceiver(), CoroutineScope by MainScope() {
                             }
                         }
 
-                        Rime.syncRimeUserData()
-                        RimeDaemon.restartRime(true)
+                        ShortcutUtils.sync(true)
                         wakeLock.release() // 释放唤醒锁
                     }
                 }

--- a/app/src/main/java/com/osfans/trime/ime/core/OneWayFolderSync.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/OneWayFolderSync.kt
@@ -1,0 +1,152 @@
+package com.osfans.trime.ime.core
+
+import android.content.Context
+import androidx.core.net.toUri
+import androidx.documentfile.provider.DocumentFile
+import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.util.appContext
+import timber.log.Timber
+import java.io.File
+
+class OneWayFolderSync(private val context: Context, private val docUriStr: String) {
+    private val sourceFiles = mutableSetOf<String>()
+
+    suspend fun copyFiles(
+        fileNames: Array<String>,
+        appSpecificPath: String,
+    ) {
+        DocumentFile.fromTreeUri(context, docUriStr.toUri())?.runCatching {
+            fileNames.forEach { name ->
+                val docFile = this.findFile(name)?.takeIf { it.isFile }
+                docFile?.let {
+                    val file = File(appSpecificPath, name)
+                    copyToFile(it, file)
+                }
+            }
+        }?.onFailure {
+            Timber.e(it, "Uri Error")
+        }
+    }
+
+    suspend fun copyAll(appSpecificPath: String) {
+        runCatching {
+            DocumentFile.fromTreeUri(context, docUriStr.toUri())?.let { tree ->
+                recursivelyCopy(tree, File(appSpecificPath))
+                recursiveDeleteFiles(File(appSpecificPath))
+            }
+        }.onFailure {
+            Timber.e(it, "Uri (%s) Error", docUriStr)
+        }
+    }
+
+    suspend fun export(
+        fileNames: Array<String>,
+        appSpecificPath: String,
+    ) {
+        fileNames.forEach { fileName ->
+            DocumentFile.fromTreeUri(context, docUriStr.toUri())?.runCatching {
+                val docFile =
+                    this.findFile(fileName)?.takeIf { it.isFile && it.canWrite() }
+                        ?: this.createFile("*/*", fileName)
+                docFile?.let { doc ->
+                    val file = File(appSpecificPath, fileName)
+                    copyToUri(file, doc)
+                }?.run {
+                    Timber.e("Cannot export file: %s", fileName)
+                }
+            }?.onFailure {
+                Timber.e(it, "Uri Error")
+            }
+        }
+    }
+
+    // IO Operation, should call in background threads
+    private fun recursivelyCopy(
+        documentTree: DocumentFile,
+        appSpecificPath: File,
+    ) {
+        documentTree.let { tree ->
+            if (!appSpecificPath.exists()) {
+                appSpecificPath.mkdir()
+            }
+            tree.listFiles().forEach { doc ->
+                if (doc.isFile) {
+                    doc.name?.let { name ->
+                        val file = File(appSpecificPath, name)
+                        sourceFiles.add(file.absolutePath)
+
+                        if (shouldCopyToFile(doc, file)) {
+                            copyToFile(doc, file)
+                        }
+                    }
+                } else if (doc.isDirectory) {
+                    doc.name?.takeIf { it != "build" && !it.contains("userdb") }?.let {
+                        val file = File(appSpecificPath, it)
+                        sourceFiles.add(file.absolutePath)
+                        recursivelyCopy(doc, file)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun shouldCopyToFile(
+        sourceDoc: DocumentFile,
+        targetFile: File,
+    ): Boolean {
+        return !targetFile.exists() || sourceDoc.length() != targetFile.length()
+    }
+
+    private fun copyToFile(
+        sourceDoc: DocumentFile,
+        targetFile: File,
+    ) {
+        val iss = context.contentResolver.openInputStream(sourceDoc.uri)
+        iss?.use {
+            targetFile.outputStream().apply {
+                it.copyTo(this)
+                close()
+            }
+//            Timber.d("Copied : ${file.absolutePath}")
+        }
+    }
+
+    private fun copyToUri(
+        sourceFile: File,
+        targetDoc: DocumentFile,
+    ) {
+        val oss = context.contentResolver.openOutputStream(targetDoc.uri, "wt")
+        oss?.use {
+            sourceFile.inputStream().apply {
+                copyTo(oss)
+
+                close()
+            }
+        }
+    }
+
+    private fun recursiveDeleteFiles(path: File) {
+        path.listFiles()?.forEachIndexed { _, file ->
+            if (file.isFile) {
+                if (!sourceFiles.contains(file.absolutePath)) {
+                    file.delete()
+                }
+            } else if (file.isDirectory) {
+                if (!file.name.contains("userdb") && file.name != "build") {
+                    recursiveDeleteFiles(file)
+                    if (!sourceFiles.contains(file.absolutePath)) {
+                        file.delete()
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        suspend fun exportTo() {
+            val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
+
+            OneWayFolderSync(appContext, userDirUri).export(arrayOf("default.custom.yaml"), AppPrefs.Profile.getAppUserDir())
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/core/OneWayFolderSync.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/OneWayFolderSync.kt
@@ -51,7 +51,7 @@ class OneWayFolderSync(private val context: Context, private val docUriStr: Stri
                 docFile?.let { doc ->
                     val file = File(appSpecificPath, fileName)
                     copyToUri(file, doc)
-                }?.run {
+                }?: {
                     Timber.e("Cannot export file: %s", fileName)
                 }
             }?.onFailure {
@@ -143,10 +143,13 @@ class OneWayFolderSync(private val context: Context, private val docUriStr: Stri
     }
 
     companion object {
-        suspend fun exportTo() {
+        suspend fun exportModifiedFiles() {
             val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
 
-            OneWayFolderSync(appContext, userDirUri).export(arrayOf("default.custom.yaml"), AppPrefs.Profile.getAppUserDir())
+            OneWayFolderSync(appContext, userDirUri).export(
+                arrayOf("default.custom.yaml", "user.yaml"),
+                AppPrefs.Profile.getAppUserDir()
+            )
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -41,6 +41,7 @@ import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.db.DraftHelper
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.ThemeManager
+import com.osfans.trime.ime.broadcast.ExternalStorageStateReceiver
 import com.osfans.trime.ime.broadcast.IntentReceiver
 import com.osfans.trime.ime.composition.CompositionPopupWindow
 import com.osfans.trime.ime.enums.FullscreenMode
@@ -218,6 +219,15 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     }
 
     override fun onCreate() {
+        val stateReceiver =
+            ExternalStorageStateReceiver(this) {
+                if (!rime.run { isReady }) {
+                    RimeDaemon.destroySession(javaClass.name)
+                    rime = RimeDaemon.createSession(javaClass.name)
+                }
+            }
+        stateReceiver.listenExternalStorageChangeState()
+
         rime = RimeDaemon.createSession(javaClass.name)
         super.onCreate()
         // MUST WRAP all code within Service onCreate() in try..catch to prevent any crash loops

--- a/app/src/main/java/com/osfans/trime/ime/dialog/AvailableSchemaPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ime/dialog/AvailableSchemaPickerDialog.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.LifecycleCoroutineScope
 import com.osfans.trime.R
 import com.osfans.trime.core.RimeApi
 import com.osfans.trime.daemon.RimeDaemon
-import com.osfans.trime.data.storage.FolderSync
+import com.osfans.trime.data.storage.FolderExport
 import kotlinx.coroutines.launch
 
 object AvailableSchemaPickerDialog {
@@ -37,7 +37,7 @@ object AvailableSchemaPickerDialog {
                     if (setOf(newEnabled) == setOf(enabledIds)) return@setPositiveButton
                     scope.launch {
                         rime.setEnabledSchemata(newEnabled.toTypedArray())
-                        FolderSync.exportModifiedFiles()
+                        FolderExport.exportModifiedFiles()
                         RimeDaemon.restartRime()
                     }
                 }

--- a/app/src/main/java/com/osfans/trime/ime/dialog/AvailableSchemaPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ime/dialog/AvailableSchemaPickerDialog.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.LifecycleCoroutineScope
 import com.osfans.trime.R
 import com.osfans.trime.core.RimeApi
 import com.osfans.trime.daemon.RimeDaemon
+import com.osfans.trime.ime.core.OneWayFolderSync
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 
@@ -37,6 +38,7 @@ object AvailableSchemaPickerDialog {
                     if (setOf(newEnabled) == setOf(enabledIds)) return@setPositiveButton
                     scope.launch {
                         rime.setEnabledSchemata(newEnabled.toTypedArray())
+                        OneWayFolderSync.exportModifiedFiles()
                         RimeDaemon.restartRime()
                     }
                 }

--- a/app/src/main/java/com/osfans/trime/ime/dialog/AvailableSchemaPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ime/dialog/AvailableSchemaPickerDialog.kt
@@ -10,9 +10,8 @@ import androidx.lifecycle.LifecycleCoroutineScope
 import com.osfans.trime.R
 import com.osfans.trime.core.RimeApi
 import com.osfans.trime.daemon.RimeDaemon
-import com.osfans.trime.ime.core.OneWayFolderSync
+import com.osfans.trime.data.storage.FolderSync
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 
 object AvailableSchemaPickerDialog {
     suspend fun build(
@@ -38,7 +37,7 @@ object AvailableSchemaPickerDialog {
                     if (setOf(newEnabled) == setOf(enabledIds)) return@setPositiveButton
                     scope.launch {
                         rime.setEnabledSchemata(newEnabled.toTypedArray())
-                        OneWayFolderSync.exportModifiedFiles()
+                        FolderSync.exportModifiedFiles()
                         RimeDaemon.restartRime()
                     }
                 }

--- a/app/src/main/java/com/osfans/trime/ime/dialog/EnabledSchemaPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ime/dialog/EnabledSchemaPickerDialog.kt
@@ -9,7 +9,7 @@ import android.content.Context
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.osfans.trime.R
 import com.osfans.trime.core.RimeApi
-import com.osfans.trime.ime.core.OneWayFolderSync
+import com.osfans.trime.data.storage.FolderSync
 import kotlinx.coroutines.launch
 import splitties.systemservices.inputMethodManager
 
@@ -36,7 +36,7 @@ object EnabledSchemaPickerDialog {
                 ) { dialog, which ->
                     scope.launch {
                         rime.selectSchema(selectedIds[which])
-                        OneWayFolderSync.exportModifiedFiles()
+                        FolderSync.exportModifiedFiles()
                         dialog.dismiss()
                     }
                 }

--- a/app/src/main/java/com/osfans/trime/ime/dialog/EnabledSchemaPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ime/dialog/EnabledSchemaPickerDialog.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.osfans.trime.R
 import com.osfans.trime.core.RimeApi
+import com.osfans.trime.ime.core.OneWayFolderSync
 import kotlinx.coroutines.launch
 import splitties.systemservices.inputMethodManager
 
@@ -35,6 +36,7 @@ object EnabledSchemaPickerDialog {
                 ) { dialog, which ->
                     scope.launch {
                         rime.selectSchema(selectedIds[which])
+                        OneWayFolderSync.exportModifiedFiles()
                         dialog.dismiss()
                     }
                 }

--- a/app/src/main/java/com/osfans/trime/ime/dialog/EnabledSchemaPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ime/dialog/EnabledSchemaPickerDialog.kt
@@ -9,7 +9,7 @@ import android.content.Context
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.osfans.trime.R
 import com.osfans.trime.core.RimeApi
-import com.osfans.trime.data.storage.FolderSync
+import com.osfans.trime.data.storage.FolderExport
 import kotlinx.coroutines.launch
 import splitties.systemservices.inputMethodManager
 
@@ -36,7 +36,7 @@ object EnabledSchemaPickerDialog {
                 ) { dialog, which ->
                     scope.launch {
                         rime.selectSchema(selectedIds[which])
-                        FolderSync.exportModifiedFiles()
+                        FolderExport.exportModifiedFiles()
                         dialog.dismiss()
                     }
                 }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/InitializationUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/InitializationUi.kt
@@ -8,8 +8,7 @@ import android.content.Context
 import android.view.View
 import android.widget.ProgressBar
 import com.osfans.trime.R
-import com.osfans.trime.util.appContext
-import com.osfans.trime.util.isStorageAvailable
+import com.osfans.trime.data.AppPrefs
 import splitties.dimensions.dp
 import splitties.resources.color
 import splitties.views.backgroundColor
@@ -41,10 +40,10 @@ class InitializationUi(override val ctx: Context) : Ui {
             val textView =
                 textView {
                     textResource =
-                        if (appContext.isStorageAvailable()) {
+                        if (isDeploying()) {
                             R.string.deploy_progress
                         } else {
-                            R.string.external_storage_permission_not_available
+                            R.string.directory_not_selected
                         }
                     textSize = 24f
                     textAlignment = View.TEXT_ALIGNMENT_CENTER
@@ -55,7 +54,7 @@ class InitializationUi(override val ctx: Context) : Ui {
                 ProgressBar(context, null, android.R.attr.progressBarStyleHorizontal).apply {
                     isIndeterminate = true
                     visibility =
-                        if (appContext.isStorageAvailable()) {
+                        if (isDeploying()) {
                             View.VISIBLE
                         } else {
                             View.GONE
@@ -77,6 +76,8 @@ class InitializationUi(override val ctx: Context) : Ui {
                 },
             )
         }
+
+    private fun isDeploying() = AppPrefs.defaultInstance().profile.isUserDataDirChosen()
 
     override val root =
         constraintLayout {

--- a/app/src/main/java/com/osfans/trime/provider/RimeDataProvider.kt
+++ b/app/src/main/java/com/osfans/trime/provider/RimeDataProvider.kt
@@ -15,6 +15,7 @@ import android.provider.DocumentsContract.Root
 import android.provider.DocumentsProvider
 import android.webkit.MimeTypeMap
 import com.osfans.trime.R
+import com.osfans.trime.data.AppPrefs
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -72,7 +73,7 @@ class RimeDataProvider : DocumentsProvider() {
     private fun fileFromDocId(docId: String) = File(docIdPrefix, docId)
 
     override fun onCreate(): Boolean {
-        baseDir = context!!.getExternalFilesDir(null)!!
+        baseDir = File(AppPrefs.Profile.getAppPath())
         docIdPrefix = "${baseDir.parent}${File.separator}"
         textFilePaths = Array(TEXT_FILES.size) { baseDir.resolve(TEXT_FILES[it]).absolutePath }
         return true

--- a/app/src/main/java/com/osfans/trime/ui/components/FolderPickerPreference.kt
+++ b/app/src/main/java/com/osfans/trime/ui/components/FolderPickerPreference.kt
@@ -5,6 +5,7 @@
 package com.osfans.trime.ui.components
 
 import android.content.Context
+import android.content.Intent
 import android.content.res.TypedArray
 import android.net.Uri
 import android.util.AttributeSet
@@ -12,10 +13,9 @@ import android.view.LayoutInflater
 import androidx.activity.result.ActivityResultLauncher
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
-import com.blankj.utilcode.util.UriUtils
 import com.osfans.trime.R
 import com.osfans.trime.databinding.FolderPickerDialogBinding
-import java.io.File
+import com.osfans.trime.ui.setup.SetupFragment
 
 class FolderPickerPreference
     @JvmOverloads
@@ -25,8 +25,9 @@ class FolderPickerPreference
         defStyleAttr: Int = androidx.preference.R.attr.preferenceStyle,
     ) : Preference(context, attrs, defStyleAttr) {
         private var value = ""
-        lateinit var documentTreeLauncher: ActivityResultLauncher<Uri?>
+        lateinit var documentTreeLauncher: ActivityResultLauncher<Intent?>
         lateinit var dialogView: FolderPickerDialogBinding
+        private var tempValue = ""
 
         var default = ""
 
@@ -71,17 +72,16 @@ class FolderPickerPreference
             dialogView = FolderPickerDialogBinding.inflate(LayoutInflater.from(context))
             dialogView.editText.setText(initValue)
             dialogView.button.setOnClickListener {
-                documentTreeLauncher.launch(UriUtils.file2Uri(File(initValue)))
+                documentTreeLauncher.launch(SetupFragment.getFolderIntent())
             }
             AlertDialog.Builder(context)
                 .setTitle(this@FolderPickerPreference.title)
                 .setView(dialogView.root)
                 .setPositiveButton(android.R.string.ok) { _, _ ->
-                    val value = dialogView.editText.text.toString()
-                    setValue(value)
-                }
-                .setNeutralButton(R.string.pref__default) { _, _ ->
-                    setValue(default)
+                    val value = tempValue
+                    if (value.isNotBlank()) {
+                        setValue(value)
+                    }
                 }
                 .setNegativeButton(android.R.string.cancel, null)
                 .show()
@@ -92,5 +92,14 @@ class FolderPickerPreference
                 persistString(value)
                 notifyChanged()
             }
+        }
+
+        fun assignValue(value: String) {
+            tempValue = value
+            dialogView.editText.text = getDisplayValue(value)
+        }
+
+        private fun getDisplayValue(value: String): String {
+            return value.split("%3A").last().replace("%2F", "/")
         }
     }

--- a/app/src/main/java/com/osfans/trime/ui/components/FolderPickerPreference.kt
+++ b/app/src/main/java/com/osfans/trime/ui/components/FolderPickerPreference.kt
@@ -85,13 +85,7 @@ class FolderPickerPreference
                 AlertDialog.Builder(context)
                     .setTitle(this@FolderPickerPreference.title)
                     .setView(dialogView.root)
-                    .setPositiveButton(android.R.string.ok) { _, _ ->
-                        val value = tempValue
-                        if (value.isNotBlank()) {
-                            setValue(value)
-                        }
-                    }
-                    .setNegativeButton(android.R.string.cancel, null)
+                    .setPositiveButton(android.R.string.ok, null)
 
             if (showDefaultButton) {
                 builder.setNeutralButton(defaultButtonLabel) { _, _ ->
@@ -110,9 +104,11 @@ class FolderPickerPreference
             }
         }
 
-        fun assignValue(value: String) {
-            tempValue = value
-            dialogView.editText.text = getDisplayValue(value)
+        fun saveValueAndClose(value: String) {
+            if (value.isNotBlank()) {
+                setValue(value)
+            }
+            alertDialog?.dismiss()
         }
 
         private fun getDisplayValue(value: String): String {

--- a/app/src/main/java/com/osfans/trime/ui/components/FolderPickerPreference.kt
+++ b/app/src/main/java/com/osfans/trime/ui/components/FolderPickerPreference.kt
@@ -7,7 +7,6 @@ package com.osfans.trime.ui.components
 import android.content.Context
 import android.content.Intent
 import android.content.res.TypedArray
-import android.net.Uri
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.activity.result.ActivityResultLauncher
@@ -38,7 +37,7 @@ class FolderPickerPreference
             context.theme.obtainStyledAttributes(attrs, R.styleable.FolderPickerPreferenceAttrs, 0, 0).run {
                 try {
                     if (getBoolean(R.styleable.FolderPickerPreferenceAttrs_useSimpleSummaryProvider, false)) {
-                        summaryProvider = SummaryProvider<FolderPickerPreference> { it.value }
+                        summaryProvider = SummaryProvider<FolderPickerPreference> { getDisplayValue(it.value) }
                     }
                     showDefaultButton = getBoolean(R.styleable.FolderPickerPreferenceAttrs_showDefaultButton, true)
                     defaultButtonLabel = getString(
@@ -75,7 +74,7 @@ class FolderPickerPreference
         override fun onClick() = showPickerDialog()
 
         private fun showPickerDialog() {
-            val initValue = value
+            val initValue = getDisplayValue(value)
             dialogView = FolderPickerDialogBinding.inflate(LayoutInflater.from(context))
             dialogView.editText.setText(initValue)
             dialogView.button.setOnClickListener {
@@ -112,6 +111,10 @@ class FolderPickerPreference
         }
 
         private fun getDisplayValue(value: String): String {
-            return value.split("%3A").last().replace("%2F", "/")
+            return if (value.isBlank()) {
+                "<EMPTY>"
+            } else {
+                value.split("%3A").last().replace("%2F", "/")
+            }
         }
     }

--- a/app/src/main/java/com/osfans/trime/ui/components/FolderPickerPreference.kt
+++ b/app/src/main/java/com/osfans/trime/ui/components/FolderPickerPreference.kt
@@ -28,6 +28,9 @@ class FolderPickerPreference
         lateinit var documentTreeLauncher: ActivityResultLauncher<Intent?>
         lateinit var dialogView: FolderPickerDialogBinding
         private var tempValue = ""
+        private var showDefaultButton = true
+        private var defaultButtonLabel: String
+        private var alertDialog: AlertDialog? = null
 
         var default = ""
 
@@ -37,6 +40,10 @@ class FolderPickerPreference
                     if (getBoolean(R.styleable.FolderPickerPreferenceAttrs_useSimpleSummaryProvider, false)) {
                         summaryProvider = SummaryProvider<FolderPickerPreference> { it.value }
                     }
+                    showDefaultButton = getBoolean(R.styleable.FolderPickerPreferenceAttrs_showDefaultButton, true)
+                    defaultButtonLabel = getString(
+                        R.styleable.FolderPickerPreferenceAttrs_defaultButtonLabel,
+                    ) ?: context.getString(R.string.pref__default)
                 } finally {
                     recycle()
                 }
@@ -74,17 +81,26 @@ class FolderPickerPreference
             dialogView.button.setOnClickListener {
                 documentTreeLauncher.launch(SetupFragment.getFolderIntent())
             }
-            AlertDialog.Builder(context)
-                .setTitle(this@FolderPickerPreference.title)
-                .setView(dialogView.root)
-                .setPositiveButton(android.R.string.ok) { _, _ ->
-                    val value = tempValue
-                    if (value.isNotBlank()) {
-                        setValue(value)
+            val builder =
+                AlertDialog.Builder(context)
+                    .setTitle(this@FolderPickerPreference.title)
+                    .setView(dialogView.root)
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
+                        val value = tempValue
+                        if (value.isNotBlank()) {
+                            setValue(value)
+                        }
                     }
+                    .setNegativeButton(android.R.string.cancel, null)
+
+            if (showDefaultButton) {
+                builder.setNeutralButton(defaultButtonLabel) { _, _ ->
+                    setValue(default)
                 }
-                .setNegativeButton(android.R.string.cancel, null)
-                .show()
+            }
+
+            alertDialog = builder.create()
+            alertDialog?.show()
         }
 
         private fun setValue(value: String) {

--- a/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
@@ -31,6 +31,7 @@ import com.osfans.trime.ui.components.FolderPickerPreference
 import com.osfans.trime.ui.components.PaddingPreferenceFragment
 import com.osfans.trime.ui.main.MainViewModel
 import com.osfans.trime.util.ResourceUtils
+import com.osfans.trime.util.ShortcutUtils
 import com.osfans.trime.util.appContext
 import com.osfans.trime.util.formatDateTime
 import com.osfans.trime.util.rimeActionWithResultDialog
@@ -83,9 +84,7 @@ class ProfileFragment :
                 lifecycleScope.launch {
                     this@ProfileFragment.context?.rimeActionWithResultDialog("rime.trime", "W", 1) {
                         viewModel.deploy()
-                        Rime.syncRimeUserData()
-                        RimeDaemon.restartRime(true)
-                        FolderExport.exportSyncDir()
+                        ShortcutUtils.sync(true)
                         viewModel.deployComplete()
                         true
                     }

--- a/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
@@ -26,6 +26,7 @@ import com.osfans.trime.core.Rime
 import com.osfans.trime.daemon.RimeDaemon
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.base.DataManager
+import com.osfans.trime.data.storage.FolderExport
 import com.osfans.trime.ui.components.FolderPickerPreference
 import com.osfans.trime.ui.components.PaddingPreferenceFragment
 import com.osfans.trime.ui.main.MainViewModel
@@ -81,8 +82,11 @@ class ProfileFragment :
             get<Preference>("profile_sync_user_data")?.setOnPreferenceClickListener {
                 lifecycleScope.launch {
                     this@ProfileFragment.context?.rimeActionWithResultDialog("rime.trime", "W", 1) {
+                        viewModel.deploy()
                         Rime.syncRimeUserData()
                         RimeDaemon.restartRime(true)
+                        FolderExport.exportSyncDir()
+                        viewModel.deployComplete()
                         true
                     }
                 }

--- a/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
@@ -22,11 +22,8 @@ import androidx.preference.SwitchPreferenceCompat
 import androidx.preference.get
 import com.blankj.utilcode.util.ToastUtils
 import com.osfans.trime.R
-import com.osfans.trime.core.Rime
-import com.osfans.trime.daemon.RimeDaemon
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.base.DataManager
-import com.osfans.trime.data.storage.FolderExport
 import com.osfans.trime.ui.components.FolderPickerPreference
 import com.osfans.trime.ui.components.PaddingPreferenceFragment
 import com.osfans.trime.ui.main.MainViewModel
@@ -83,10 +80,10 @@ class ProfileFragment :
             get<Preference>("profile_sync_user_data")?.setOnPreferenceClickListener {
                 lifecycleScope.launch {
                     this@ProfileFragment.context?.rimeActionWithResultDialog("rime.trime", "W", 1) {
-                        viewModel.deploy()
-                        ShortcutUtils.sync(true)
-                        viewModel.deployComplete()
-                        true
+                        viewModel.setToLoading()
+                        val result = ShortcutUtils.sync(true)
+                        viewModel.setToReady()
+                        result
                     }
                 }
                 true

--- a/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
@@ -59,7 +59,7 @@ class ProfileFragment :
                                 Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                         contentResolver.takePersistableUriPermission(uri, takeFlags)
 
-                        assignValue(uri.toString())
+                        saveValueAndClose(uri.toString())
                     }
                 }
             }

--- a/app/src/main/java/com/osfans/trime/ui/fragments/ToolkitFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ToolkitFragment.kt
@@ -8,7 +8,9 @@ import android.app.AlertDialog
 import android.os.Bundle
 import androidx.fragment.app.activityViewModels
 import androidx.preference.Preference
+import com.blankj.utilcode.util.ToastUtils
 import com.osfans.trime.R
+import com.osfans.trime.data.storage.StorageUtils
 import com.osfans.trime.ui.components.PaddingPreferenceFragment
 import com.osfans.trime.ui.main.MainViewModel
 import com.osfans.trime.util.Logcat
@@ -44,6 +46,21 @@ class ToolkitFragment : PaddingPreferenceFragment() {
                             Logcat.default.clearLog()
                         }.setNegativeButton(R.string.cancel, null)
                         .show()
+                    true
+                }
+            },
+        )
+        screen.addPreference(
+            Preference(context).apply {
+                setTitle(R.string.pref_toolkit_internal_dir)
+                isIconSpaceReserved = false
+                setOnPreferenceClickListener {
+                    val intent = StorageUtils.getViewDirIntent(context)
+                    intent?.let {
+                        startActivity(it)
+                    } ?: run {
+                        ToastUtils.showShort("No Document App Found")
+                    }
                     true
                 }
             },

--- a/app/src/main/java/com/osfans/trime/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/MainViewModel.kt
@@ -12,6 +12,11 @@ import com.osfans.trime.daemon.RimeSession
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+enum class MainUiState{
+    LOADING,
+    READY,
+    ERR_DIRECTORY_MISSING
+}
 class MainViewModel : ViewModel() {
     private val _statusStateFlow = MutableStateFlow(RimeLifecycle.State.STOPPED)
     val statusStateFlow = _statusStateFlow.asStateFlow()

--- a/app/src/main/java/com/osfans/trime/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/MainViewModel.kt
@@ -6,10 +6,16 @@ package com.osfans.trime.ui.main
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.osfans.trime.core.RimeLifecycle
 import com.osfans.trime.daemon.RimeDaemon
 import com.osfans.trime.daemon.RimeSession
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class MainViewModel : ViewModel() {
+    private val _statusStateFlow = MutableStateFlow(RimeLifecycle.State.STOPPED)
+    val statusStateFlow = _statusStateFlow.asStateFlow()
+
     val toolbarTitle = MutableLiveData<String>()
 
     val topOptionsMenu = MutableLiveData<Boolean>()
@@ -30,5 +36,13 @@ class MainViewModel : ViewModel() {
 
     override fun onCleared() {
         RimeDaemon.destroySession(javaClass.name)
+    }
+
+    fun deploy() {
+        _statusStateFlow.value = RimeLifecycle.State.STARTING
+    }
+
+    fun deployComplete() {
+        _statusStateFlow.value = RimeLifecycle.State.READY
     }
 }

--- a/app/src/main/java/com/osfans/trime/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/MainViewModel.kt
@@ -62,10 +62,10 @@ class MainViewModel : ViewModel() {
         shareDirUri: String,
     ): Boolean {
         return if (!persistedUriList.contains(userDirUri)) {
-            AppPrefs.defaultInstance().profile.userDataDir = ""
+            AppPrefs.defaultInstance().profile.userDataDirUri = ""
             false
         } else if (shareDirUri.isNotBlank() && !persistedUriList.contains(shareDirUri)) {
-            AppPrefs.defaultInstance().profile.sharedDataDir = ""
+            AppPrefs.defaultInstance().profile.sharedDataDirUri = ""
             false
         } else {
             true

--- a/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
@@ -36,7 +36,6 @@ import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.sound.SoundEffectManager
 import com.osfans.trime.databinding.ActivityPrefBinding
 import com.osfans.trime.ui.setup.SetupActivity
-import com.osfans.trime.util.isStorageAvailable
 import com.osfans.trime.util.progressBarDialogIndeterminate
 import com.osfans.trime.util.rimeActionWithResultDialog
 import kotlinx.coroutines.launch
@@ -166,7 +165,7 @@ class PrefMainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        if (isStorageAvailable()) {
+        if (AppPrefs.defaultInstance().profile.isUserDataDirChosen()) {
             SoundEffectManager.init()
         }
     }

--- a/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
@@ -34,8 +34,8 @@ import com.osfans.trime.core.RimeLifecycle
 import com.osfans.trime.daemon.RimeDaemon
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.sound.SoundEffectManager
+import com.osfans.trime.data.storage.FolderSync
 import com.osfans.trime.databinding.ActivityPrefBinding
-import com.osfans.trime.ime.core.OneWayFolderSync
 import com.osfans.trime.ui.setup.SetupActivity
 import com.osfans.trime.util.progressBarDialogIndeterminate
 import com.osfans.trime.util.rimeActionWithResultDialog
@@ -189,10 +189,10 @@ class PrefMainActivity : AppCompatActivity() {
         val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
         val shareDirUri = AppPrefs.defaultInstance().profile.sharedDataDir
 
-        OneWayFolderSync(this, userDirUri).copyAll((AppPrefs.Profile.getAppUserDir()))
+        FolderSync(this, userDirUri).copyAll((AppPrefs.Profile.getAppUserDir()))
 
         if (shareDirUri != userDirUri && shareDirUri.isNotBlank()) {
-            OneWayFolderSync(this, shareDirUri).copyAll((AppPrefs.Profile.getAppShareDir()))
+            FolderSync(this, shareDirUri).copyAll((AppPrefs.Profile.getAppShareDir()))
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
@@ -35,6 +35,7 @@ import com.osfans.trime.daemon.RimeDaemon
 import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.data.sound.SoundEffectManager
 import com.osfans.trime.databinding.ActivityPrefBinding
+import com.osfans.trime.ime.core.OneWayFolderSync
 import com.osfans.trime.ui.setup.SetupActivity
 import com.osfans.trime.util.progressBarDialogIndeterminate
 import com.osfans.trime.util.rimeActionWithResultDialog
@@ -157,9 +158,21 @@ class PrefMainActivity : AppCompatActivity() {
     private fun deploy() {
         lifecycleScope.launch {
             rimeActionWithResultDialog("rime.trime", "W", 1) {
+                copyToInternal()
                 RimeDaemon.restartRime(true)
                 true
             }
+        }
+    }
+
+    private suspend fun copyToInternal() {
+        val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
+        val shareDirUri = AppPrefs.defaultInstance().profile.sharedDataDir
+
+        OneWayFolderSync(this, userDirUri).copyAll((AppPrefs.Profile.getAppUserDir()))
+
+        if (shareDirUri != userDirUri && shareDirUri.isNotBlank()) {
+            OneWayFolderSync(this, shareDirUri).copyAll((AppPrefs.Profile.getAppShareDir()))
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
@@ -185,11 +185,21 @@ class PrefMainActivity : AppCompatActivity() {
         }
     }
 
-    private suspend fun copyToInternal() {
+    private suspend fun copyToInternal(): Boolean {
+        val allowedUriList = contentResolver.persistedUriPermissions.map {
+            it.uri.toString()
+        }
+
         val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
         val shareDirUri = AppPrefs.defaultInstance().profile.sharedDataDir
 
-        FolderSync(this, userDirUri).copyAll((AppPrefs.Profile.getAppUserDir()))
+        return if(viewModel.checkAndResetPathPermission(allowedUriList, userDirUri, shareDirUri)){
+            FolderSync.copyDir(this)
+            true
+        } else {
+            false
+        }
+    }
 
         if (shareDirUri != userDirUri && shareDirUri.isNotBlank()) {
             FolderSync(this, shareDirUri).copyAll((AppPrefs.Profile.getAppShareDir()))

--- a/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
@@ -205,8 +205,8 @@ class PrefMainActivity : AppCompatActivity() {
                 it.uri.toString()
             }
 
-        val userDirUri = AppPrefs.defaultInstance().profile.userDataDir
-        val shareDirUri = AppPrefs.defaultInstance().profile.sharedDataDir
+        val userDirUri = AppPrefs.defaultInstance().profile.userDataDirUri
+        val shareDirUri = AppPrefs.defaultInstance().profile.sharedDataDirUri
 
         return if (viewModel.checkAndResetPathPermission(allowedUriList, userDirUri, shareDirUri)) {
             FolderSync.copyDir(this)

--- a/app/src/main/java/com/osfans/trime/ui/main/settings/ThemePickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/settings/ThemePickerDialog.kt
@@ -9,8 +9,8 @@ import android.content.Context
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.osfans.trime.R
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.storage.FolderSync
 import com.osfans.trime.data.theme.ThemeManager
-import com.osfans.trime.ime.core.OneWayFolderSync
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -57,10 +57,13 @@ object ThemePickerDialog {
         }.create()
     }
 
-    private suspend fun copyThemeFile(context: Context, selectedName: String){
+    private suspend fun copyThemeFile(
+        context: Context,
+        selectedName: String,
+    ) {
         val fileNameWithoutExt = if (selectedName == "trime") selectedName else "$selectedName.trime"
 
-        val sync = OneWayFolderSync(context, AppPrefs.defaultInstance().profile.userDataDir)
+        val sync = FolderSync(context, AppPrefs.defaultInstance().profile.userDataDir)
         sync.copyFiles(
             arrayOf("$fileNameWithoutExt.yaml", "$fileNameWithoutExt.custom.yaml"),
             AppPrefs.Profile.getAppPath(),

--- a/app/src/main/java/com/osfans/trime/ui/main/settings/ThemePickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/settings/ThemePickerDialog.kt
@@ -63,7 +63,7 @@ object ThemePickerDialog {
     ) {
         val fileNameWithoutExt = if (selectedName == "trime") selectedName else "$selectedName.trime"
 
-        val sync = FolderSync(context, AppPrefs.defaultInstance().profile.userDataDir)
+        val sync = FolderSync(context, AppPrefs.defaultInstance().profile.userDataDirUri)
         sync.copyFiles(
             arrayOf("$fileNameWithoutExt.yaml", "$fileNameWithoutExt.custom.yaml"),
             AppPrefs.Profile.getAppPath(),

--- a/app/src/main/java/com/osfans/trime/ui/main/settings/ThemePickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/settings/ThemePickerDialog.kt
@@ -34,7 +34,7 @@ object ThemePickerDialog {
             }
         val current =
             AppPrefs.defaultInstance().theme.selectedTheme
-        val currentIndex = all.indexOfFirst { it == current }
+        val currentIndex = all.indexOfFirst { it == current }.coerceAtLeast(0)
         return AlertDialog.Builder(context).apply {
             setTitle(R.string.looks__selected_theme_title)
             if (allNames.isEmpty()) {

--- a/app/src/main/java/com/osfans/trime/ui/setup/SetupFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/setup/SetupFragment.kt
@@ -4,15 +4,27 @@
 
 package com.osfans.trime.ui.setup
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.DocumentsContract
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.databinding.FragmentSetupBinding
 import com.osfans.trime.ui.setup.SetupPage.Companion.isLastPage
+import com.osfans.trime.util.InputMethodUtils
 import com.osfans.trime.util.serializable
+import timber.log.Timber
 
 class SetupFragment : Fragment() {
     private val viewModel: SetupViewModel by activityViewModels()
@@ -30,7 +42,7 @@ class SetupFragment : Fragment() {
                 hintText.text = page.getHintText(requireContext())
                 actionButton.visibility = if (new) View.GONE else View.VISIBLE
                 actionButton.text = page.getButtonText(requireContext())
-                actionButton.setOnClickListener { page.getButtonAction(requireContext()) }
+                actionButton.setOnClickListener { getButtonAction(page, requireContext()) }
                 doneText.visibility = if (new) View.VISIBLE else View.GONE
             }
             field = new
@@ -54,5 +66,57 @@ class SetupFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         sync()
+    }
+
+    fun getButtonAction(
+        setupPage: SetupPage,
+        context: Context,
+    ) {
+        when (setupPage) {
+            SetupPage.Permissions -> openDirectory()
+            SetupPage.Enable -> InputMethodUtils.showImeEnablerActivity(context)
+            SetupPage.Select -> InputMethodUtils.showImePicker()
+        }
+    }
+
+    private fun saveUri(uri: Uri) {
+        AppPrefs.defaultInstance().profile.userDataDir = uri.toString()
+    }
+
+    private fun openDirectory() {
+        startForResult.launch(getFolderIntent())
+    }
+
+    private val startForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val context = requireContext()
+                result.data?.data?.also { uri ->
+                    Timber.d("Selected URI is %s", uri.toString())
+
+                    val contentResolver = context.contentResolver
+
+                    val takeFlags: Int =
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    contentResolver.takePersistableUriPermission(uri, takeFlags)
+
+                    saveUri(uri)
+                }
+            }
+        }
+
+    companion object {
+        fun getFolderIntent(): Intent {
+            val pickerInitialUri = AppPrefs.Profile.URI_PREFIX + "document/primary%3Arime".toUri()
+
+            return Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                // Optionally, specify a URI for the directory that should be opened in
+                // the system file picker when it loads.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    putExtra(DocumentsContract.EXTRA_INITIAL_URI, pickerInitialUri)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ui/setup/SetupFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/setup/SetupFragment.kt
@@ -80,7 +80,7 @@ class SetupFragment : Fragment() {
     }
 
     private fun saveUri(uri: Uri) {
-        AppPrefs.defaultInstance().profile.userDataDir = uri.toString()
+        AppPrefs.defaultInstance().profile.userDataDirUri = uri.toString()
     }
 
     private fun openDirectory() {

--- a/app/src/main/java/com/osfans/trime/ui/setup/SetupPage.kt
+++ b/app/src/main/java/com/osfans/trime/ui/setup/SetupPage.kt
@@ -6,10 +6,8 @@ package com.osfans.trime.ui.setup
 
 import android.content.Context
 import com.osfans.trime.R
+import com.osfans.trime.data.AppPrefs
 import com.osfans.trime.util.InputMethodUtils
-import com.osfans.trime.util.appContext
-import com.osfans.trime.util.isStorageAvailable
-import com.osfans.trime.util.requestExternalStoragePermission
 
 enum class SetupPage {
     Permissions,
@@ -29,7 +27,7 @@ enum class SetupPage {
     fun getHintText(context: Context) =
         context.getText(
             when (this) {
-                Permissions -> R.string.setup__request_permmision_hint
+                Permissions -> R.string.setup__request_permission_hint
                 Enable -> R.string.setup__enable_ime_hint
                 Select -> R.string.setup__select_ime_hint
             },
@@ -38,23 +36,15 @@ enum class SetupPage {
     fun getButtonText(context: Context) =
         context.getText(
             when (this) {
-                Permissions -> R.string.setup__request_permmision
+                Permissions -> R.string.setup__request_permission
                 Enable -> R.string.setup__enable_ime
                 Select -> R.string.setup__select_ime
             },
         )
 
-    fun getButtonAction(context: Context) {
-        when (this) {
-            Permissions -> context.requestExternalStoragePermission()
-            Enable -> InputMethodUtils.showImeEnablerActivity(context)
-            Select -> InputMethodUtils.showImePicker()
-        }
-    }
-
     fun isDone() =
         when (this) {
-            Permissions -> appContext.isStorageAvailable()
+            Permissions -> AppPrefs.defaultInstance().profile.isUserDataDirChosen()
             Enable -> InputMethodUtils.checkIsTrimeEnabled()
             Select -> InputMethodUtils.checkIsTrimeSelected()
         }

--- a/app/src/main/java/com/osfans/trime/util/ResourceUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ResourceUtils.kt
@@ -13,6 +13,7 @@ object ResourceUtils {
         dest: File,
         removedPrefix: String = "",
     ) = runCatching {
+        Timber.d("CopyFiles %s -> %s", filename, File(dest, filename.removePrefix(removedPrefix)).absolutePath)
         appContext.assets.open(filename).use { i ->
             File(dest, filename.removePrefix(removedPrefix))
                 .also { it.parentFile?.mkdirs() }
@@ -34,6 +35,7 @@ object ResourceUtils {
                     acc + copyFiles("$assetPath/$file", File(destFile, formattedDestPath), file).getOrDefault(0L)
                 }
             } else {
+                Timber.d("CopyFiles %s -> %s", assetPath, File(destFile, formattedDestPath.split(File.pathSeparator).last()).absolutePath)
                 appContext.assets.open(assetPath).use { i ->
                     File(destFile, formattedDestPath.split(File.pathSeparator).last())
                         .also { it.parentFile?.mkdirs() }

--- a/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
@@ -21,6 +21,7 @@ import com.blankj.utilcode.util.IntentUtils
 import com.osfans.trime.core.Rime
 import com.osfans.trime.daemon.RimeDaemon
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.storage.FolderExport
 import com.osfans.trime.ime.core.TrimeInputMethodService
 import com.osfans.trime.ime.symbol.SymbolBoardType
 import com.osfans.trime.ui.main.LiquidKeyboardEditActivity
@@ -144,7 +145,14 @@ object ShortcutUtils {
         val prefs = AppPrefs.defaultInstance()
         prefs.profile.lastBackgroundSync = Date().time.toString()
         CoroutineScope(Dispatchers.IO).launch {
-            prefs.profile.lastSyncStatus = Rime.syncRimeUserData().also { RimeDaemon.restartRime() }
+            prefs.profile.lastSyncStatus = sync()
+        }
+    }
+
+    suspend fun sync(fullCheck: Boolean = false): Boolean{
+        return Rime.syncRimeUserData().also {
+            FolderExport.exportSyncDir()
+            RimeDaemon.restartRime(fullCheck)
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
@@ -149,10 +149,12 @@ object ShortcutUtils {
         }
     }
 
-    suspend fun sync(fullCheck: Boolean = false): Boolean{
-        return Rime.syncRimeUserData().also {
-            FolderExport.exportSyncDir()
+    suspend fun sync(fullCheck: Boolean = false): Boolean {
+        return if (Rime.syncRimeUserData()) {
             RimeDaemon.restartRime(fullCheck)
+            return FolderExport.exportSyncDir()
+        } else {
+            false
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/util/Utils.kt
+++ b/app/src/main/java/com/osfans/trime/util/Utils.kt
@@ -18,11 +18,8 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.preference.Preference
 import androidx.recyclerview.widget.RecyclerView
-import com.blankj.utilcode.util.ToastUtils
-import com.hjq.permissions.OnPermissionCallback
 import com.hjq.permissions.Permission
 import com.hjq.permissions.XXPermissions
-import com.osfans.trime.R
 import com.osfans.trime.TrimeApplication
 import splitties.experimental.InternalSplittiesApi
 import splitties.resources.withResolvedThemeAttribute
@@ -110,38 +107,6 @@ fun Preference.optionalPreference() {
 inline fun Context.isStorageAvailable(): Boolean {
     return XXPermissions.isGranted(this, Permission.MANAGE_EXTERNAL_STORAGE) &&
         Environment.getExternalStorageDirectory().absolutePath.isNotEmpty()
-}
-
-fun Context.requestExternalStoragePermission() {
-    XXPermissions.with(this)
-        .permission(Permission.MANAGE_EXTERNAL_STORAGE)
-        .request(
-            object : OnPermissionCallback {
-                override fun onGranted(
-                    permissions: List<String>,
-                    all: Boolean,
-                ) {
-                    if (all) {
-                        ToastUtils.showShort(R.string.external_storage_permission_granted)
-                    }
-                }
-
-                override fun onDenied(
-                    permissions: List<String>,
-                    never: Boolean,
-                ) {
-                    if (never) {
-                        ToastUtils.showShort(R.string.external_storage_permission_denied)
-                        XXPermissions.startPermissionActivity(
-                            this@requestExternalStoragePermission,
-                            permissions,
-                        )
-                    } else {
-                        ToastUtils.showShort(R.string.external_storage_permission_denied)
-                    }
-                }
-            },
-        )
 }
 
 fun Configuration.isNightMode() = uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES

--- a/app/src/main/res/layout/folder_picker_dialog.xml
+++ b/app/src/main/res/layout/folder_picker_dialog.xml
@@ -13,14 +13,13 @@ SPDX-License-Identifier: GPL-3.0-or-later
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <EditText
+    <TextView
         android:id="@+id/editText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="5dp"
         android:ems="10"
-        android:inputType="textPersonName"
         app:layout_constraintEnd_toStartOf="@+id/button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/folder_picker_dialog.xml
+++ b/app/src/main/res/layout/folder_picker_dialog.xml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="horizontal"
+    android:layout_margin="8dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -22,7 +22,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
         android:ems="10"
         app:layout_constraintEnd_toStartOf="@+id/button"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
     <Button
         android:id="@+id/button"
@@ -34,5 +35,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/editText"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:ignore="HardcodedText" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -134,10 +134,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__hook_candidate_commit">点击候选词后，模拟空格键完成上屏(暂未实现)</string>
     <string name="trime_app_slogan">击响中文之韵</string>
     <string name="directory_not_selected">未设定配置文件的文件夹</string>
-    <string name="external_storage_access_required">同文输入法需要存储权限以部署或读取方案和配置，点击“确定”前往授权。</string>
-    <string name="external_storage_permission_not_available">存储权限不可用</string>
-    <string name="external_storage_permission_granted">已授予存储权限</string>
-    <string name="external_storage_permission_denied">已拒绝授权存储权限，部署或读取方案和配置功能或不可用</string>
     <string name="alert_window_access_required">同文输入法需要允许显示在其他应用上方以能显示应用外悬浮窗或对话框，点击“确定”以授权。</string>
     <string name="keyboard__key_sound_effect_title">按键音效</string>
     <string name="sound_progress">正在应用音效...</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -262,8 +262,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__split_title">转换到横屏键盘</string>
     <string name="keyboard__split_space_title">自动分割键盘比例</string>
     <string name="setup__step_three">第 3 步</string>
-    <string name="setup__request_permmision_hint">当前同文需要存储权限以访问配置、使得用户容易更改。</string>
-    <string name="setup__request_permmision">请求存储权限</string>
+    <string name="setup__request_permission_hint">请选择存放配置文件的文件夹 (如 "rime")</string>
+    <string name="setup__request_permission">选择文件夹</string>
     <string name="grant_permission">授予权限</string>
     <string name="schedule_exact_alarm_permission_title">没有闹钟和提醒权限</string>
     <string name="schedule_exact_alarm_permission_message">没有闹钟和提醒权限，我们无法在启用定时同步时及时为您同步数据配置。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -133,6 +133,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__hook_candidate">点击候选词</string>
     <string name="keyboard__hook_candidate_commit">点击候选词后，模拟空格键完成上屏(暂未实现)</string>
     <string name="trime_app_slogan">击响中文之韵</string>
+    <string name="directory_not_selected">未设定配置文件的文件夹</string>
     <string name="external_storage_access_required">同文输入法需要存储权限以部署或读取方案和配置，点击“确定”前往授权。</string>
     <string name="external_storage_permission_not_available">存储权限不可用</string>
     <string name="external_storage_permission_granted">已授予存储权限</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -94,6 +94,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="profile_timing_sync">定时同步</string>
     <string name="profile_timing_sync_trigger_time">已开启定时同步 下次同步时间: %1$s</string>
     <string name="profile_enable_timing_sync">点击以开启定时同步</string>
+    <string name="profile__error_user_data_dir">请到「配置管理」设定相关资料。</string>
     <string name="pref_help__marketplace">应用市场</string>
     <string name="pref_help__user_community">用户社区</string>
     <string name="pref_keyboard__effect">按键效果</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -204,6 +204,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <item name="100">100</item>
     </string-array>
     <string name="pref_toolkit">工具箱</string>
+    <string name="pref_toolkit_internal_dir">內部文件夹</string>
     <string name="system">系统</string>
     <string name="export">导出</string>
     <string name="scroll_to_bottom">跳到最后</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -274,6 +274,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="enable_schemata">启用方案</string>
     <string name="no_schema_to_select">当前没有方案可选择。请前往启用方案。</string>
     <string name="no_schema_to_enable">没有方案可启用。请确保您已在用户文件夹中放入了前置文件和方案文件。</string>
+    <string name="no_schema_before_deploy">没有方案可使用。请先进行「部署」。</string>
     <string name="schemata">方案</string>
     <string name="schemata_hint">选择当前方案或启用更多方案</string>
     <string name="navbar_background">导航栏背景</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -289,4 +289,5 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="theme_trime">默认</string>
     <string name="theme_tongwenfeng">同文风</string>
     <string name="pref__clear">清除</string>
+    <string name="share">共享</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -288,4 +288,5 @@ SPDX-License-Identifier: GPL-3.0-or-later
     </string-array>
     <string name="theme_trime">默认</string>
     <string name="theme_tongwenfeng">同文风</string>
+    <string name="pref__clear">清除</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -263,8 +263,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__split_title">轉換到橫屏鍵盤</string>
     <string name="keyboard__split_space_title">自動分割鍵盤比例</string>
     <string name="setup__step_three">第 3 步</string>
-    <string name="setup__request_permmision_hint">當前同文須要存儲權限以訪問配置檔案、使得使用者容易修改。</string>
-    <string name="setup__request_permmision">请求存储权限</string>
+    <string name="setup__request_permission_hint">請選擇存放配置檔案的資料夾 (如 "rime")</string>
+    <string name="setup__request_permission">選擇資料夾</string>
     <string name="grant_permission">授予權限</string>
     <string name="schedule_exact_alarm_permission_title">沒有鬧鐘和提醒權限</string>
     <string name="schedule_exact_alarm_permission_message">尚未賦予鬧鐘和提醒權限，因此無法在啟用定時同步時及時為您同步資料配置。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -98,6 +98,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="profile_timing_sync">定時同步</string>
     <string name="profile_timing_sync_trigger_time">已啟用定時同步 下次同步時間: %1$s</string>
     <string name="profile_enable_timing_sync">點擊以啟用定時同步</string>
+    <string name="profile__error_user_data_dir">請到「配置管理」設定相關資料。</string>
     <string name="pref_help__marketplace">應用市場</string>
     <string name="pref_help__user_community">使用者社群</string>
     <string name="pref_keyboard__function">檢視</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -137,10 +137,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__hook_candidate_commit">點擊候選詞後，模擬空格鍵完成上屏(暫未實現)</string>
     <string name="trime_app_slogan">擊響中文之韻</string>
     <string name="directory_not_selected">未設定配置文件的資料夾</string>
-    <string name="external_storage_access_required">同文輸入法需要儲存許可權以部署或讀取方案和配置，點選“確定”前往授權。</string>
-    <string name="external_storage_permission_not_available">儲存許可權不可用</string>
-    <string name="external_storage_permission_granted">已授予儲存許可權</string>
-    <string name="external_storage_permission_denied">已拒絕授權儲存許可權，部署或讀取方案和配置功能或不可用</string>
     <string name="alert_window_access_required">同文輸入法需要允許顯示在其他應用上方以能顯示應用外懸浮窗或對話方塊，點選“確定”以授權。</string>
     <string name="keyboard__key_sound_effect_title">按鍵音效</string>
     <string name="sound_progress">正在應用音效...</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -136,6 +136,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__hook_candidate">點擊候選詞</string>
     <string name="keyboard__hook_candidate_commit">點擊候選詞後，模擬空格鍵完成上屏(暫未實現)</string>
     <string name="trime_app_slogan">擊響中文之韻</string>
+    <string name="directory_not_selected">未設定配置文件的資料夾</string>
     <string name="external_storage_access_required">同文輸入法需要儲存許可權以部署或讀取方案和配置，點選“確定”前往授權。</string>
     <string name="external_storage_permission_not_available">儲存許可權不可用</string>
     <string name="external_storage_permission_granted">已授予儲存許可權</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -217,6 +217,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="clear">清除畫面</string>
     <string name="system">系統</string>
     <string name="pref_toolkit">工具箱</string>
+    <string name="pref_toolkit_internal_dir">內部資料夾</string>
     <string name="exception_logcat_created">Logcat 行程已建立</string>
     <string name="pref_about">關於</string>
     <string name="pref_theme_and_color">主題與配色</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -275,6 +275,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="enable_schemata">啓用方案</string>
     <string name="no_schema_to_select">當前沒有方案可選擇。請前往啟用方案。</string>
     <string name="no_schema_to_enable">沒有方案可啟用。請確保您已在使用者資料夾中放入了前置檔案和方案檔案。</string>
+    <string name="no_schema_before_deploy">沒有方案可使用。請先進行「部署」。</string>
     <string name="schemata">方案</string>
     <string name="schemata_hint">選擇當前方案或啓用更多方案</string>
     <string name="navbar_background">導航欄背景</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -290,4 +290,5 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="theme_trime">預設</string>
     <string name="theme_tongwenfeng">同文風</string>
     <string name="pref__clear">清除</string>
+    <string name="share">共享</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -289,4 +289,5 @@ SPDX-License-Identifier: GPL-3.0-or-later
     </string-array>
     <string name="theme_trime">預設</string>
     <string name="theme_tongwenfeng">同文風</string>
+    <string name="pref__clear">清除</string>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -21,5 +21,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
     <declare-styleable name="FolderPickerPreferenceAttrs">
         <attr name="useSimpleSummaryProvider" />
+        <attr name="showDefaultButton" format="boolean" />
+        <attr name="defaultButtonLabel" format="reference|string" />
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="profile_timing_sync">Timing sync</string>
     <string name="profile_timing_sync_trigger_time">Timing sync is enabled Next sync at time: %1$s</string>
     <string name="profile_enable_timing_sync">Click to enable</string>
+    <string name="profile__error_user_data_dir">Please set it in &quot;Profile&quot;.</string>
     <string name="pref_help__marketplace">Marketplace</string>
     <string name="pref_help__user_community">User Community</string>
     <string name="pref_keyboard__function">View</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="enable_schemata">Enable schemata</string>
     <string name="no_schema_to_select">Currently there is no schema to select. Please go to enable schemata from the available list.</string>
     <string name="no_schema_to_enable">No schema to enable. Make sure you have prelude and schema files in the user directory.</string>
+    <string name="no_schema_before_deploy">No schema to select.  Please "Deploy" first.</string>
     <string name="schemata">Schemata</string>
     <string name="schemata_hint">Select current schema or enable more schemata</string>
     <string name="navbar_background">Navigation bar background</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,4 +290,5 @@ SPDX-License-Identifier: GPL-3.0-or-later
     </string-array>
     <string name="theme_trime">default</string>
     <string name="theme_tongwenfeng">tongwenfeng</string>
+    <string name="pref__clear">Clear</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,10 +141,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__hook_candidate_commit">Send Space when click candidate (coming soon)</string>
     <string name="trime_app_slogan">Trimes with Your Keystrokes</string>
     <string name="directory_not_selected">Working folder is not yet set.</string>
-    <string name="external_storage_access_required">Trime needs to access external storage to deploy or read schemas and config, tap OK to grant the permission.</string>
-    <string name="external_storage_permission_not_available">External storage permission is not available</string>
-    <string name="external_storage_permission_granted">External storage permission is granted</string>
-    <string name="external_storage_permission_denied">External storage permission was denied, deployment or reading schemas and config may not be available</string>
     <string name="alert_window_access_required">Trime needs alert window permission to show up popup window or dialog, tap OK to grant the permission.</string>
     <string name="keyboard__key_sound_effect_title">Key Sound Effect</string>
     <string name="sound_progress">Loading sound...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,4 +291,5 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="theme_trime">default</string>
     <string name="theme_tongwenfeng">tongwenfeng</string>
     <string name="pref__clear">Clear</string>
+    <string name="share">Share</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="scroll_to_bottom">Jump to Bottom</string>
     <string name="system">System</string>
     <string name="pref_toolkit">Toolkit</string>
+    <string name="pref_toolkit_internal_dir">Internal Directory</string>
     <string name="reset__asset_is_null_or_empty">This path points to a empty directory or null pointer.</string>
     <string name="pref_profile">Profile</string>
     <string name="pref_keyboard">Keyboard settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,11 +264,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__split_title">Change to Landscape keyboard</string>
     <string name="keyboard__split_space_title">Auto Split Keyboard Space Ratio</string>
     <string name="setup__step_three">Setup 3</string>
-    <string name="setup__request_permmision_hint">Currently Trime requests storage permmissions to access its configuration\nand allow users to modify easily.</string>
-    <string name="setup__request_permmision">Request storage permmision</string>
+    <string name="setup__request_permission_hint">Please select a directory(e.g. "rime") where configuration files reside.</string>
+    <string name="setup__request_permission">Select folder</string>
     <string name="grant_permission">Grant permission</string>
-    <string name="schedule_exact_alarm_permission_title">No Schedule Exact Alarm Permmision</string>
-    <string name="schedule_exact_alarm_permission_message">Without the permmission to schedule exact alarm, we are not able to sync your profile in time when you enable syncing on schedule.</string>
+    <string name="schedule_exact_alarm_permission_title">No Schedule Exact Alarm Permission</string>
+    <string name="schedule_exact_alarm_permission_message">Without the permission to schedule exact alarm, we are not able to sync your profile in time when you enable syncing on schedule.</string>
     <string name="notification_permission_title">No Notification Permission</string>
     <string name="notification_permission_message">Without the permission to post notifications, we are not able to notify you when some time-consuming operations are done.</string>
     <string name="rime_daemon">Rime Daemon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__hook_candidate">Click candidate</string>
     <string name="keyboard__hook_candidate_commit">Send Space when click candidate (coming soon)</string>
     <string name="trime_app_slogan">Trimes with Your Keystrokes</string>
+    <string name="directory_not_selected">Working folder is not yet set.</string>
     <string name="external_storage_access_required">Trime needs to access external storage to deploy or read schemas and config, tap OK to grant the permission.</string>
     <string name="external_storage_permission_not_available">External storage permission is not available</string>
     <string name="external_storage_permission_granted">External storage permission is granted</string>
@@ -264,7 +265,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__split_title">Change to Landscape keyboard</string>
     <string name="keyboard__split_space_title">Auto Split Keyboard Space Ratio</string>
     <string name="setup__step_three">Setup 3</string>
-    <string name="setup__request_permission_hint">Please select a directory(e.g. "rime") where configuration files reside.</string>
+    <string name="setup__request_permission_hint">Please select a folder(e.g. "rime") where configuration files reside.</string>
     <string name="setup__request_permission">Select folder</string>
     <string name="grant_permission">Grant permission</string>
     <string name="schedule_exact_alarm_permission_title">No Schedule Exact Alarm Permission</string>

--- a/app/src/main/res/xml/profile_preference.xml
+++ b/app/src/main/res/xml/profile_preference.xml
@@ -16,6 +16,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             app:iconSpaceReserved="false"
             android:title="@string/profile_shared_data_dir"
             app:persistent="true"
+            app:defaultButtonLabel="@string/pref__clear"
             app:useSimpleSummaryProvider="true" />
 
         <com.osfans.trime.ui.components.FolderPickerPreference
@@ -23,6 +24,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             app:iconSpaceReserved="false"
             android:title="@string/profile_user_data_dir"
             app:persistent="true"
+            app:showDefaultButton="false"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1186
Fixes #1096
Refs #997

#### Feature
如我在 #1186 描述的方法。「手動部署」(主頁面中按「部署」)時，Trime 會將 `/sdcard/rime` 的資料複製到內置目錄 `/sdcard/Android/data/com.osfans.trime` 中使用。之後所有的運作會在 `/sdcard/Android/data/com.osfans.trime` 中進行。而為了方便測試主題，每次切換「主題」時也會將相關的主題文件覆寫一次到內置目錄。

關於效能方面，「手動部置」和「同步」所需的時間一定有所增加。我的 `rime`文件夾 約 50MB，需時多了約 20 秒 (取決於你的配置文件大小和手機效能)。平常的文字輸入或切換輸入法等效能不變。

而為了改善效能，以下檔案不會覆製

- 內部檔案跟外部檔案大小一樣 (_若文件只修改一個 character 的話，因為大小一樣便不會複製。這條件有待商榷。_)
- `build` 資料夾
- `userdb` 資料夾


另外， Trime 也會覆寫以下檔案回到 `/sdcard/rime`：

- `default.custom.yaml` (選擇方案後)
- `user.yaml` (啟用不同方案後)
- `/sync` (同步後)


最後，在「工具箱」中新增「內部資料夾」選項，可透過 Android 內置的 `DocumentsUI` 瀏覽內置目錄。

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [X] `make sytle-lint`
- [X] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

