### PR TITLE
refactor: migrate key symbol/hint visibility to app prefs

### DIFF
--- a/app/src/main/assets/shared/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/shared/tongwenfeng.trime.yaml
@@ -1100,7 +1100,7 @@ preset_keyboards:
       - {click: BackSpace2, width: 15, key_back_color: bbs, key_text_color: tbs}
 
       - {click: Keyboard_number, long_click: Menu, width: 12.5, key_back_color: bgn, key_text_color: tgn}
-      - {click: Keyboard_bqrw, long_click: Theme_settings, swipe_down: Color_switch, swipe_up: Color_switch, width: 12.5, key_text_size: "18", key_back_color: bgn, key_text_color: tgn}
+      - {click: Keyboard_bqrw, label_symbol: "简洁", long_click: "{hide_key_symbol}{hide_key_hint}", swipe_down: Color_switch, swipe_up: Color_switch, width: 12.5, key_text_size: "18", key_back_color: bgn, key_text_color: tgn}
       - {click: ',', label: '，', long_click: '<>{Left}', key_back_color: bh4, key_text_color: th4}
       - {click: space, long_click: Mode_switch, swipe_left: "Left", swipe_right: "Right", swipe_up: Schema_switchcn, width: 30, key_back_color: bkg, key_text_color: tkg}
       - {click: '.', label: '。', long_click: clipboard_window, key_back_color: bh4, key_text_color: th4}
@@ -4043,6 +4043,8 @@ preset_keys:
   Info: {label: 关于, send: INFO}
   Menu: {label: 菜单, functional: false, send: MENU}
   Settings: {label: 设置, functional: false, send: SETTINGS}
+  hide_key_symbol: {label: 隐藏符号, send: FUNCTION, command: switch_hide_key_symbol}
+  hide_key_hint: {label: 隐藏注解, send: FUNCTION, command: switch_hide_key_hint}
   # trime命令
   Date: {label: 日期, send: FUNCTION, command: date, option: " yyyy-MM-dd "}
   Time: {label: 時間, send: FUNCTION, command: date, option: "HH:mm:ss"} #時間： date 格式

