### PR TITLE
feat: implement GestureFrame to support gesture actions on view

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
@@ -29,6 +29,7 @@ import com.osfans.trime.ime.candidates.unrolled.window.FlexboxUnrolledCandidateW
 import com.osfans.trime.ime.core.TrimeInputMethodService
 import com.osfans.trime.ime.dependency.InputScope
 import com.osfans.trime.ime.keyboard.CommonKeyboardActionListener
+import com.osfans.trime.ime.keyboard.GestureFrame
 import com.osfans.trime.ime.keyboard.InputFeedbackManager
 import com.osfans.trime.ime.keyboard.KeyboardWindow
 import com.osfans.trime.ime.option.SwitchOptionWindow
@@ -71,17 +72,30 @@ class QuickBar(
         alwaysUi.updateState(newState)
     }
 
+    private val swipeDownHideKeyboardCallback: ((GestureFrame.SwipeDirection) -> Unit) = { d ->
+        if (d == GestureFrame.SwipeDirection.Down) {
+            service.requestHideSelf(0)
+        }
+    }
+
     private val alwaysUi: AlwaysUi by lazy {
         AlwaysUi(context, theme) { action ->
             action?.let { commonKeyboardActionListener.listener.onAction(KeyActionManager.getAction(it)) }
                 ?: windowManager.attachWindow(SwitchOptionWindow(context, service, rime, theme))
         }.apply {
-            hideKeyboardButton.setOnClickListener { service.requestHideSelf(0) }
+            hideKeyboardButton.apply {
+                setOnClickListener { service.requestHideSelf(0) }
+                onSwipeListener = swipeDownHideKeyboardCallback
+            }
         }
     }
 
     private val candidateUi by lazy {
-        CandidateUi(context, candidate.compactCandidateModule.view)
+        CandidateUi(context, candidate.compactCandidateModule.view).apply {
+            unrollButton.apply {
+                onSwipeListener = swipeDownHideKeyboardCallback
+            }
+        }
     }
 
     private val suggestionUi by lazy {

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/ToolButton.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/ToolButton.kt
@@ -9,7 +9,6 @@ import android.content.res.ColorStateList
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.StateListDrawable
-import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
@@ -20,6 +19,7 @@ import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.KeyActionManager
 import com.osfans.trime.data.theme.model.ToolBar
+import com.osfans.trime.ime.keyboard.GestureFrame
 import com.osfans.trime.ime.keyboard.KeyboardSwitcher
 import com.osfans.trime.util.circlePressHighlightDrawable
 import splitties.dimensions.dp
@@ -33,7 +33,7 @@ import splitties.views.imageDrawable
 import splitties.views.imageResource
 import splitties.views.padding
 
-class ToolButton : FrameLayout {
+class ToolButton : GestureFrame {
     private val image = imageView {
         isClickable = false
         isFocusable = false

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/GestureFrame.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/GestureFrame.kt
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2025 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.keyboard
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.MotionEvent
+import android.widget.FrameLayout
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.osfans.trime.data.prefs.AppPrefs
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.floor
+
+open class GestureFrame(context: Context) : FrameLayout(context) {
+    enum class SwipeDirection {
+        Up,
+        Down,
+        Left,
+        Right,
+    }
+
+    private val lifecycleScope by lazy {
+        findViewTreeLifecycleOwner()?.lifecycleScope!!
+    }
+
+    private var touchId = 0
+
+    @Volatile
+    private var longPressTriggered = false
+    private var longPressJob: Job? = null
+
+    @Volatile
+    private var swipeTriggered = false
+    private var shouldPerformSwipe = false
+    private var swipeStartX = -1f
+    private var swipeStartY = -1f
+    private var swipeLastX = -1f
+
+    @Volatile
+    private var slideActivated = false
+
+    private var lastTapTime = 0L
+    private var maybeDoubleTap = false
+
+    var onDoubleTapListener: (() -> Unit)? = null
+    var onSwipeListener: ((SwipeDirection) -> Unit)? = null
+    var onSlideListener: ((Int) -> Unit)? = null
+    var onReleaseListener: (() -> Unit)? = null
+
+    init {
+        // disable system sound effect and haptic feedback
+        isSoundEffectsEnabled = false
+        isHapticFeedbackEnabled = false
+    }
+
+    fun getSwipeDirection(dx: Float, dy: Float): SwipeDirection = if (abs(dx) > abs(dy)) {
+        if (dx > 0) SwipeDirection.Right else SwipeDirection.Left
+    } else {
+        if (dy > 0) SwipeDirection.Down else SwipeDirection.Up
+    }
+
+    fun getNStep(start: Float, end: Float, step: Float): Int = (if (start < end) 1 else -1) * floor(abs(end - start) / step).toInt()
+
+    private fun resetState() {
+        onReleaseListener?.invoke()
+        swipeStartX = -1f
+        swipeStartY = -1f
+        swipeLastX = -1f
+        longPressTriggered = false
+        longPressJob?.cancel()
+        longPressJob = null
+        shouldPerformSwipe = false
+        swipeTriggered = false
+        slideActivated = false
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        val x = event.x
+        val y = event.y
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                if (!isEnabled) return false
+                touchId = (touchId) and 0xFFFF
+                val currentTouchId = touchId
+                drawableHotspotChanged(x, y)
+                isPressed = true
+                InputFeedbackManager.keyPressVibrate(this)
+                longPressJob?.cancel()
+                longPressJob = lifecycleScope.launch {
+                    delay(longPressTimeout.toLong())
+                    if (touchId != currentTouchId) return@launch
+                    if (!(swipeTriggered || longPressTriggered || shouldPerformSwipe)) {
+                        InputFeedbackManager.keyPressVibrate(this@GestureFrame, true)
+                        longPressTriggered = true
+                    }
+                }
+                swipeStartX = x
+                swipeStartY = y
+                swipeLastX = x
+                return true
+            }
+            MotionEvent.ACTION_MOVE -> {
+                if (!isEnabled) return false
+                drawableHotspotChanged(x, y)
+                val dx = x - swipeStartX
+                val dy = y - swipeStartY
+
+                if (!longPressTriggered) {
+                    if (!shouldPerformSwipe && (abs(dx) > SWIPE_THRESHOLD || abs(dy) > SWIPE_THRESHOLD)) {
+                        shouldPerformSwipe = true
+                        swipeTriggered = true
+                    }
+                }
+                val onSlide = onSlideListener
+                if (onSlide != null) {
+                    if (!slideActivated) {
+                        if (abs(dx) >= SWIPE_THRESHOLD) {
+                            val startX = swipeStartX
+                            slideActivated = true
+                            swipeLastX = startX + (if (dx > 0) SWIPE_THRESHOLD else -SWIPE_THRESHOLD)
+                        }
+                    }
+                    if (slideActivated) {
+                        val startX = swipeStartX
+                        val lastX = swipeLastX
+                        val totalPast = getNStep(startX, lastX, SLIDE_STEP_SIZE)
+                        val totalNow = getNStep(startX, x, SLIDE_STEP_SIZE)
+                        val delta = totalNow - totalPast
+                        if (delta != 0) {
+                            onSlide(delta)
+                        }
+                        swipeLastX = x
+                    }
+                } else if (longPressTriggered) {
+                    val lastX = swipeLastX
+                    val delta = getNStep(lastX, x, SWIPE_MOVE_SIZE)
+                    if (delta != 0) {
+                        swipeLastX += delta.toFloat() * SWIPE_MOVE_SIZE
+                    }
+                }
+                return true
+            }
+            MotionEvent.ACTION_UP -> {
+                isPressed = false
+                val dx = x - swipeStartX
+                val dy = y - swipeStartY
+
+                if (slideActivated) {
+                    val onSlide = onSlideListener
+                    if (onSlide != null) {
+                        onSlide(0)
+                        resetState()
+                        return true
+                    }
+                }
+
+                if (!swipeTriggered && longPressTriggered) {
+                    performLongClick()
+                    resetState()
+                    return true
+                }
+
+                if (shouldPerformSwipe) {
+                    if (!longPressTriggered) {
+                        onSwipeListener?.invoke(getSwipeDirection(dx, dy))
+                    }
+                } else {
+                    if (!longPressTriggered) {
+                        val onDoubleTap = onDoubleTapListener
+                        if (onDoubleTap != null) {
+                            val now = System.currentTimeMillis()
+                            if (maybeDoubleTap && now - lastTapTime <= longPressTimeout) {
+                                maybeDoubleTap = false
+                                onDoubleTap()
+                            } else {
+                                maybeDoubleTap = true
+                                performClick()
+                            }
+                            lastTapTime = now
+                        } else {
+                            performClick()
+                        }
+                    }
+                }
+                resetState()
+                return true
+            }
+            MotionEvent.ACTION_CANCEL -> {
+                isPressed = false
+                resetState()
+                return true
+            }
+        }
+        return true
+    }
+
+    companion object {
+        private const val SWIPE_THRESHOLD = 24f
+        private const val SWIPE_MOVE_SIZE = 24f
+        private const val SLIDE_STEP_SIZE = 12f
+
+        private val longPressTimeout by AppPrefs.defaultInstance().keyboard.longPressTimeout
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/option/SwitchOptionEntryUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/option/SwitchOptionEntryUi.kt
@@ -17,6 +17,7 @@ import android.widget.ImageView
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.ime.core.AutoScaleTextView
+import com.osfans.trime.ime.keyboard.GestureFrame
 import splitties.dimensions.dp
 import splitties.resources.drawable
 import splitties.views.dsl.constraintlayout.above
@@ -76,7 +77,7 @@ class SwitchOptionEntryUi(
         }
 
     override val root =
-        object : FrameLayout(ctx) {
+        object : GestureFrame(ctx) {
             val content =
                 constraintLayout {
                     add(

--- a/app/src/main/java/com/osfans/trime/ime/symbol/DatabaseItemUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/DatabaseItemUi.kt
@@ -12,6 +12,7 @@ import com.osfans.trime.R
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.ime.keyboard.GestureFrame
 import splitties.dimensions.dp
 import splitties.resources.drawable
 import splitties.views.dsl.constraintlayout.bottomOfParent
@@ -21,7 +22,6 @@ import splitties.views.dsl.constraintlayout.endOfParent
 import splitties.views.dsl.constraintlayout.lParams
 import splitties.views.dsl.core.Ui
 import splitties.views.dsl.core.add
-import splitties.views.dsl.core.frameLayout
 import splitties.views.dsl.core.imageView
 import splitties.views.dsl.core.lParams
 import splitties.views.dsl.core.matchParent
@@ -72,7 +72,7 @@ class DatabaseItemUi(
         }
 
     override val root =
-        frameLayout {
+        GestureFrame(ctx).apply {
             isClickable = true
             minimumHeight = dp(30)
             background =

--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidTabsUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidTabsUi.kt
@@ -13,14 +13,15 @@ import com.chad.library.adapter4.BaseQuickAdapter
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.ime.keyboard.GestureFrame
 import com.osfans.trime.util.rippleDrawable
 import splitties.dimensions.dp
 import splitties.views.dsl.core.Ui
 import splitties.views.dsl.core.add
-import splitties.views.dsl.core.frameLayout
 import splitties.views.dsl.core.lParams
 import splitties.views.dsl.core.matchParent
 import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.view
 import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
 import splitties.views.gravityCenter
@@ -42,7 +43,7 @@ class LiquidTabsUi(
             }
 
         override val root =
-            frameLayout {
+            view(::GestureFrame) {
                 add(
                     text,
                     lParams {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

This PR implements GestureFrame view, a base view that supports click, long click, double tap, swipe, slide and release action. Views inherited from it can perform these gesture and provide input feedback to users.

Currently, I apply it to tool bar buttons and switch buttons. New key views based on it are in plan.

Ref: https://github.com/fcitx-contrib/fcitx5-ios/blob/3c58b51f7f01f838e94adc790b4ace2497495e52/uipanel/KeyModifier.swift

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

