### PR TITLE
Split out the switches display from the candidate view

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,7 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     implementation(libs.androidx.viewpager2)
     implementation(libs.flexbox)
+    implementation(libs.bravh)
     implementation(libs.kaml)
     implementation(libs.timber)
     implementation(libs.xxpermissions)

--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -6,7 +6,6 @@ package com.osfans.trime.core
 
 import com.osfans.trime.data.base.DataManager
 import com.osfans.trime.data.opencc.OpenCCDictManager
-import com.osfans.trime.data.prefs.AppPrefs
 import com.osfans.trime.data.schema.SchemaManager
 import com.osfans.trime.util.appContext
 import com.osfans.trime.util.isAsciiPrintable
@@ -254,17 +253,6 @@ class Rime : RimeApi, RimeLifecycleOwner {
                 updateContext()
             }
         }
-
-        @JvmStatic
-        val candidatesOrStatusSwitches: Array<CandidateListItem>
-            get() {
-                val showSwitches = AppPrefs.defaultInstance().keyboard.switchesEnabled
-                return if (!isComposing && showSwitches) {
-                    SchemaManager.getStatusSwitches()
-                } else {
-                    inputContext?.candidates ?: arrayOf()
-                }
-            }
 
         val candidatesWithoutSwitch: Array<CandidateListItem>
             get() = if (isComposing) inputContext?.candidates ?: arrayOf() else arrayOf()

--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -96,6 +96,19 @@ class Rime : RimeApi, RimeLifecycleOwner {
             updateContext()
         }
 
