### PR TITLE
Fix Again `KP_X` Issue

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -243,7 +243,13 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
                                 handleReturnKey()
                                 return
                             }
-                            sendDownKeyEvent(eventTime, keyCode, it.modifiers.metaState)
+
+                            if (keyCode in KeyEvent.KEYCODE_NUMPAD_0..KeyEvent.KEYCODE_NUMPAD_EQUALS) {
+                                // ignore KP_X keys, which is handled in `CommonKeyboardActionListener`.
+                                // Requires this empty body becoz Kotlin request it
+                            } else {
+                                sendDownKeyEvent(eventTime, keyCode, it.modifiers.metaState)
+                            }
                         }
                     } else {
                         if (!it.modifiers.release && it.unicode > 0) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
@@ -297,6 +297,15 @@ class CommonKeyboardActionListener(
 
                     when (keyEventCode) {
                         KeyEvent.KEYCODE_BACK -> service.requestHideSelf(0)
+                        else -> {
+                            // 小键盘自动增加锁定
+                            if (keyEventCode in KeyEvent.KEYCODE_NUMPAD_0..KeyEvent.KEYCODE_NUMPAD_EQUALS) {
+                                service.sendDownUpKeyEvent(
+                                    keyEventCode,
+                                    metaState or KeyEvent.META_NUM_LOCK_ON,
+                                )
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1524

#### Feature
My bad.  Previous fix in f83d28cb5f748ff5342e339566bc35bcb1a108e4 will cause `KP_X` keys not working in normal text field. 
This fix will let `KP_X` working correctly in normal & number text field.

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [X] `make sytle-lint`
- [X] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

