### PR TITLE
Fix deprecated function usage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,8 +4,6 @@
 
 @file:Suppress("UnstableApiUsage")
 
-import org.gradle.configurationcache.extensions.capitalized
-
 plugins {
     id("com.osfans.trime.native-app-convention")
     id("com.osfans.trime.data-checksums")
@@ -110,7 +108,7 @@ ksp {
 }
 
 android.applicationVariants.all {
-    val variantName = name.capitalized()
+    val variantName = name.replaceFirstChar { it.uppercase() }
     tasks.findByName("generateDataChecksums")?.also {
         tasks.getByName("merge${variantName}Assets").dependsOn(it)
     }


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

```
app/build.gradle.kts:113:28: 'capitalized(): String' is deprecated. This was never intended as a public API.
```
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/capitalize.html
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/replace-first-char.html

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

