### PR TITLE
feat(ime): add option to hide virtual keyboard while keeping toolbar

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
@@ -125,6 +125,10 @@ class AppPrefs(
             const val USE_SOFT_CURSOR = "use_soft_cursor"
             const val HIDE_INPUT_BAR = "hide_input_bar"
 
+            // Distinct key (not "hide_virtual_keyboard") to avoid a type clash with the
+            // String value some experimental builds stored under that key.
+            const val HIDE_VIRTUAL_KEYBOARD = "hide_virtual_keyboard_keep_toolbar"
+
             const val SOUND_ON_KEYPRESS = "sound_on_keypress"
             const val KEY_SOUND_VOLUME = "sound_volume"
             const val USE_CUSTOM_SOUND_EFFECT = "custom_sound_effect_enabled"
@@ -179,6 +183,8 @@ class AppPrefs(
         val useSoftCursor = switch(R.string.use_soft_cursor, USE_SOFT_CURSOR, true)
 
         val hideInputBar = switch(R.string.hide_input_bar, HIDE_INPUT_BAR, false)
+
+        val hideVirtualKeyboard = switch(R.string.hide_virtual_keyboard, HIDE_VIRTUAL_KEYBOARD, false)
 
         val soundOnKeyPress = switch(R.string.sound_on_keypress, SOUND_ON_KEYPRESS, false)
         val soundVolume = int(

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -94,7 +94,10 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     private var cursorUpdateIndex = 0
 
     private val recreateInputViewPrefs: Array<PreferenceDelegate<*>> =
-        arrayOf(prefs.keyboard.hideInputBar)
+        arrayOf(
+            prefs.keyboard.hideInputBar,
+            prefs.keyboard.hideVirtualKeyboard,
+        )
 
     @Keep
     private val recreateInputViewListener =

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
@@ -71,6 +71,8 @@ class KeyboardWindow :
     override val key: ResidentWindow.Key
         get() = KeyboardWindow
 
+    override val isKeyboardArea: Boolean = true
+
     private val presetKeyboardIds = theme.presetKeyboards.keys.toList()
     private var currentKeyboardId = ""
     private var lastKeyboardId = ""

--- a/app/src/main/java/com/osfans/trime/ime/window/BoardWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/window/BoardWindow.kt
@@ -19,6 +19,14 @@ sealed class BoardWindow {
     protected val context: Context by di.instance()
 
     /**
+     * Whether this window represents the virtual keyboard area. When the user enables
+     * "hide virtual keyboard", only windows for which this is `true` are hidden, so that
+     * non-keyboard panels (option switcher, unrolled candidates, liquid keyboard, ...)
+     * remain visible when opened from the toolbar.
+     */
+    open val isKeyboardArea: Boolean = false
+
+    /**
      * Animation when the window is added to the layout
      */
     open fun enterAnimation(lastWindow: BoardWindow): Transition? = Slide().apply {

--- a/app/src/main/java/com/osfans/trime/ime/window/BoardWindowManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/window/BoardWindowManager.kt
@@ -11,6 +11,7 @@ import androidx.transition.Transition
 import androidx.transition.TransitionManager
 import androidx.transition.TransitionSet
 import com.osfans.trime.R
+import com.osfans.trime.data.prefs.AppPrefs
 import com.osfans.trime.ime.broadcast.InputBroadcaster
 import com.osfans.trime.ime.dependency.InputDependencyManager
 import org.kodein.di.instance
@@ -28,6 +29,8 @@ class BoardWindowManager {
 
     private var currentWindow: BoardWindow? = null
     private var currentView: View? = null
+
+    private val hideVirtualKeyboard by AppPrefs.defaultInstance().keyboard.hideVirtualKeyboard
 
     private fun prepareAnimation(
         exitAnimation: Transition?,
@@ -108,6 +111,10 @@ class BoardWindowManager {
         Timber.d("Attach $window")
         window.onAttached()
         currentWindow = window
+        // Toolbar-only mode: hide the window host only while the keyboard area is shown, so that
+        // non-keyboard panels (option switcher, unrolled candidates, liquid keyboard, ...) opened
+        // from the toolbar remain visible. Returning to the keyboard hides the host again.
+        view.visibility = if (hideVirtualKeyboard && window.isKeyboardArea) View.GONE else View.VISIBLE
         broadcaster.onWindowAttached(window)
     }
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -172,6 +172,7 @@
     <string name="deploy_failure">部署失败</string>
     <string name="view_deploy_failure_log">部署失败。点此查看错误日志。</string>
     <string name="hide_input_bar">隐藏输入工具栏</string>
+    <string name="hide_virtual_keyboard">隐藏虚拟键盘（保留工具栏）</string>
     <string name="navbar_bkg_none">无背景</string>
     <string name="navbar_bkg_color_only">跟随键盘背景色</string>
     <string name="navbar_bkg_full">键盘背景图片</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -173,6 +173,7 @@
     <string name="deploy_failure">部署失敗</string>
     <string name="view_deploy_failure_log">部署失敗。點此檢視錯誤日誌。</string>
     <string name="hide_input_bar">隱藏輸入工具欄</string>
+    <string name="hide_virtual_keyboard">隱藏虛擬鍵盤（保留工具欄）</string>
     <string name="navbar_bkg_none">無背景</string>
     <string name="navbar_bkg_color_only">跟隨鍵盤背景色</string>
     <string name="navbar_bkg_full">鍵盤背景圖片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,7 @@
     <string name="deploy_failure">Deploy failure</string>
     <string name="view_deploy_failure_log">Deploy failure. Click here to view error log.</string>
     <string name="hide_input_bar">Hide input bar</string>
+    <string name="hide_virtual_keyboard">Hide virtual keyboard (keep toolbar)</string>
     <string name="navbar_bkg_none">No background</string>
     <string name="navbar_bkg_color_only">Follow keyboard color</string>
     <string name="navbar_bkg_full">Keyboard background image</string>


### PR DESCRIPTION
## Pull request

#### Issue tracker
<!-- No open issue; this is a reworked, slimmed-down take on the closed #2012 -->
Fixes #

#### Feature
Add a keyboard preference **Hide virtual keyboard (keep toolbar)**
(`hide_virtual_keyboard`, default off). When enabled, Trime renders a
toolbar-only input surface: the on-screen keyboard area is hidden while the
input bar (toolbar, candidates, clipboard and inline suggestions) stays
visible. This helps devices with a physical keyboard (e.g. Unihertz Titan 2),
where the virtual keyboard is redundant but the toolbar/candidates are wanted.

Design:
- The toolbar keeps its default position above the keyboard; 
- Visibility is driven statically from the preference, mirroring the existing
  `hide_input_bar` behavior — no runtime/external control of `InputView`
  internals.
- The window host is hidden only while the keyboard window is the active board
  window (new `BoardWindow.isKeyboardArea` flag), so non-keyboard panels opened
  from the toolbar (option switcher, unrolled candidates, liquid keyboard) stay
  visible; returning to the keyboard hides the host again.

This reworks the previously closed #2012, dropping the parts maintainers
objected to: toolbar-position switching, the runtime `toggle_keyboard`
command, and the InputDeviceManager→InputView coupling.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make style-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done
<img width="1189" height="1189" alt="image" src="https://github.com/user-attachments/assets/fcf88909-8517-4330-b071-e8f8e34b5007" />
<img width="1190" height="1190" alt="image" src="https://github.com/user-attachments/assets/ec77321b-76c6-4417-ade5-d498a1119286" />


#### Additional Info
Files changed (8): 

- new `hide_virtual_keyboard` switch in `AppPrefs` (registered
in `recreateInputViewPrefs`); 
- `BoardWindow.isKeyboardArea` + override in
`KeyboardWindow`; host-visibility logic in `BoardWindowManager`; 
- strings in `values`, `values-zh-rCN`, `values-zh-rTW`.