### PR TITLE
fix: don't fake bold toolbar labels rendered with icon fonts

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/ToolButton.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/ToolButton.kt
@@ -7,6 +7,7 @@ package com.osfans.trime.ime.bar.ui
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.graphics.Paint
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
@@ -16,6 +17,7 @@ import android.graphics.drawable.StateListDrawable
 import android.graphics.drawable.shapes.OvalShape
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
+import androidx.core.graphics.PaintCompat
 import androidx.core.view.isVisible
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.utils.sizeDp
@@ -100,8 +102,6 @@ class ToolButton(context: Context) : GestureFrame(context) {
 
         fontSize = fg.fontSize
         label.textSize = fontSize
-
-        label.typeface = Typeface.create(FontManager.getTypeface("toolbar_font"), Typeface.BOLD)
 
         colorStateList = ColorStateList(
             arrayOf(intArrayOf(android.R.attr.state_pressed), intArrayOf()),
@@ -201,7 +201,14 @@ class ToolButton(context: Context) : GestureFrame(context) {
             label.isVisible = false
             image.isVisible = true
         } else { // text icon
-            label.text = if (useLocalImage || style.isEmpty()) actionLabel else style
+            val text = if (useLocalImage || style.isEmpty()) actionLabel else style
+            label.text = text
+            // probe against the baseline typeface, not label.paint which may
+            // still hold the toolbar typeface from a previous update
+            val probePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { typeface = Typeface.DEFAULT }
+            val hasGlyph = PaintCompat.hasGlyph(probePaint, text)
+            val font = FontManager.getTypeface("toolbar_font")
+            label.typeface = if (hasGlyph) Typeface.create(font, Typeface.BOLD) else font
             image.isVisible = false
             label.isVisible = true
         }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #2071 

#### Feature
Describe features of this pull request

Probe the glyph coverage of the label's paint with PaintCompat.hasGlyph in updateContent, and only apply the bold style when the displayed text is covered by the toolbar font. Icon fonts, whose glyphs are pictograms rather than letters, keep the regular style instead of being rendered with a fake bold.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

