### PR TITLE
perf: query the candidate layout with the response 

### DIFF
--- a/app/src/main/java/com/osfans/trime/core/RimeProto.kt
+++ b/app/src/main/java/com/osfans/trime/core/RimeProto.kt
@@ -71,6 +71,8 @@ sealed interface Candidates {
         val hasPrevPage: Boolean = false,
         /** Whether there is a next page to turn to */
         val hasNextPage: Boolean = false,
+        /** Whether the candidates are laid out horizontally (queried natively) */
+        val isHorizontalLayout: Boolean = false,
         override val highlighted: Int = 0,
         override val candidates: Array<CandidateProto> = arrayOf(),
     ) : Candidates {
@@ -82,6 +84,7 @@ sealed interface Candidates {
 
             if (hasPrevPage != other.hasPrevPage) return false
             if (hasNextPage != other.hasNextPage) return false
+            if (isHorizontalLayout != other.isHorizontalLayout) return false
             if (highlighted != other.highlighted) return false
             if (!candidates.contentEquals(other.candidates)) return false
 
@@ -91,10 +94,13 @@ sealed interface Candidates {
         override fun hashCode(): Int {
             var result = hasPrevPage.hashCode()
             result = 31 * result + hasNextPage.hashCode()
+            result = 31 * result + isHorizontalLayout.hashCode()
             result = 31 * result + highlighted
             result = 31 * result + candidates.contentHashCode()
             return result
         }
+
+        override fun toString(): String = "Paged(hasPrevPage=$hasPrevPage, hasNextPage=$hasNextPage, isHorizontalLayout=$isHorizontalLayout, highlighted=$highlighted, candidatesCount=${candidates.size})"
     }
 
     /** Bulk list: [total] is the candidate count, or -1 if unknown */
@@ -122,6 +128,8 @@ sealed interface Candidates {
             result = 31 * result + candidates.contentHashCode()
             return result
         }
+
+        override fun toString(): String = "Bulk(total=$total, highlighted=$highlighted, candidatesCount=${candidates.size})"
     }
 }
 

--- a/app/src/main/java/com/osfans/trime/ime/candidates/popup/PagedCandidatesUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/popup/PagedCandidatesUi.kt
@@ -131,12 +131,11 @@ class PagedCandidatesUi(
 
     fun update(
         candidates: Candidates.Paged,
-        horizontal: Boolean,
         layout: PopupCandidatesLayout,
     ) {
         this.candidates = candidates
         this.isHorizontal = when (layout) {
-            PopupCandidatesLayout.AUTOMATIC -> horizontal
+            PopupCandidatesLayout.AUTOMATIC -> candidates.isHorizontalLayout
             else -> layout == PopupCandidatesLayout.HORIZONTAL
         }
         candidatesLayoutManager.apply {
@@ -144,7 +143,7 @@ class PagedCandidatesUi(
                 PopupCandidatesLayout.HORIZONTAL -> FlexDirection.ROW
                 PopupCandidatesLayout.VERTICAL_REVERSE -> FlexDirection.COLUMN_REVERSE
                 PopupCandidatesLayout.AUTOMATIC ->
-                    if (horizontal) FlexDirection.ROW else FlexDirection.COLUMN
+                    if (isHorizontal) FlexDirection.ROW else FlexDirection.COLUMN
                 else -> FlexDirection.COLUMN
             }
             alignItems = if (isHorizontal) AlignItems.BASELINE else AlignItems.STRETCH

--- a/app/src/main/java/com/osfans/trime/ime/composition/CandidatesView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/composition/CandidatesView.kt
@@ -129,12 +129,8 @@ class CandidatesView(
     private fun updateUi() {
         preeditUi.update(composition)
         preeditUi.root.visibility = if (preeditUi.visible) VISIBLE else GONE
-        // if CandidatesView can be shown, rime engine is ready most of the time,
-        // so it should be safety to get option immediately
-        val isHorizontalLayout = rime.run {
-            getRuntimeOption("_linear") || getRuntimeOption("_horizontal")
-        }
-        candidatesUi.update(candidates, isHorizontalLayout, layout)
+        // the candidate layout is queried natively with the page itself
+        candidatesUi.update(candidates, layout)
         if (evaluateVisibility()) {
             visibility = VISIBLE
         } else {

--- a/app/src/main/jni/librime_jni/jni-utils.h
+++ b/app/src/main/jni/librime_jni/jni-utils.h
@@ -198,7 +198,7 @@ class GlobalRefSingleton {
         env->FindClass("com/osfans/trime/core/Candidates$Paged")));
     CandidatesPagedInit =
         env->GetMethodID(CandidatesPaged, "<init>",
-                         "(ZZI[Lcom/osfans/trime/core/CandidateProto;)V");
+                         "(ZZZI[Lcom/osfans/trime/core/CandidateProto;)V");
 
     CandidatesBulk = reinterpret_cast<jclass>(env->NewGlobalRef(
         env->FindClass("com/osfans/trime/core/Candidates$Bulk")));

--- a/app/src/main/jni/librime_jni/objconv.h
+++ b/app/src/main/jni/librime_jni/objconv.h
@@ -89,8 +89,8 @@ inline jobject rimeCompositionToJObject(JNIEnv* env,
           : nullptr);
 }
 
-inline jobject rimeCandidatesPagedToJObject(JNIEnv* env,
-                                            const MenuProto& menu) {
+inline jobject rimeCandidatesPagedToJObject(JNIEnv* env, const MenuProto& menu,
+                                            bool is_horizontal_layout) {
   int numCandidates = static_cast<int>(menu.candidates.size());
   auto jCandidates = JRef<jobjectArray>(
       env,
@@ -102,8 +102,8 @@ inline jobject rimeCandidatesPagedToJObject(JNIEnv* env,
   }
   return env->NewObject(GlobalRef->CandidatesPaged,
                         GlobalRef->CandidatesPagedInit, menu.pageNumber != 0,
-                        !menu.isLastPage, menu.highlightedCandidateIndex,
-                        *jCandidates);
+                        !menu.isLastPage, is_horizontal_layout,
+                        menu.highlightedCandidateIndex, *jCandidates);
 }
 
 inline jobject rimeContextToJObject(JNIEnv* env, const ContextProto& context) {

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -435,7 +435,13 @@ Java_com_osfans_trime_core_Rime_getRimeResponse(JNIEnv *env, jclass clazz,
   // keep the local references alive until RimeResponse is constructed below
   jobject jCandidates = nullptr;
   if (paging_mode) {
-    jCandidates = rimeCandidatesPagedToJObject(env, context->menu);
+    // the candidate layout is queried right where the page is built, so the
+    // consumer does not need a separate rime option round-trip per key
+    auto &rime = Rime::Instance();
+    bool is_horizontal_layout =
+        rime.getOption("_linear") || rime.getOption("_horizontal");
+    jCandidates =
+        rimeCandidatesPagedToJObject(env, context->menu, is_horizontal_layout);
   } else {
     auto [size, highlighted, list] = Rime::Instance().getBulkCandidates();
     auto jList =


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

The per-key "Handling \$message" log interpolates the message before the tree filter runs, and the bulk candidate message dumped every candidate's full text into a multi-KB string in both builds. Give the candidate data types a summary toString with just the counts and highlight index, and have the candidate messages delegate to it.

Also add `isHorizontalLayout` field in `Canidaites.Paged` data class, avoid querying it in CandidatesView in place to prevent potential thread blocking.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

