### PR TITLE
fix: preset keys abbreviation not working

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyAction.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyAction.kt
@@ -175,17 +175,13 @@ class KeyAction(
 
     companion object {
         private val BRACED_STR = Regex("""\{[^{}]+\}""")
-        private val KV_PATTERN = Regex("""(\\w+)=(\\w+)""")
 
-        private fun decodeMapFromString(str: String): Map<String, String> {
-            val map = mutableMapOf<String, String>()
-            val trimmed = str.removeSurrounding("{", "}")
-            val matches = KV_PATTERN.findAll(trimmed)
-            for (match in matches) {
-                val (_, k, v) = match.groupValues
-                map[k] = v
-            }
-            return map
-        }
+        private fun decodeMapFromString(str: String): Map<String, String> =
+            str
+                .removeSurrounding("{", "}")
+                .split(", ")
+                .mapNotNull {
+                    it.split("=").takeIf { it.size == 2 }?.let { (key, value) -> key to value }
+                }.toMap()
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1592 
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

