### PR TITLE
ci: fix code style error on macos

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -33,11 +33,6 @@ jobs:
           echo ${GITHUB_REF#refs/*/}
           echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
-      - name: Install macOS dependency
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          brew install coreutils clang-format
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -67,7 +62,7 @@ jobs:
         uses: android-actions/setup-android@v3
         
       - name: Check code style
-        if: ${{ !startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           make style-lint
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -40,11 +40,6 @@ jobs:
           echo ${GITHUB_REF#refs/*/}
           echo CI_BRANCH=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
-      - name: Install macOS dependency
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          brew install coreutils clang-format
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -72,9 +67,9 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-        
+
       - name: Check code style
-        if: ${{ !startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           make style-lint
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

Fix the style check on macos by disable it.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

