### PR TITLE
Add Autofill for Inline Suggestion Support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.autofill)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.navigation.fragment)

--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
@@ -21,9 +21,10 @@ import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.ime.bar.ui.AlwaysUi
 import com.osfans.trime.ime.bar.ui.CandidateUi
+import com.osfans.trime.ime.bar.ui.SuggestionUi
 import com.osfans.trime.ime.bar.ui.TabUi
 import com.osfans.trime.ime.broadcast.InputBroadcastReceiver
-import com.osfans.trime.ime.candidates.compact.CompactCandidateModule
+import com.osfans.trime.ime.candidates.CandidateModule
 import com.osfans.trime.ime.candidates.unrolled.window.FlexboxUnrolledCandidateWindow
 import com.osfans.trime.ime.core.TrimeInputMethodService
 import com.osfans.trime.ime.dependency.InputScope
@@ -44,9 +45,9 @@ class QuickBar(
     private val rime: RimeSession,
     private val theme: Theme,
     private val windowManager: BoardWindowManager,
-    lazyCompactCandidate: Lazy<CompactCandidateModule>,
+    lazyCandidate: Lazy<CandidateModule>,
 ) : InputBroadcastReceiver {
-    private val compactCandidate by lazyCompactCandidate
+    private val candidate by lazyCandidate
 
     private val prefs = AppPrefs.defaultInstance()
 
@@ -93,7 +94,7 @@ class QuickBar(
     }
 
     private val candidateUi by lazy {
-        CandidateUi(context, compactCandidate.view)
+        CandidateUi(context, candidate.compactCandidateModule.view)
     }
 
     private val tabUi by lazy {
@@ -125,7 +126,7 @@ class QuickBar(
     private fun setUnrollButtonToAttach() {
         candidateUi.unrollButton.setOnClickListener {
             windowManager.attachWindow(
-                FlexboxUnrolledCandidateWindow(context, service, rime, theme, this, windowManager, compactCandidate),
+                FlexboxUnrolledCandidateWindow(context, service, rime, theme, this, windowManager, candidate.compactCandidateModule),
             )
         }
         candidateUi.unrollButton.setIcon(R.drawable.ic_baseline_expand_more_24)

--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
@@ -97,6 +97,17 @@ class QuickBar(
         CandidateUi(context, candidate.compactCandidateModule.view)
     }
 
+    private val suggestionUi by lazy {
+        SuggestionUi(context, candidate.suggestionCandidateModule.view).apply {
+            homeButton.setOnClickListener {
+                barStateMachine.push(
+                    QuickBarStateMachine.TransitionEvent.SuggestionUpdated,
+                    QuickBarStateMachine.BooleanKey.SuggestionEmpty to true,
+                )
+            }
+        }
+    }
+
     private val tabUi by lazy {
         TabUi(context)
     }
@@ -183,6 +194,7 @@ class QuickBar(
             add(alwaysUi.root, lParams(matchParent, matchParent))
             add(candidateUi.root, lParams(matchParent, matchParent))
             add(tabUi.root, lParams(matchParent, matchParent))
+            add(suggestionUi.root, lParams(matchParent, matchParent))
 
             evalAlwaysUiState()
         }
@@ -225,5 +237,12 @@ class QuickBar(
 
     override fun onWindowDetached(window: BoardWindow) {
         barStateMachine.push(QuickBarStateMachine.TransitionEvent.WindowDetached)
+    }
+
+    override fun onInlineSuggestion(views: List<View>) {
+        barStateMachine.push(
+            QuickBarStateMachine.TransitionEvent.SuggestionUpdated,
+            QuickBarStateMachine.BooleanKey.SuggestionEmpty to views.isEmpty(),
+        )
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBarStateMachine.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBarStateMachine.kt
@@ -8,8 +8,10 @@
 package com.osfans.trime.ime.bar
 
 import com.osfans.trime.ime.bar.QuickBarStateMachine.BooleanKey.CandidateEmpty
+import com.osfans.trime.ime.bar.QuickBarStateMachine.BooleanKey.SuggestionEmpty
 import com.osfans.trime.ime.bar.QuickBarStateMachine.State.Always
 import com.osfans.trime.ime.bar.QuickBarStateMachine.State.Candidate
+import com.osfans.trime.ime.bar.QuickBarStateMachine.State.Suggestion
 import com.osfans.trime.ime.bar.QuickBarStateMachine.State.Tab
 import com.osfans.trime.util.BuildTransitionEvent
 import com.osfans.trime.util.EventStateMachine
@@ -20,10 +22,12 @@ object QuickBarStateMachine {
         Always,
         Candidate,
         Tab,
+        Suggestion,
     }
 
     enum class BooleanKey : EventStateMachine.BooleanStateKey {
         CandidateEmpty,
+        SuggestionEmpty,
     }
 
     enum class TransitionEvent(
@@ -32,15 +36,22 @@ object QuickBarStateMachine {
         CandidatesUpdated({
             from(Always) transitTo Candidate on (CandidateEmpty to false)
             from(Candidate) transitTo Always on (CandidateEmpty to true)
+            from(Suggestion) transitTo Candidate on (CandidateEmpty to false)
         }),
         BarBoardWindowAttached({
             from(Always) transitTo Tab
             from(Candidate) transitTo Tab
+            from(Suggestion) transitTo Tab
         }),
         WindowDetached({
             // candidate state has higher priority so here it goes first
             from(Tab) transitTo Candidate on (CandidateEmpty to false)
+            from(Tab) transitTo Suggestion on (SuggestionEmpty to false)
             from(Tab) transitTo Always
+        }),
+        SuggestionUpdated({
+            from(Always) transitTo Suggestion on (SuggestionEmpty to false)
+            from(Suggestion) transitTo Always on (SuggestionEmpty to true)
         }),
     }
 
@@ -50,6 +61,7 @@ object QuickBarStateMachine {
             externalBooleanStates =
                 mutableMapOf(
                     CandidateEmpty to true,
+                    SuggestionEmpty to true,
                 ),
         ).apply {
             onNewStateListener = block

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/SuggestionUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/SuggestionUi.kt
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.bar.ui
+
+import android.content.Context
+import android.view.View
+import com.osfans.trime.R
+import splitties.dimensions.dp
+import splitties.views.dsl.constraintlayout.after
+import splitties.views.dsl.constraintlayout.centerVertically
+import splitties.views.dsl.constraintlayout.constraintLayout
+import splitties.views.dsl.constraintlayout.endOfParent
+import splitties.views.dsl.constraintlayout.lParams
+import splitties.views.dsl.constraintlayout.startOfParent
+import splitties.views.dsl.core.Ui
+import splitties.views.dsl.core.add
+
+class SuggestionUi(
+    override val ctx: Context,
+    private val compatView: View,
+) : Ui {
+    val homeButton =
+        ToolButton(ctx, R.drawable.ic_trime_status)
+
+    override val root =
+        ctx.constraintLayout {
+            add(
+                homeButton,
+                lParams(dp(40)) {
+                    centerVertically()
+                    startOfParent()
+                },
+            )
+            add(
+                compatView,
+                lParams {
+                    centerVertically()
+                    after(homeButton)
+                    endOfParent()
+                },
+            )
+        }
+}

--- a/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcastReceiver.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcastReceiver.kt
@@ -4,6 +4,7 @@
 
 package com.osfans.trime.ime.broadcast
 
+import android.view.View
 import android.view.inputmethod.EditorInfo
 import com.osfans.trime.core.RimeMessage
 import com.osfans.trime.core.RimeProto
@@ -29,4 +30,6 @@ interface InputBroadcastReceiver {
     fun onWindowDetached(window: BoardWindow) {}
 
     fun onEnterKeyLabelUpdate(label: String) {}
+
+    fun onInlineSuggestion(views: List<View>) {}
 }

--- a/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcaster.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcaster.kt
@@ -4,6 +4,7 @@
 
 package com.osfans.trime.ime.broadcast
 
+import android.view.View
 import android.view.inputmethod.EditorInfo
 import com.osfans.trime.core.RimeMessage
 import com.osfans.trime.core.RimeProto
@@ -67,5 +68,9 @@ class InputBroadcaster : InputBroadcastReceiver {
 
     override fun onEnterKeyLabelUpdate(label: String) {
         receivers.forEach { it.onEnterKeyLabelUpdate(label) }
+    }
+
+    override fun onInlineSuggestion(views: List<View>) {
+        receivers.forEach { it.onInlineSuggestion(views) }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/candidates/CandidateModule.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/CandidateModule.kt
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2025 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.candidates
+
+import android.content.Context
+import com.osfans.trime.daemon.RimeSession
+import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.ime.bar.QuickBar
+import com.osfans.trime.ime.candidates.compact.CompactCandidateModule
+import com.osfans.trime.ime.candidates.suggestion.SuggestionCandidateModule
+import com.osfans.trime.ime.core.TrimeInputMethodService
+import com.osfans.trime.ime.dependency.InputScope
+import me.tatarka.inject.annotations.Inject
+
+@InputScope
+@Inject
+class CandidateModule(
+    val context: Context,
+    val service: TrimeInputMethodService,
+    val rime: RimeSession,
+    val theme: Theme,
+    val bar: QuickBar,
+) {
+    val compactCandidateModule = CompactCandidateModule(context, service, rime, theme, bar)
+    val suggestionCandidateModule = SuggestionCandidateModule(context, service, rime, theme, bar)
+}

--- a/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateModule.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateModule.kt
@@ -29,20 +29,16 @@ import com.osfans.trime.ime.bar.UnrollButtonStateMachine
 import com.osfans.trime.ime.broadcast.InputBroadcastReceiver
 import com.osfans.trime.ime.candidates.unrolled.decoration.FlexboxVerticalDecoration
 import com.osfans.trime.ime.core.TrimeInputMethodService
-import com.osfans.trime.ime.dependency.InputScope
 import com.osfans.trime.ime.keyboard.InputFeedbackManager
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import me.tatarka.inject.annotations.Inject
 import splitties.dimensions.dp
 import splitties.views.dsl.recyclerview.recyclerView
 import kotlin.math.max
 
-@InputScope
-@Inject
 class CompactCandidateModule(
     val context: Context,
     val service: TrimeInputMethodService,

--- a/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/InlineSuggestionHandler.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/InlineSuggestionHandler.kt
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2025 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.candidates.suggestion
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.util.Size
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.InlineSuggestionsRequest
+import android.view.inputmethod.InlineSuggestionsResponse
+import android.widget.inline.InlinePresentationSpec
+import androidx.annotation.RequiresApi
+import androidx.autofill.inline.UiVersions
+import androidx.autofill.inline.common.ImageViewStyle
+import androidx.autofill.inline.common.TextViewStyle
+import androidx.autofill.inline.common.ViewStyle
+import androidx.autofill.inline.v1.InlineSuggestionUi
+import androidx.core.graphics.ColorUtils
+import com.osfans.trime.R
+import com.osfans.trime.data.theme.ColorManager
+import splitties.dimensions.dp
+import java.util.concurrent.Executor
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class InlineSuggestionHandler(
+    private val context: Context,
+) {
+    @SuppressLint("NewApi", "RestrictedApi")
+    fun createRequest(): InlineSuggestionsRequest {
+        val firstTextColor = ColorManager.getColor("candidate_text_color")!!
+        val backColor = ColorManager.getColor("candidate_background")!!
+
+        val style =
+            InlineSuggestionUi
+                .newStyleBuilder()
+                .setSingleIconChipStyle(
+                    ViewStyle
+                        .Builder()
+                        .setBackgroundColor(Color.TRANSPARENT)
+                        .setPadding(0, 0, 0, 0)
+                        .build(),
+                ).setChipStyle(
+                    ViewStyle
+                        .Builder()
+                        .setBackground(
+                            Icon.createWithResource(context, R.drawable.bg_inline_suggestion).apply {
+                                setTint(ColorUtils.blendARGB(backColor, firstTextColor, 0.2f))
+                            },
+                        ).build(),
+                ).setTitleStyle(
+                    TextViewStyle
+                        .Builder()
+                        .setLayoutMargin(context.dp(4), 0, context.dp(4), 0)
+                        .setTextColor(firstTextColor)
+                        .setTextSize(14f)
+                        .build(),
+                ).setSubtitleStyle(
+                    TextViewStyle
+                        .Builder()
+                        .setTextColor(
+                            ColorUtils.blendARGB(firstTextColor, backColor, 0.3f),
+                        ).setTextSize(12f)
+                        .build(),
+                ).setStartIconStyle(
+                    ImageViewStyle
+                        .Builder()
+                        .setTintList(ColorStateList.valueOf(firstTextColor))
+                        .build(),
+                ).setEndIconStyle(
+                    ImageViewStyle
+                        .Builder()
+                        .setTintList(ColorStateList.valueOf(firstTextColor))
+                        .build(),
+                ).build()
+        val styleBundle =
+            UiVersions
+                .newStylesBuilder()
+                .addStyle(style)
+                .build()
+        val spec =
+            InlinePresentationSpec
+                .Builder(Size(0, 0), Size(context.dp(160), Int.MAX_VALUE))
+                .setStyle(styleBundle)
+                .build()
+        return InlineSuggestionsRequest
+            .Builder(listOf(spec))
+            .setMaxSuggestionCount(InlineSuggestionsRequest.SUGGESTION_COUNT_UNLIMITED)
+            .build()
+    }
+
+    private val suggestionSize by lazy {
+        Size(ViewGroup.LayoutParams.WRAP_CONTENT, context.dp(INLINE_SUGGESTION_HEIGHT))
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    suspend fun inflateSuggestion(response: InlineSuggestionsResponse): List<View> =
+        response.inlineSuggestions.map {
+            suspendCoroutine { c ->
+                it.inflate(context, suggestionSize, directExecutor) { v ->
+                    c.resume(v)
+                }
+            }
+        }
+
+    companion object {
+        private const val INLINE_SUGGESTION_HEIGHT = 40
+
+        private val directExecutor by lazy {
+            Executor { it.run() }
+        }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionCandidateModule.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionCandidateModule.kt
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2024 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.candidates.suggestion
+
+import android.content.Context
+import android.view.View
+import com.osfans.trime.R
+import com.osfans.trime.daemon.RimeSession
+import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.ime.bar.QuickBar
+import com.osfans.trime.ime.broadcast.InputBroadcastReceiver
+import com.osfans.trime.ime.core.TrimeInputMethodService
+import splitties.views.dsl.recyclerview.recyclerView
+import splitties.views.recyclerview.horizontalLayoutManager
+
+class SuggestionCandidateModule(
+    val context: Context,
+    val service: TrimeInputMethodService,
+    val rime: RimeSession,
+    val theme: Theme,
+    val bar: QuickBar,
+) : InputBroadcastReceiver {
+    val adapter by lazy {
+        SuggestionCandidateViewAdapter(theme)
+    }
+
+    val view by lazy {
+        context.recyclerView(R.id.suggestion_view) {
+            adapter = this@SuggestionCandidateModule.adapter
+            layoutManager = horizontalLayoutManager()
+            isVerticalScrollBarEnabled = false
+            isHorizontalScrollBarEnabled = false
+        }
+    }
+
+    override fun onInlineSuggestion(views: List<View>) {
+        adapter.updateCandidates(
+            views.map {
+                SuggestionViewItem(it)
+            },
+            true,
+            0,
+            -1,
+        )
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionCandidateViewAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionCandidateViewAdapter.kt
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.candidates.suggestion
+
+import android.content.Context
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.chad.library.adapter4.BaseQuickAdapter
+import com.osfans.trime.data.theme.Theme
+import splitties.dimensions.dp
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.wrapContent
+import splitties.views.setPaddingDp
+
+open class SuggestionCandidateViewAdapter(
+    val theme: Theme,
+) : BaseQuickAdapter<SuggestionViewItem, SuggestionViewHolder>() {
+    var isLastPage: Boolean = false
+        private set
+
+    var previous: Int = 0
+        private set
+
+    var highlightedIdx: Int = -1
+        private set
+
+    fun updateCandidates(
+        list: List<SuggestionViewItem>,
+        isLastPage: Boolean,
+        previous: Int,
+        highlightedIdx: Int,
+    ) {
+        this.isLastPage = isLastPage
+        this.previous = previous
+        this.highlightedIdx = highlightedIdx
+        super.submitList(list)
+    }
+
+    override fun onCreateViewHolder(
+        context: Context,
+        parent: ViewGroup,
+        viewType: Int,
+    ): SuggestionViewHolder {
+        val ui = SuggestionItemUi(context, theme)
+        ui.root.apply {
+            minimumWidth = dp(40)
+            val size = theme.generalStyle.candidatePadding
+            setPaddingDp(size, 0, size, 0)
+            layoutParams = RecyclerView.LayoutParams(wrapContent, matchParent)
+        }
+        return SuggestionViewHolder(ui)
+    }
+
+    override fun onBindViewHolder(
+        holder: SuggestionViewHolder,
+        position: Int,
+        item: SuggestionViewItem?,
+    ) {
+        item ?: return
+        val isHighlighted = theme.generalStyle.candidateUseCursor && position == highlightedIdx
+        holder.ui.update(item, isHighlighted)
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionItemUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionItemUi.kt
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.candidates.suggestion
+
+import android.content.Context
+import android.graphics.drawable.ColorDrawable
+import com.osfans.trime.data.theme.ColorManager
+import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.util.pressHighlightDrawable
+import splitties.views.dsl.constraintlayout.constraintLayout
+import splitties.views.dsl.core.Ui
+
+class SuggestionItemUi(
+    override val ctx: Context,
+    theme: Theme,
+) : Ui {
+    private val firstBackColorH = ColorManager.getColor("hilited_candidate_back_color")!!
+
+    override val root = constraintLayout {}
+
+    fun update(
+        item: SuggestionViewItem,
+        isHighlighted: Boolean,
+    ) {
+        root.removeAllViews()
+        root.addView(item.view)
+
+        root.background =
+            if (isHighlighted) {
+                ColorDrawable(firstBackColorH)
+            } else {
+                pressHighlightDrawable(firstBackColorH)
+            }
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionViewHolder.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionViewHolder.kt
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.ime.candidates.suggestion
+
+import androidx.recyclerview.widget.RecyclerView
+
+class SuggestionViewHolder(
+    val ui: SuggestionItemUi,
+) : RecyclerView.ViewHolder(ui.root)

--- a/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionViewItem.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/suggestion/SuggestionViewItem.kt
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2025 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.candidates.suggestion
+
+import android.view.View
+
+data class SuggestionViewItem(
+    val view: View,
+)

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -25,6 +25,7 @@ import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.ime.bar.QuickBar
 import com.osfans.trime.ime.candidates.compact.CompactCandidateModule
+import com.osfans.trime.ime.candidates.suggestion.SuggestionCandidateModule
 import com.osfans.trime.ime.composition.PreeditModule
 import com.osfans.trime.ime.dependency.InputComponent
 import com.osfans.trime.ime.dependency.create
@@ -101,7 +102,8 @@ class InputView(
     private val preedit: PreeditModule = inputComponent.preedit
     private val keyboardWindow: KeyboardWindow = inputComponent.keyboardWindow
     private val liquidKeyboard: LiquidKeyboard = inputComponent.liquidKeyboard
-    private val compactCandidate: CompactCandidateModule = inputComponent.compactCandidate
+    private val compactCandidate: CompactCandidateModule = inputComponent.candidate.compactCandidateModule
+    private val suggestionCandidate: SuggestionCandidateModule = inputComponent.candidate.suggestionCandidateModule
     private val preview: KeyPreviewChoreographer = inputComponent.preview
 
     private fun addBroadcastReceivers() {
@@ -110,6 +112,7 @@ class InputView(
         broadcaster.addReceiver(keyboardWindow)
         broadcaster.addReceiver(liquidKeyboard)
         broadcaster.addReceiver(compactCandidate)
+        broadcaster.addReceiver(suggestionCandidate)
     }
 
     private val keyboardSidePadding = theme.generalStyle.keyboardPadding

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -364,6 +364,10 @@ class InputView(
         broadcaster.onSelectionUpdate(start, end)
     }
 
+    fun updateInlineSuggestion(views: List<View>) {
+        broadcaster.onInlineSuggestion(views)
+    }
+
     override fun onDetachedFromWindow() {
         ViewCompat.setOnApplyWindowInsetsListener(this, null)
         // cancel the notification job and clear all broadcast receivers,

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -13,6 +13,7 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.inputmethodservice.InputMethodService
 import android.os.Build
+import android.os.Bundle
 import android.os.SystemClock
 import android.text.InputType
 import android.view.InputDevice
@@ -25,6 +26,8 @@ import android.view.WindowManager
 import android.view.inputmethod.CursorAnchorInfo
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.ExtractedTextRequest
+import android.view.inputmethod.InlineSuggestionsRequest
+import android.view.inputmethod.InlineSuggestionsResponse
 import android.widget.FrameLayout
 import androidx.annotation.Keep
 import androidx.core.content.ContextCompat
@@ -48,6 +51,7 @@ import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.broadcast.IntentReceiver
+import com.osfans.trime.ime.candidates.suggestion.InlineSuggestionHandler
 import com.osfans.trime.ime.composition.ComposingPopupWindow
 import com.osfans.trime.ime.keyboard.InitializationUi
 import com.osfans.trime.ime.keyboard.InputFeedbackManager
@@ -86,6 +90,8 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     private var initializationUi: InitializationUi? = null
     private var mIntentReceiver: IntentReceiver? = null
     private val locales = Array(2) { Locale.getDefault() }
+
+    private lateinit var inlineSuggestionHandler: InlineSuggestionHandler
 
     var lastCommittedText: CharSequence = ""
         private set
@@ -204,6 +210,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
                         2 -> Locale(latinLocale[0], latinLocale[1])
                         else -> Locale.US
                     }
+                inlineSuggestionHandler = InlineSuggestionHandler(this@TrimeInputMethodService)
                 Timber.d("Trime.onCreate  completed")
             }
         } catch (e: Exception) {
@@ -436,6 +443,19 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
                 clearComposition()
             }
         }
+    }
+
+    @SuppressLint("NewApi", "RestrictedApi")
+    override fun onCreateInlineSuggestionsRequest(uiExtras: Bundle): InlineSuggestionsRequest? = inlineSuggestionHandler.createRequest()
+
+    @SuppressLint("NewApi")
+    override fun onInlineSuggestionsResponse(response: InlineSuggestionsResponse): Boolean {
+        lifecycleScope.launch {
+            val views = inlineSuggestionHandler.inflateSuggestion(response)
+
+            inputView?.updateInlineSuggestion(views)
+        }
+        return true
     }
 
     override fun onStartInputView(

--- a/app/src/main/java/com/osfans/trime/ime/dependency/InputComponent.kt
+++ b/app/src/main/java/com/osfans/trime/ime/dependency/InputComponent.kt
@@ -10,7 +10,7 @@ import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.ime.bar.QuickBar
 import com.osfans.trime.ime.broadcast.EnterKeyLabelModule
 import com.osfans.trime.ime.broadcast.InputBroadcaster
-import com.osfans.trime.ime.candidates.compact.CompactCandidateModule
+import com.osfans.trime.ime.candidates.CandidateModule
 import com.osfans.trime.ime.composition.PreeditModule
 import com.osfans.trime.ime.core.InputView
 import com.osfans.trime.ime.core.TrimeInputMethodService
@@ -40,5 +40,5 @@ abstract class InputComponent(
     abstract val preview: KeyPreviewChoreographer
     abstract val keyboardWindow: KeyboardWindow
     abstract val liquidKeyboard: LiquidKeyboard
-    abstract val compactCandidate: CompactCandidateModule
+    abstract val candidate: CandidateModule
 }

--- a/app/src/main/res/drawable/bg_inline_suggestion.xml
+++ b/app/src/main/res/drawable/bg_inline_suggestion.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ SPDX-FileCopyrightText: 2015 - 2025 Rime community
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#FFFFFFFF">
+    <item
+        android:bottom="4dp"
+        android:left="4dp"
+        android:right="4dp"
+        android:shape="rectangle"
+        android:top="4dp">
+        <shape>
+            <corners android:radius="6dp" />
+            <solid android:color="#FFFFFF" />
+            <stroke
+                android:width="1dp"
+                android:color="#FFFFFF" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/values/input_view_ids.xml
+++ b/app/src/main/res/values/input_view_ids.xml
@@ -11,4 +11,5 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <item name="unrolled_candidate_view" type="id" />
     <item name="input_window" type="id" />
     <item name="keyboard_view" type="id" />
+    <item name="suggestion_view" type="id" />
 </resources>

--- a/app/src/main/res/xml-v30/method.xml
+++ b/app/src/main/res/xml-v30/method.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2015 - 2024 Rime community
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsSwitchingToNextInputMethod="true"
+    android:supportsInlineSuggestions="true"
+    android:settingsActivity="com.osfans.trime.ui.main.PrefMainActivity">
+
+    <!-- Add default system subtype so we can properly set the icon and label -->
+    <subtype android:label="@string/trime_app_slogan"
+        android:name="@string/trime_app_name"
+        android:icon="@mipmap/ic_app_icon"
+        android:imeSubtypeMode="keyboard"
+        android:imeSubtypeExtraValue="AsciiCapable" />
+
+</input-method>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-androi
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.6.3" }
 androidx-activity = { module = "androidx.activity:activity-ktx", version = "1.9.0" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.6.1" }
+androidx-autofill = { module = "androidx.autofill:autofill", version ="1.1.0"}
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version = "2.1.4" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.13.1" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigation" }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes #1021

#### Feature
支援 自動填充。

一些補充：
- 基本改動參照 fxict5-android 
- 本來想改動 `CandidateViewAdapter` 去做，但 IME 收回來的 inline suggestion 回應是 `View` ，IME 讀取不到其內容，要改動 `CandidateItem` 去支援 `View` 的話又太混亂，所以新增了 `SuggestionCandidateModule` 去處理
- 新增了 `SuggestionUi` 後又要在 `QuickBarStateMachine` 加新 `State`，這部份不肯定有沒有遺漏 `State`
- 新增了 `CandidateModule` 去包裝 `CompactCandidateModule` 和`SuggestionCandidateModule` 做 injection，因為 kotlin-inject 不支援一個以上的 lazy object inject (https://github.com/evant/kotlin-inject/issues/425)
- 為免新增多一款顏色，使用了 `ColorUtils.blendARGB()` 去組合 `candidate_text_color` 和 `candidate_background` 做提示的顏色。
- 測試得不多，因為找不到其他可測試的情況😫

#### Code of conduct
- [X] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [X] `make sytle-lint`
- [X] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [X] `make debug`

#### Manually test
- [X] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