+    override suspend fun setRuntimeOption(
+        option: String,
+        value: Boolean,
+    ): Unit =
+        withRimeContext {
+            setRimeOption(option, value)
+        }
+
+    override suspend fun getRuntimeOption(option: String): Boolean =
+        withRimeContext {
+            getRimeOption(option)
+        }
+
     private fun handleRimeNotification(notif: RimeNotification<*>) {
         when (notif) {
             is RimeNotification.SchemaNotification -> schemaItemCached = notif.value

--- a/app/src/main/java/com/osfans/trime/core/RimeApi.kt
+++ b/app/src/main/java/com/osfans/trime/core/RimeApi.kt
@@ -34,4 +34,11 @@ interface RimeApi {
     suspend fun commitComposition(): Boolean
 
     suspend fun clearComposition()
+
+    suspend fun setRuntimeOption(
+        option: String,
+        value: Boolean,
+    )
+
+    suspend fun getRuntimeOption(option: String): Boolean
 }

--- a/app/src/main/java/com/osfans/trime/data/schema/SchemaManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/schema/SchemaManager.kt
@@ -4,14 +4,13 @@
 
 package com.osfans.trime.data.schema
 
-import com.osfans.trime.core.CandidateListItem
 import com.osfans.trime.core.Rime
 import com.osfans.trime.data.prefs.AppPrefs
 import kotlinx.serialization.builtins.ListSerializer
 
 object SchemaManager {
     private lateinit var currentSchema: Schema
-    private lateinit var visibleSwitches: List<Schema.Switch>
+    lateinit var visibleSwitches: List<Schema.Switch>
 
     private val arrow get() = AppPrefs.defaultInstance().keyboard.switchArrowEnabled
 
@@ -42,40 +41,6 @@ object SchemaManager {
                     // 需要 coerceAtLeast 确保其至少为 0
                     s.options.indexOfFirst { Rime.getRimeOption(it) }.coerceAtLeast(0)
                 }
-        }
-    }
-
-    @JvmStatic
-    fun toggleSwitchOption(index: Int) {
-        if (!this::visibleSwitches.isInitialized || visibleSwitches.isEmpty()) return
-        val switch = visibleSwitches[index]
-        val enabled = switch.enabled
-        switch.enabled =
-            if (switch.options.isNullOrEmpty()) {
-                (1 - enabled).also { Rime.setOption(switch.name!!, it == 1) }
-            } else {
-                val options = switch.options
-                ((enabled + 1) % options.size).also {
-                    Rime.setOption(options[enabled], false)
-                    Rime.setOption(options[it], true)
-                }
-            }
-    }
-
-    @JvmStatic
-    fun getStatusSwitches(): Array<CandidateListItem> {
-        if (!this::visibleSwitches.isInitialized || visibleSwitches.isEmpty()) return arrayOf()
-        return Array(visibleSwitches.size) {
-            val switch = visibleSwitches[it]
-            val enabled = switch.enabled
-            val text = switch.states!![enabled]
-            val comment =
-                if (switch.options.isNullOrEmpty()) {
-                    "${if (arrow) "→ " else ""}${switch.states[1 - enabled]}"
-                } else {
-                    ""
-                }
-            CandidateListItem(comment, text)
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
@@ -14,6 +14,7 @@ import com.osfans.trime.core.RimeNotification.OptionNotification
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.databinding.CandidateBarBinding
+import com.osfans.trime.ime.bar.ui.TabUi
 import com.osfans.trime.ime.broadcast.InputBroadcastReceiver
 import com.osfans.trime.ime.core.TrimeInputMethodService
 import com.osfans.trime.ime.dependency.InputScope

--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
@@ -38,6 +38,9 @@ class QuickBar(context: Context, service: TrimeInputMethodService, rime: RimeSes
 
     private val showSwitchers get() = prefs.keyboard.switchesEnabled
 
+    val themedHeight =
+        theme.generalStyle.candidateViewHeight + theme.generalStyle.commentHeight
+
     private fun evalAlwaysUiState() {
         val newState =
             when {

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/AlwaysUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/AlwaysUi.kt
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2015 - 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.bar.ui
+
+import android.content.Context
+import android.widget.Space
+import android.widget.ViewAnimator
+import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.ime.bar.ui.always.switches.SwitchesUi
+import splitties.views.dsl.constraintlayout.centerInParent
+import splitties.views.dsl.constraintlayout.constraintLayout
+import splitties.views.dsl.constraintlayout.lParams
+import splitties.views.dsl.constraintlayout.matchConstraints
+import splitties.views.dsl.core.Ui
+import splitties.views.dsl.core.add
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import timber.log.Timber
+
+class AlwaysUi(
+    override val ctx: Context,
+    private val theme: Theme,
+) : Ui {
+    enum class State {
+        Empty,
+        Switchers,
+    }
+
+    var currentState = State.Empty
+        private set
+
+    val emptyBar = Space(ctx)
+
+    val switchesUi = SwitchesUi(ctx, theme)
+
+    private val animator =
+        ViewAnimator(ctx).apply {
+            add(emptyBar, lParams(matchParent, matchParent))
+            add(switchesUi.root, lParams(matchParent, matchParent))
+        }
+
+    override val root =
+        constraintLayout {
+            add(
+                animator,
+                lParams(matchConstraints, matchParent) {
+                    centerInParent()
+                },
+            )
+        }
+
+    fun updateState(state: State) {
+        Timber.d("Switch always ui to $state")
+        when (state) {
+            State.Empty -> animator.displayedChild = 0
+            State.Switchers -> animator.displayedChild = 1
+        }
+        currentState = state
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/TabUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/TabUi.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.osfans.trime.ime.bar
+package com.osfans.trime.ime.bar.ui
 
 import android.content.Context
 import android.view.View

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchUi.kt
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2015 - 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.bar.ui.always.switches
+
+import android.content.Context
+import com.osfans.trime.data.theme.ColorManager
+import com.osfans.trime.data.theme.FontManager
+import com.osfans.trime.data.theme.Theme
+import splitties.views.dsl.core.Ui
+import splitties.views.dsl.core.add
+import splitties.views.dsl.core.frameLayout
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.textView
+import splitties.views.gravityCenter
+
+class SwitchUi(override val ctx: Context, private val theme: Theme) : Ui {
+    var enabled: Int = -1
+
+    private val label =
+        textView {
+            textSize = theme.generalStyle.candidateTextSize.toFloat()
+            typeface = FontManager.getTypeface("candidate_font")
+            ColorManager.getColor("candidate_text_color")?.let { setTextColor(it) }
+        }
+
+    override val root =
+        frameLayout {
+            add(label, lParams { gravity = gravityCenter })
+        }
+
+    fun setLabel(str: String) {
+        label.text = str
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchUi.kt
@@ -5,15 +5,27 @@
 package com.osfans.trime.ime.bar.ui.always.switches
 
 import android.content.Context
+import android.view.View
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
+import splitties.dimensions.dp
+import splitties.views.dsl.constraintlayout.above
+import splitties.views.dsl.constraintlayout.after
+import splitties.views.dsl.constraintlayout.before
+import splitties.views.dsl.constraintlayout.below
+import splitties.views.dsl.constraintlayout.bottomOfParent
+import splitties.views.dsl.constraintlayout.centerHorizontally
+import splitties.views.dsl.constraintlayout.centerVertically
+import splitties.views.dsl.constraintlayout.constraintLayout
+import splitties.views.dsl.constraintlayout.endOfParent
+import splitties.views.dsl.constraintlayout.lParams
+import splitties.views.dsl.constraintlayout.startOfParent
+import splitties.views.dsl.constraintlayout.topOfParent
 import splitties.views.dsl.core.Ui
 import splitties.views.dsl.core.add
-import splitties.views.dsl.core.frameLayout
-import splitties.views.dsl.core.lParams
 import splitties.views.dsl.core.textView
-import splitties.views.gravityCenter
+import splitties.views.dsl.core.wrapContent
 
 class SwitchUi(override val ctx: Context, private val theme: Theme) : Ui {
     var enabled: Int = -1
@@ -25,12 +37,64 @@ class SwitchUi(override val ctx: Context, private val theme: Theme) : Ui {
             ColorManager.getColor("candidate_text_color")?.let { setTextColor(it) }
         }
 
+    private val altLabel =
+        textView {
+            textSize = theme.generalStyle.commentTextSize.toFloat()
+            typeface = FontManager.getTypeface("comment_font")
+            ColorManager.getColor("comment_text_color")?.let { setTextColor(it) }
+            visibility = View.GONE
+        }
+
     override val root =
-        frameLayout {
-            add(label, lParams { gravity = gravityCenter })
+        constraintLayout {
+            layoutParams = lParams(wrapContent, wrapContent)
+            if (theme.generalStyle.commentOnTop) {
+                add(
+                    altLabel,
+                    lParams(wrapContent, wrapContent) {
+                        bottomMargin = dp(-3)
+                        topOfParent()
+                        above(label)
+                        centerHorizontally()
+                    },
+                )
+                add(
+                    label,
+                    lParams(wrapContent, wrapContent) {
+                        topMargin = dp(-3)
+                        below(altLabel)
+                        centerHorizontally()
+                        bottomOfParent()
+                    },
+                )
+            } else {
+                add(
+                    label,
+                    lParams(wrapContent, wrapContent) {
+                        startOfParent()
+                        before(altLabel)
+                        centerVertically()
+                    },
+                )
+                add(
+                    altLabel,
+                    lParams(wrapContent, wrapContent) {
+                        after(label)
+                        centerVertically()
+                        endOfParent()
+                    },
+                )
+            }
         }
 
     fun setLabel(str: String) {
         label.text = str
+    }
+
+    fun setAltLabel(str: String) {
+        altLabel.text = str
+        if (altLabel.visibility == View.GONE) {
+            altLabel.visibility = View.VISIBLE
+        }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchesAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchesAdapter.kt
@@ -8,11 +8,14 @@ import android.content.Context
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.chad.library.adapter4.BaseQuickAdapter
+import com.osfans.trime.data.prefs.AppPrefs
 import com.osfans.trime.data.schema.Schema
 import com.osfans.trime.data.theme.Theme
 
 class SwitchesAdapter(private val theme: Theme) :
     BaseQuickAdapter<Schema.Switch, SwitchesAdapter.Holder>() {
+    private val showArrow = AppPrefs.defaultInstance().keyboard.switchArrowEnabled
+
     inner class Holder(val ui: SwitchUi) : RecyclerView.ViewHolder(ui.root)
 
     override fun onCreateViewHolder(
@@ -31,6 +34,17 @@ class SwitchesAdapter(private val theme: Theme) :
         holder.ui.apply {
             val enabled = item!!.enabled
             setLabel(item.states!![enabled])
+            if (item.options.isNullOrEmpty()) {
+                val text =
+                    item.states[1 - enabled].let {
+                        if (showArrow) {
+                            "→ $it"
+                        } else {
+                            it
+                        }
+                    }
+                setAltLabel(text)
+            }
         }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchesAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchesAdapter.kt
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2015 - 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.bar.ui.always.switches
+
+import android.content.Context
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.chad.library.adapter4.BaseQuickAdapter
+import com.osfans.trime.data.schema.Schema
+import com.osfans.trime.data.theme.Theme
+
+class SwitchesAdapter(private val theme: Theme) :
+    BaseQuickAdapter<Schema.Switch, SwitchesAdapter.Holder>() {
+    inner class Holder(val ui: SwitchUi) : RecyclerView.ViewHolder(ui.root)
+
+    override fun onCreateViewHolder(
+        context: Context,
+        parent: ViewGroup,
+        viewType: Int,
+    ): Holder {
+        return Holder(SwitchUi(context, theme))
+    }
+
+    override fun onBindViewHolder(
+        holder: Holder,
+        position: Int,
+        item: Schema.Switch?,
+    ) {
+        holder.ui.apply {
+            val enabled = item!!.enabled
+            setLabel(item.states!![enabled])
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchesUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/always/switches/SwitchesUi.kt
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2015 - 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.bar.ui.always.switches
+
+import android.content.Context
+import android.view.ViewGroup
+import com.chad.library.adapter4.util.setOnDebouncedItemClick
+import com.osfans.trime.data.schema.Schema
+import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.ime.symbol.SpacesItemDecoration
+import splitties.dimensions.dp
+import splitties.views.dsl.core.Ui
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.recyclerview.recyclerView
+import splitties.views.recyclerview.horizontalLayoutManager
+
+class SwitchesUi(override val ctx: Context, val theme: Theme) : Ui {
+    private val switchesAdapter by lazy {
+        SwitchesAdapter(theme)
+    }
+
+    override val root =
+        recyclerView {
+            layoutParams = ViewGroup.LayoutParams(matchParent, matchParent)
+            layoutManager = horizontalLayoutManager()
+            adapter = switchesAdapter
+            addItemDecoration(SpacesItemDecoration(dp(3)))
+        }
+
+    fun setSwitches(list: List<Schema.Switch>) {
+        switchesAdapter.submitList(list)
+    }
+
+    fun setOnSwitchClick(listener: (Schema.Switch) -> Unit) {
+        switchesAdapter.setOnDebouncedItemClick { adapter, _, position ->
+            val typed = (adapter as SwitchesAdapter)
+            if (typed.items.isEmpty()) return@setOnDebouncedItemClick
+            val switch = typed.items[position]
+            listener(switch)
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcastReceiver.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcastReceiver.kt
@@ -6,6 +6,7 @@ package com.osfans.trime.ime.broadcast
 
 import android.view.inputmethod.EditorInfo
 import com.osfans.trime.core.RimeNotification.OptionNotification
+import com.osfans.trime.core.SchemaItem
 import com.osfans.trime.ime.window.BoardWindow
 
 interface InputBroadcastReceiver {
@@ -15,6 +16,8 @@ interface InputBroadcastReceiver {
         start: Int,
         end: Int,
     ) {}
+
+    fun onRimeSchemaUpdated(schema: SchemaItem) {}
 
     fun onRimeOptionUpdated(value: OptionNotification.Value) {}
 

--- a/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcaster.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcaster.kt
@@ -6,6 +6,7 @@ package com.osfans.trime.ime.broadcast
 
 import android.view.inputmethod.EditorInfo
 import com.osfans.trime.core.RimeNotification.OptionNotification
+import com.osfans.trime.core.SchemaItem
 import com.osfans.trime.ime.dependency.InputScope
 import com.osfans.trime.ime.window.BoardWindow
 import me.tatarka.inject.annotations.Inject
@@ -41,6 +42,10 @@ class InputBroadcaster : InputBroadcastReceiver {
         end: Int,
     ) {
         receivers.forEach { it.onSelectionUpdate(start, end) }
+    }
+
+    override fun onRimeSchemaUpdated(schema: SchemaItem) {
+        receivers.forEach { it.onRimeSchemaUpdated(schema) }
     }
 
     override fun onRimeOptionUpdated(value: OptionNotification.Value) {

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -308,6 +308,9 @@ class InputView(
 
     private fun handleRimeNotification(it: RimeNotification<*>) {
         when (it) {
+            is RimeNotification.SchemaNotification -> {
+                broadcaster.onRimeSchemaUpdated(it.value)
+            }
             is RimeNotification.OptionNotification -> {
                 broadcaster.onRimeOptionUpdated(it.value)
             }
@@ -351,6 +354,11 @@ class InputView(
             }
         } else {
             candidateView.setText(0)
+        }
+        if (Rime.isComposing) {
+            quickBar.switchUiByState(QuickBar.State.Candidate)
+        } else {
+            quickBar.switchUiByState(QuickBar.State.Always)
         }
         mainKeyboardView.invalidateComposingKeys()
     }

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -197,7 +197,7 @@ class InputView(
                 )
                 add(
                     quickBar.view,
-                    lParams(matchParent, wrapContent) {
+                    lParams(matchParent, dp(quickBar.themedHeight)) {
                         topOfParent()
                         centerHorizontally()
                     },

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
@@ -112,12 +112,7 @@ class Candidate(
         widthMeasureSpec: Int,
         heightMeasureSpec: Int,
     ) {
-        val h =
-            if (shouldShowComment && isCommentOnTop) {
-                candidateViewHeight + commentHeight
-            } else {
-                candidateViewHeight
-            }
+        val h = candidateViewHeight + commentHeight
         setMeasuredDimension(
             MeasureSpec.makeMeasureSpec(widthMeasureSpec, MeasureSpec.UNSPECIFIED),
             MeasureSpec.makeMeasureSpec(h, MeasureSpec.AT_MOST),

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.kt
@@ -383,7 +383,7 @@ class Candidate(
 
     private fun updateCandidates() {
         candidates.clear()
-        candidates.addAll(Rime.candidatesOrStatusSwitches)
+        candidates.addAll(Rime.candidatesWithoutSwitch)
         highlightIndex = Rime.candHighlightIndex - startNum
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/text/TextInputManager.kt
@@ -409,12 +409,7 @@ class TextInputManager(
      */
     override fun onCandidatePressed(index: Int) {
         onPress(0)
-        if (!Rime.isComposing) {
-            if (index >= 0) {
-                SchemaManager.toggleSwitchOption(index)
-                trime.updateComposing()
-            }
-        } else if (prefs.keyboard.hookCandidate || index > 9) {
+        if (prefs.keyboard.hookCandidate || index > 9) {
             if (Rime.selectCandidate(index)) {
                 if (prefs.keyboard.hookCandidateCommit) {
                     // todo 找到切换高亮候选词的API，并把此处改为模拟移动候选后发送空格

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version = "1.1.0" }
 flexbox = { module = "com.google.android.flexbox:flexbox", version = "3.0.0" }
+bravh = { module = "io.github.cymchad:BaseRecyclerViewAdapterHelper4", version = "4.1.4" }
 kaml = { module = "com.charleskorn.kaml:kaml", version = "0.56.0" }
 timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
 xxpermissions = { module = "com.github.getActivity:XXPermissions", version = "18.5" }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

This PR is to split out the switch display from candidate view, and put it in the new created AlwaysUi, which is a container to hold several resident views. By the way, I introduce [BaseRecyclerViewAdapterHelper](https://github.com/CymChad/BaseRecyclerViewAdapterHelper) to help with creating RecyclerView adapter.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

