### PR TITLE
fix: end composition only when toggling ascii_mode

### DIFF
--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -282,6 +282,12 @@ class Rime :
                 statusCached = status
                 updateSchemaCached(status)
                 if (it.data.option == "ascii_mode") {
+                    if (it.data.value && status.isComposing) {
+                        getRimeRawInput().takeIf { it.isNotEmpty() }?.let {
+                            handleRimeMessage(4, arrayOf(CommitProto(it)))
+                        }
+                        lifecycleScope.launch { clearComposition() }
+                    }
                     showAsciiSwitchTips()
                 }
             }

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
@@ -171,7 +171,6 @@ class CommonKeyboardActionListener {
                     service.lifecycleScope.launch {
                         val status = api.getRuntimeOption(option)
                         api.setRuntimeOption(option, !status)
-                        api.commitComposition()
                     }
                 }
             }


### PR DESCRIPTION
before: switching any option in Mode_Switch would end composition and commit the first candidate

after: only toggling ascii_mode ends composition and commits the raw input; switching other options no longer end composition. Keyboard switching still commits the first candidate

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1514
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

