### PR TITLE
use unified landscape mode

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
@@ -85,7 +85,7 @@ class AppPrefs(
             const val FLOATING_WINDOW_ENABLED = "keyboard__show_window"
             const val POPUP_KEY_PRESS_ENABLED = "keyboard__show_key_popup"
             const val SWITCHES_ENABLED = "keyboard__show_switches"
-            const val SPLIT = "keyboard__split"
+            const val LANDSCAPE_MODE = "keyboard__landscape_mode"
             const val SPLIT_SPACE_PERCENT = "keyboard__split_space"
             const val SWITCH_ARROW_ENABLED = "keyboard__show_switch_arrow"
             const val FULLSCREEN_MODE = "keyboard__fullscreen_mode"
@@ -134,14 +134,14 @@ class AppPrefs(
         val switchesEnabled by bool(SWITCHES_ENABLED, true)
         val switchArrowEnabled by bool(SWITCH_ARROW_ENABLED, true)
 
-        enum class SplitOption {
+        enum class LandscapeModeOption {
             NEVER,
             LANDSCAPE,
             AUTO,
             ALWAYS,
         }
 
-        val splitOption by enum(SPLIT, SplitOption.NEVER)
+        val landscapeModeOption by enum(LANDSCAPE_MODE, LandscapeModeOption.NEVER)
         val splitSpacePercent by int(SPLIT_SPACE_PERCENT, 100)
         val candidatePageSize by string(CANDIDATE_PAGE_SIZE, "0")
 

--- a/app/src/main/java/com/osfans/trime/ime/composition/Composition.kt
+++ b/app/src/main/java/com/osfans/trime/ime/composition/Composition.kt
@@ -102,8 +102,12 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
     private var onActionMove: ((Float, Float) -> Unit)? = null
 
     private val stickyLines: Int
-        get() = if (context.isLandscapeMode()) theme.generalStyle.layout.stickyLinesLand
-        else theme.generalStyle.layout.stickyLines
+        get() =
+            if (context.isLandscapeMode()) {
+                theme.generalStyle.layout.stickyLinesLand
+            } else {
+                theme.generalStyle.layout.stickyLines
+            }
 
     private enum class Movable {
         ALWAYS,
@@ -418,9 +422,11 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                 for (component in windowComponents) {
                     when {
                         component.move.isNotBlank() -> buildSpannedMove(component)
-                        component.composition.isNotBlank() -> buildSpannedComposition(
-                            component, inputContext.composition
-                        )
+                        component.composition.isNotBlank() ->
+                            buildSpannedComposition(
+                                component,
+                                inputContext.composition,
+                            )
 
                         component.click.isNotBlank() -> buildSpannedButton(component)
                         component.candidate.isNotBlank() ->

--- a/app/src/main/java/com/osfans/trime/ime/composition/Composition.kt
+++ b/app/src/main/java/com/osfans/trime/ime/composition/Composition.kt
@@ -38,9 +38,11 @@ import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.data.theme.model.CompositionComponent
 import com.osfans.trime.ime.core.TrimeInputMethodService
 import com.osfans.trime.ime.keyboard.Event
+import com.osfans.trime.ime.keyboard.KeyboardPrefs.isLandscapeMode
 import com.osfans.trime.ime.keyboard.KeyboardSwitcher
 import com.osfans.trime.ime.text.Candidate
 import com.osfans.trime.ime.text.TextInputManager
+import com.osfans.trime.util.appContext
 import com.osfans.trime.util.sp
 import splitties.dimensions.dp
 import kotlin.math.absoluteValue
@@ -102,11 +104,8 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
     private var onActionMove: ((Float, Float) -> Unit)? = null
 
     private val stickyLines: Int
-        get() =
-            when (resources.configuration.orientation) {
-                Configuration.ORIENTATION_LANDSCAPE -> theme.generalStyle.layout.stickyLinesLand
-                else -> theme.generalStyle.layout.stickyLines
-            }
+        get() = if (appContext.isLandscapeMode()) theme.generalStyle.layout.stickyLinesLand
+        else theme.generalStyle.layout.stickyLines
 
     private enum class Movable {
         ALWAYS,
@@ -223,6 +222,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                     }
                 }
             }
+
             MotionEvent.ACTION_MOVE -> {
                 if (movable != Movable.NEVER) {
                     if (touched in movableRange[0]..movableRange[1]) {
@@ -237,6 +237,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                     }
                 }
             }
+
             MotionEvent.ACTION_UP -> {
                 if (touched in preeditRange[0]..preeditRange[1]) {
                     val s =
@@ -419,7 +420,10 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
                 for (component in windowComponents) {
                     when {
                         component.move.isNotBlank() -> buildSpannedMove(component)
-                        component.composition.isNotBlank() -> buildSpannedComposition(component, inputContext.composition)
+                        component.composition.isNotBlank() -> buildSpannedComposition(
+                            component, inputContext.composition
+                        )
+
                         component.click.isNotBlank() -> buildSpannedButton(component)
                         component.candidate.isNotBlank() ->
                             buildSpannedCandidates(

--- a/app/src/main/java/com/osfans/trime/ime/composition/Composition.kt
+++ b/app/src/main/java/com/osfans/trime/ime/composition/Composition.kt
@@ -6,7 +6,6 @@ package com.osfans.trime.ime.composition
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.res.Configuration
 import android.graphics.Typeface
 import android.text.Layout
 import android.text.SpannableStringBuilder
@@ -42,7 +41,6 @@ import com.osfans.trime.ime.keyboard.KeyboardPrefs.isLandscapeMode
 import com.osfans.trime.ime.keyboard.KeyboardSwitcher
 import com.osfans.trime.ime.text.Candidate
 import com.osfans.trime.ime.text.TextInputManager
-import com.osfans.trime.util.appContext
 import com.osfans.trime.util.sp
 import splitties.dimensions.dp
 import kotlin.math.absoluteValue
@@ -104,7 +102,7 @@ class Composition(context: Context, attrs: AttributeSet?) : TextView(context, at
     private var onActionMove: ((Float, Float) -> Unit)? = null
 
     private val stickyLines: Int
-        get() = if (appContext.isLandscapeMode()) theme.generalStyle.layout.stickyLinesLand
+        get() = if (context.isLandscapeMode()) theme.generalStyle.layout.stickyLinesLand
         else theme.generalStyle.layout.stickyLines
 
     private enum class Movable {

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -6,7 +6,6 @@ package com.osfans.trime.ime.core
 
 import android.annotation.SuppressLint
 import android.app.Dialog
-import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Build
 import android.view.View
@@ -36,7 +35,6 @@ import com.osfans.trime.ime.keyboard.KeyboardPrefs.isLandscapeMode
 import com.osfans.trime.ime.keyboard.KeyboardWindow
 import com.osfans.trime.ime.symbol.LiquidKeyboard
 import com.osfans.trime.util.ColorUtils
-import com.osfans.trime.util.appContext
 import com.osfans.trime.util.styledFloat
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -120,14 +118,14 @@ class InputView(
     private val keyboardSidePaddingPx: Int
         get() {
             val value =
-                if (appContext.isLandscapeMode()) keyboardSidePaddingLandscape else keyboardSidePadding
+                if (context.isLandscapeMode()) keyboardSidePaddingLandscape else keyboardSidePadding
             return dp(value)
         }
 
     private val keyboardBottomPaddingPx: Int
         get() {
             val value =
-                if (appContext.isLandscapeMode()) keyboardBottomPaddingLandscape else keyboardBottomPadding
+                if (context.isLandscapeMode()) keyboardBottomPaddingLandscape else keyboardBottomPadding
             return dp(value)
         }
 

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -32,9 +32,11 @@ import com.osfans.trime.ime.bar.QuickBar
 import com.osfans.trime.ime.composition.CompositionPopupWindow
 import com.osfans.trime.ime.dependency.InputComponent
 import com.osfans.trime.ime.dependency.create
+import com.osfans.trime.ime.keyboard.KeyboardPrefs.isLandscapeMode
 import com.osfans.trime.ime.keyboard.KeyboardWindow
 import com.osfans.trime.ime.symbol.LiquidKeyboard
 import com.osfans.trime.util.ColorUtils
+import com.osfans.trime.util.appContext
 import com.osfans.trime.util.styledFloat
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -118,20 +120,14 @@ class InputView(
     private val keyboardSidePaddingPx: Int
         get() {
             val value =
-                when (resources.configuration.orientation) {
-                    Configuration.ORIENTATION_LANDSCAPE -> keyboardSidePaddingLandscape
-                    else -> keyboardSidePadding
-                }
+                if (appContext.isLandscapeMode()) keyboardSidePaddingLandscape else keyboardSidePadding
             return dp(value)
         }
 
     private val keyboardBottomPaddingPx: Int
         get() {
             val value =
-                when (resources.configuration.orientation) {
-                    Configuration.ORIENTATION_LANDSCAPE -> keyboardBottomPaddingLandscape
-                    else -> keyboardBottomPadding
-                }
+                if (appContext.isLandscapeMode()) keyboardBottomPaddingLandscape else keyboardBottomPadding
             return dp(value)
         }
 

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -59,6 +59,7 @@ import com.osfans.trime.util.ShortcutUtils
 import com.osfans.trime.util.ShortcutUtils.openCategory
 import com.osfans.trime.util.WeakHashSet
 import com.osfans.trime.util.findSectionFrom
+import com.osfans.trime.util.isLandscape
 import com.osfans.trime.util.isNightMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -1115,7 +1116,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
 
     override fun onEvaluateFullscreenMode(): Boolean {
         val config = resources.configuration
-        if (config == null || config.orientation != Configuration.ORIENTATION_LANDSCAPE) return false
+        if (config == null || !resources.configuration.isLandscape()) return false
         return when (prefs.keyboard.fullscreenMode) {
             FullscreenMode.AUTO_SHOW -> {
                 Timber.d("FullScreen: Auto")

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -4,7 +4,6 @@
 
 package com.osfans.trime.ime.keyboard
 
-import android.content.res.Configuration
 import android.view.KeyEvent
 import com.osfans.trime.data.prefs.AppPrefs.Companion.defaultInstance
 import com.osfans.trime.data.theme.EventManager
@@ -425,8 +424,11 @@ class Keyboard() {
         val keyboardHeight = theme.generalStyle.keyboardHeight
         val keyboardHeightLand = theme.generalStyle.keyboardHeightLand
         val value =
-            if (appContext.isLandscapeMode()) keyboardHeightLand.takeIf { it > 0 } ?: keyboardHeight
-            else keyboardHeight
+            if (appContext.isLandscapeMode()) {
+                keyboardHeightLand.takeIf { it > 0 } ?: keyboardHeight
+            } else {
+                keyboardHeight
+            }
         return appContext.dp(value)
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -17,7 +17,6 @@ import com.osfans.trime.util.CollectionUtils.obtainInt
 import com.osfans.trime.util.CollectionUtils.obtainString
 import com.osfans.trime.util.appContext
 import com.osfans.trime.util.config.ConfigMap
-import com.osfans.trime.util.isLandscape
 import com.osfans.trime.util.sp
 import splitties.dimensions.dp
 import timber.log.Timber
@@ -426,16 +425,14 @@ class Keyboard() {
         val keyboardHeight = theme.generalStyle.keyboardHeight
         val keyboardHeightLand = theme.generalStyle.keyboardHeightLand
         val value =
-            when (appContext.resources.configuration.orientation) {
-                Configuration.ORIENTATION_LANDSCAPE -> keyboardHeightLand.takeIf { it > 0 } ?: keyboardHeight
-                else -> keyboardHeight
-            }
+            if (appContext.isLandscapeMode()) keyboardHeightLand.takeIf { it > 0 } ?: keyboardHeight
+            else keyboardHeight
         return appContext.dp(value)
     }
 
     private fun getKeyboardHeightFromKeyboardConfig(keyboardConfig: Map<String, Any?>?): Int {
         var mkeyboardHeight = appContext.sp(obtainFloat(keyboardConfig, "keyboard_height", 0f)).toInt()
-        if (appContext.resources.configuration.isLandscape()) {
+        if (appContext.isLandscapeMode()) {
             val mkeyBoardHeightLand =
                 appContext.sp(
                     obtainFloat(keyboardConfig, "keyboard_height_land", 0f),
@@ -643,11 +640,7 @@ class Keyboard() {
 
         val keyboardSidePaddingPx =
             appContext.dp(
-                if (appContext.resources.configuration.isLandscape()) {
-                    keyboardSidePaddingLandscape
-                } else {
-                    keyboardSidePadding
-                },
+                if (appContext.isLandscapeMode()) keyboardSidePaddingLandscape else keyboardSidePadding,
             )
 
         mDisplayWidth = appContext.resources.displayMetrics.widthPixels - 2 * keyboardSidePaddingPx

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardPrefs.kt
@@ -14,10 +14,10 @@ object KeyboardPrefs {
     private const val WIDE_SCREEN_WIDTH_DP = 600
 
     fun Context.isLandscapeMode(): Boolean {
-        return when (prefs.keyboard.splitOption) {
-            AppPrefs.Keyboard.SplitOption.AUTO -> isWideScreen()
-            AppPrefs.Keyboard.SplitOption.LANDSCAPE -> resources.configuration.isLandscape()
-            AppPrefs.Keyboard.SplitOption.ALWAYS -> true
+        return when (prefs.keyboard.landscapeModeOption) {
+            AppPrefs.Keyboard.LandscapeModeOption.AUTO -> resources.configuration.isLandscape() || isWideScreen()
+            AppPrefs.Keyboard.LandscapeModeOption.LANDSCAPE -> resources.configuration.isLandscape()
+            AppPrefs.Keyboard.LandscapeModeOption.ALWAYS -> true
             else -> false
         }
     }

--- a/app/src/main/java/com/osfans/trime/ui/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/KeyboardFragment.kt
@@ -46,7 +46,7 @@ class KeyboardFragment :
             "keyboard__key_long_press_timeout",
             "keyboard__key_repeat_interval",
             "keyboard__show_key_popup",
-            AppPrefs.Keyboard.SPLIT, AppPrefs.Keyboard.SPLIT_SPACE_PERCENT,
+            AppPrefs.Keyboard.LANDSCAPE_MODE, AppPrefs.Keyboard.SPLIT_SPACE_PERCENT,
             "keyboard__show_window",
             "keyboard__inline_preedit", "keyboard__soft_cursor",
             -> {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -58,10 +58,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <item>输入码</item>
         <item>无</item>
     </string-array>
-    <string-array name="keyboard__split_entries">
+    <string-array name="keyboard__landscape_mode_entries">
         <item>永不</item>
         <item>只在横屏时</item>
-        <item>在阔萤幕或横屏时</item>
+        <item>在屏幕较宽或横屏时</item>
         <item>永远都是</item>
     </string-array>
     <string-array name="other__ui_mode_entries" >
@@ -259,7 +259,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__custom_key_sound">使用自定义按键音</string>
 
     <string name="pref_keyboard__landscape">横屏模式</string>
-    <string name="keyboard__split_title">转换到横屏键盘</string>
+    <string name="keyboard__landscape_mode_title">启用横屏模式</string>
     <string name="keyboard__split_space_title">自动分割键盘比例</string>
     <string name="setup__step_three">第 3 步</string>
     <string name="setup__request_permmision_hint">当前同文需要存储权限以访问配置、使得用户容易更改。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -61,7 +61,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <item>輸入碼</item>
         <item>無</item>
     </string-array>
-    <string-array name="keyboard__split_entries">
+    <string-array name="keyboard__landscape_mode_entries">
         <item>永不</item>
         <item>只在橫屏時</item>
         <item>在闊螢幕或橫屏時</item>
@@ -260,7 +260,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__custom_key_sound">使用自訂按鍵音</string>
 
     <string name="pref_keyboard__landscape">橫向模式</string>
-    <string name="keyboard__split_title">轉換到橫屏鍵盤</string>
+    <string name="keyboard__landscape_mode_title">啟用橫屏模式</string>
     <string name="keyboard__split_space_title">自動分割鍵盤比例</string>
     <string name="setup__step_three">第 3 步</string>
     <string name="setup__request_permmision_hint">當前同文須要存儲權限以訪問配置檔案、使得使用者容易修改。</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <item>input</item>
         <item>none</item>
     </string-array>
-    <string-array name="keyboard__split_values">
+    <string-array name="keyboard__landscape_mode_values">
         <item>NEVER</item>
         <item>LANDSCAPE</item>
         <item>AUTO</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <item>Input</item>
         <item>None</item>
     </string-array>
-    <string-array name="keyboard__split_entries">
+    <string-array name="keyboard__landscape_mode_entries">
         <item>Never</item>
         <item>Only in landscape mode</item>
         <item>Auto (In wide screen or landscape mode)</item>
@@ -261,7 +261,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="keyboard__custom_key_sound">Use custom key sound</string>
 
     <string name="pref_keyboard__landscape">Landscape Mode</string>
-    <string name="keyboard__split_title">Change to Landscape keyboard</string>
+    <string name="keyboard__landscape_mode_title">Enable Landscape Mode</string>
     <string name="keyboard__split_space_title">Auto Split Keyboard Space Ratio</string>
     <string name="setup__step_three">Setup 3</string>
     <string name="setup__request_permmision_hint">Currently Trime requests storage permmissions to access its configuration\nand allow users to modify easily.</string>

--- a/app/src/main/res/xml/keyboard_preference.xml
+++ b/app/src/main/res/xml/keyboard_preference.xml
@@ -42,10 +42,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
         app:title="@string/pref_keyboard__landscape">
         <ListPreference
             android:defaultValue="never"
-            android:entries="@array/keyboard__split_entries"
-            android:entryValues="@array/keyboard__split_values"
-            android:key="keyboard__split"
-            android:title="@string/keyboard__split_title"
+            android:entries="@array/keyboard__landscape_mode_entries"
+            android:entryValues="@array/keyboard__landscape_mode_values"
+            android:key="keyboard__landscape_mode"
+            android:title="@string/keyboard__landscape_mode_title"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Feature
[文档](https://github.com/osfans/trime/wiki/trime.yaml-%E8%A9%B3%E8%A7%A3)中有「横屏模式」的概念，#1191 添加了Landscape Keyboard，但是「横屏模式」的含义并不清晰，也不能很好地适配折叠屏等设备。这个PR将Landscape Mode设置项应用到其他使用横屏布局的判断中（除了`onEvaluateFullscreenMode`没有更改），在设置了「启用横屏模式」，`keyboardSidePadding`等参数将会使用对应横屏模式的值（这也与文档中的描述一致）。

这样的设置主要考虑了以下几种设备：
- 普通手机：竖屏时屏幕宽度较窄，横屏时较宽，需要不同的键盘设置，这里设为`AUTO`或`LANDSCAPE`都可以正常在横竖屏中切换。
- 平板：竖屏或横屏时屏幕宽度都较宽，如果横竖屏需要不同的键盘设置，设为`LANDSCAPE`，否则设为`AUTO`会使用竖屏设置，设为`NEVER`会使用横屏设置。
- 折叠屏手机：折叠时和普通手机一致，展开时横竖屏比例较为接近，设为`AUTO`可以使展开状态和横屏使用横屏设置，折叠状态竖屏使用竖屏设置。
- 竖折屏手机：展开时和普通手机一致，折叠时无论横屏和竖屏屏幕宽度都较窄，但折叠时应该没有使用输入法的需求。

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [ ] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info
设置项的名称改变会导致此设置被重置，此外PR改变了现有设置的逻辑，可能需要更多讨论。
