### PR TITLE
fix: key bindings not working for Shift + symbol

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
@@ -253,7 +253,7 @@ class CommonKeyboardActionListener(
                             val shouldHookNumber =
                                 prefs.keyboard.hookShiftNum && action.code in KeyEvent.KEYCODE_0..KeyEvent.KEYCODE_9
                             val shouldHookSymbol =
-                                (prefs.keyboard.hookShiftSymbol || !Rime.isAsciiMode) &&
+                                prefs.keyboard.hookShiftSymbol &&
                                     (
                                         action.code in KeyEvent.KEYCODE_GRAVE..KeyEvent.KEYCODE_SLASH ||
                                             action.code == KeyEvent.KEYCODE_COMMA ||

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyAction.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyAction.kt
@@ -66,6 +66,7 @@ class KeyAction(
                 return adjustCase(shiftLabel, keyboard)
             }
             if (!hookShiftSymbol &&
+                // TODO: 判断中英模式仅能正确处理已配置映射的符号，对于未配置映射的符号，即使在中文模式下也能上屏 Shift 切换的符号。
                 Rime.isAsciiMode &&
                 (
                     code in KeyEvent.KEYCODE_GRAVE..KeyEvent.KEYCODE_SLASH ||


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1595 
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

