### PR TITLE
fix: crashes when trying to insert using liquid keyboard candidate.

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/CandidateAdapter.kt
@@ -40,7 +40,7 @@ class CandidateAdapter(theme: Theme) : RecyclerView.Adapter<CandidateAdapter.Vie
     fun updateCandidates(candidates: List<CandidateListItem>) {
         mCandidates.clear()
         mCandidates.addAll(candidates)
-        notifyDataSetChanged()
+        notifyItemRangeChanged(0, candidates.size)
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -10,6 +10,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ItemAnimator
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
@@ -45,6 +46,7 @@ class LiquidKeyboard(
     private val symbolHistory = SymbolHistory(180)
     private lateinit var currentBoardType: SymbolBoardType
     private lateinit var currentBoardAdapter: RecyclerView.Adapter<*>
+    private var defaultKeyboardAnimation: ItemAnimator? = null
 
     private val simpleAdapter by lazy {
         val itemWidth = context.dp(theme.liquid.getInt("single_width"))
@@ -185,6 +187,9 @@ class LiquidKeyboard(
                 adapter = simpleAdapter
                 setItemViewCacheSize(10)
                 setHasFixedSize(true)
+                defaultKeyboardAnimation?.let {
+                    keyboardView.itemAnimator = it
+                }
                 // 添加分割线
                 // 设置添加删除动画
                 // 调用ListView的setSelected(!ListView.isSelected())方法，这样就能及时刷新布局
@@ -203,6 +208,9 @@ class LiquidKeyboard(
                 adapter = dbAdapter
                 setItemViewCacheSize(10)
                 setHasFixedSize(false)
+                defaultKeyboardAnimation?.let {
+                    keyboardView.itemAnimator = it
+                }
                 // 调用ListView的setSelected(!ListView.isSelected())方法，这样就能及时刷新布局
                 isSelected = true
             }
@@ -220,8 +228,11 @@ class LiquidKeyboard(
                 layoutManager = flexboxLayoutManager
                 adapter = varLengthAdapter
                 setItemViewCacheSize(50)
-                // CandidateAdapter现在使用notifyItemRangeChanged，下面禁用layout变化的缺省动画。
-                keyboardView.itemAnimator = null
+                // CandidateAdapter现在使用notifyItemRangeChanged，保存并禁用layout变化的缺省动画。
+                keyboardView.itemAnimator?.let {
+                    defaultKeyboardAnimation = it
+                    keyboardView.itemAnimator = null
+                }
                 setHasFixedSize(false)
                 isSelected = true
             }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -220,6 +220,8 @@ class LiquidKeyboard(
                 layoutManager = flexboxLayoutManager
                 adapter = varLengthAdapter
                 setItemViewCacheSize(50)
+                // CandidateAdapter现在使用notifyItemRangeChanged，下面禁用layout变化的缺省动画。
+                keyboardView.itemAnimator = null
                 setHasFixedSize(false)
                 isSelected = true
             }


### PR DESCRIPTION
This can also fix the problem that invisible TextView objects' widths are not updated after updating candidates.
我看了一下以前的修改记录
0f1ad698b8df705f706659d782db5db52de38e01这个commit从

```
notifyItemRangeRemoved(0, prevSize)
notifyItemRangeInserted(0, candidates.size)、
```
改成了
```
notifyDataSetChanged()
```
但是notifyDataSetChanged()似乎有两个问题，一个是我在https://github.com/osfans/trime/issues/1409 里提到的crash，不知道哪个index out of bound了。
还有一个就是notifyDataSetChanged似乎只invalidate可见的text，以及Text View的宽度。这样导致选字之后Text View的宽度不会改变。如果原来的TextView从一个字符变成两个字符会分行。

我对Android的开发也就是刚开始看的水平。所以这个修改是不是最优解可能需要进一步的讨论。

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1409

#### Feature
Describe features of this pull request

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [ ] `make sytle-lint`
- [ ] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

