### PR TITLE
fix: ime could not follow the keyboard's ascii mode after switching

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
@@ -83,6 +83,9 @@ class KeyboardWindow(
         currentKeyboard?.let {
             if (it.isLock) lastLockKeyboardId = target
             dispatchCapsState(it::setShifted)
+            if (Rime.isAsciiMode != it.currentAsciiMode) {
+                Rime.setOption("ascii_mode", it.currentAsciiMode)
+            }
             // TODO：为避免过量重构，这里暂时将 currentKeyboard 同步到 KeyboardSwitcher
             KeyboardSwitcher.currentKeyboard = it
             mainKeyboardView.keyboard = it
@@ -202,8 +205,6 @@ class KeyboardWindow(
                 } else {
                     if (Rime.isAsciiMode) Rime.setOption("ascii_mode", false)
                 }
-            } else if (Rime.isAsciiMode != it.currentAsciiMode) {
-                Rime.setOption("ascii_mode", it.currentAsciiMode)
             }
         }
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

fix: ime could not follow the keyboard's ascii mode after switching

A small issue caused by #1432 

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