--- a/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
@@ -124,6 +124,8 @@ class AppPrefs(
 
             const val USE_SOFT_CURSOR = "use_soft_cursor"
             const val HIDE_INPUT_BAR = "hide_input_bar"
+            const val HIDE_KEY_SYMBOL = "hide_key_symbol"
+            const val HIDE_KEY_HINT = "hide_key_hint"
 
             const val SOUND_ON_KEYPRESS = "sound_on_keypress"
             const val KEY_SOUND_VOLUME = "sound_volume"
@@ -179,6 +181,8 @@ class AppPrefs(
         val useSoftCursor = switch(R.string.use_soft_cursor, USE_SOFT_CURSOR, true)
 
         val hideInputBar = switch(R.string.hide_input_bar, HIDE_INPUT_BAR, false)
+        val hideKeySymbol = switch(R.string.hide_key_symbol, HIDE_KEY_SYMBOL, false)
+        val hideKeyHint = switch(R.string.hide_key_hint, HIDE_KEY_HINT, false)
 
         val soundOnKeyPress = switch(R.string.sound_on_keypress, SOUND_ON_KEYPRESS, false)
         val soundVolume = int(

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -97,6 +97,8 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     private var cursorUpdateIndex = 0
 
     private val recreateInputViewPrefs: Array<PreferenceDelegate<*>> = arrayOf(
+        prefs.keyboard.hideKeySymbol,
+        prefs.keyboard.hideKeyHint,
         prefs.keyboard.hideInputBar,
         prefs.advanced.ignoreSystemGestureInsets,
     )

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -97,6 +97,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     private var cursorUpdateIndex = 0
 
     private val recreateInputViewPrefs: Array<PreferenceDelegate<*>> = arrayOf(
+        prefs.keyboard.expandKeypressArea,
         prefs.keyboard.hideKeySymbol,
         prefs.keyboard.hideKeyHint,
         prefs.keyboard.hideInputBar,

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
@@ -189,6 +189,8 @@ class CommonKeyboardActionListener {
                     "apply" -> handleApplyCommand(arg)
                     "share_text" -> service.shareText()
                     "select_candidate" -> handleSelectCandidate(arg)
+                    "switch_hide_key_symbol" -> switchHideKeySymbol()
+                    "switch_hide_key_hint" -> switchHideKeyHint()
                     else -> handleIntentAction(action.command, arg)
                 }
             }
@@ -289,6 +291,16 @@ class CommonKeyboardActionListener {
                         api.selectCandidate(index, false)
                     }
                 }
+            }
+
+            private fun switchHideKeySymbol() {
+                val preference = prefs.keyboard.hideKeySymbol
+                preference.setValue(!preference.getValue())
+            }
+
+            private fun switchHideKeyHint() {
+                val preference = prefs.keyboard.hideKeyHint
+                preference.setValue(!preference.getValue())
             }
 
             private fun handleSettings(action: KeyAction) {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyView.kt
@@ -44,10 +44,6 @@ class KeyView(
 
     private val rime get() = RimeDaemon.getFirstSessionOrNull()!!
 
-    private val hookShiftArrow: Boolean by lazy {
-        AppPrefs.defaultInstance().keyboard.hookShiftArrow.getValue()
-    }
-
     private val deletedTextBuffer = ArrayDeque<String>()
 
     private var keyPressed = false
@@ -212,7 +208,7 @@ class KeyView(
 
         keyboardActionListener.onAction(action)
 
-        val hookArrow = if (hookShiftArrow) {
+        val hookArrow = if (keyboardView.hookShiftArrow) {
             when (action.code) {
                 in KeyEvent.KEYCODE_DPAD_UP..KeyEvent.KEYCODE_DPAD_RIGHT -> true
                 KeyEvent.KEYCODE_MOVE_HOME, KeyEvent.KEYCODE_MOVE_END -> true
@@ -379,11 +375,8 @@ class KeyView(
     }
 
     private fun drawSymbol(canvas: Canvas, text: String, isTop: Boolean = true) {
-        val showSymbol = rime.run { !getRuntimeOption("_hide_key_symbol") }
-        val showHint = rime.run { !getRuntimeOption("_hide_key_hint") }
-
-        if (isTop && !showSymbol) return
-        if (!isTop && !showHint) return
+        if (isTop && keyboardView.hideKeySymbol) return
+        if (!isTop && keyboardView.hideKeyHint) return
 
         val textColor = key.getSymbolColor()
         val textSize = sp(key.symbolTextSize.takeIf { it > 0f } ?: keyboardView.symbolTextSize)

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.kt
@@ -36,6 +36,9 @@ class KeyboardView(
     internal val keyLongTextSize = theme.generalStyle.keyLongTextSize.takeIf { it > 0 } ?: keyTextSize
     internal val symbolTextSize = theme.generalStyle.symbolTextSize.takeIf { it > 0 } ?: keyTextSize
     internal val popupOnKeyPress by AppPrefs.defaultInstance().keyboard.popupOnKeyPress
+    internal val hookShiftArrow: Boolean by AppPrefs.defaultInstance().keyboard.hookShiftArrow
+    internal val hideKeySymbol: Boolean by AppPrefs.defaultInstance().keyboard.hideKeySymbol
+    internal val hideKeyHint: Boolean by AppPrefs.defaultInstance().keyboard.hideKeyHint
 
     init {
         setWillNotDraw(false)

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -179,6 +179,8 @@
     <string name="deploy_failure">部署失败</string>
     <string name="view_deploy_failure_log">部署失败。点此查看错误日志。</string>
     <string name="hide_input_bar">隐藏输入工具栏</string>
+    <string name="hide_key_symbol">隐藏按键符号</string>
+    <string name="hide_key_hint">隐藏按键注解</string>
     <string name="navbar_bkg_none">无背景</string>
     <string name="navbar_bkg_color_only">跟随键盘背景色</string>
     <string name="navbar_bkg_full">键盘背景图片</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -180,6 +180,8 @@
     <string name="deploy_failure">部署失敗</string>
     <string name="view_deploy_failure_log">部署失敗。點此檢視錯誤日誌。</string>
     <string name="hide_input_bar">隱藏輸入工具欄</string>
+    <string name="hide_key_symbol">隱藏按鍵符號</string>
+    <string name="hide_key_hint">隱藏按鍵註解</string>
     <string name="navbar_bkg_none">無背景</string>
     <string name="navbar_bkg_color_only">跟隨鍵盤背景色</string>
     <string name="navbar_bkg_full">鍵盤背景圖片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,8 @@
     <string name="deploy_failure">Deploy failure</string>
     <string name="view_deploy_failure_log">Deploy failure. Click here to view error log.</string>
     <string name="hide_input_bar">Hide input bar</string>
+    <string name="hide_key_symbol">Hide key symbol</string>
+    <string name="hide_key_hint">Hide key hint</string>
     <string name="navbar_bkg_none">No background</string>
     <string name="navbar_bkg_color_only">Follow keyboard color</string>
     <string name="navbar_bkg_full">Keyboard background image</string>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

