### PR TITLE
fix: defer theme initialization until rime is ready

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -176,9 +176,14 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
             it.registerOnChangeListener(recreateInputViewListener)
         }
         prefs.candidates.registerOnChangeListener(recreateCandidatesViewListener)
-        ThemeManager.init(resources.configuration)
-        ThemeManager.addOnChangedListener(onThemeChangeListener)
-        ColorManager.addOnChangedListener(onColorChangeListener)
+        // ensure theme and color managers are initialized after rime is ready
+        lifecycleScope.launch {
+            rime.runOnReady {
+                ThemeManager.init(resources.configuration)
+                ThemeManager.addOnChangedListener(onThemeChangeListener)
+                ColorManager.addOnChangedListener(onColorChangeListener)
+            }
+        }
         InputFeedbackManager.init(this)
         registerReceiver()
         super.onCreate()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #2000
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

