### PR TITLE
fix: uppercase key actions commit lowercase in ascii mode

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
@@ -364,8 +364,21 @@ class CommonKeyboardActionListener {
                 keyEventCode: Int,
                 metaState: Int,
             ) {
-                val name = KeyCode.codeToKeyName(keyEventCode) ?: "VoidSymbol"
-                val value = RimeKeyEvent.getKeycodeByName(name)
+                // An uppercase letter key (e.g. from `{x: A}`) is passed to
+                // rime as the uppercase keysym with Shift, matching what a
+                // physical keyboard reports via the unicode char, so that
+                // rime commits the uppercase letter in ascii mode as well.
+                // The generated reverse mapping would otherwise resolve e.g.
+                // KEYCODE_A to the lowercase name "a" (XK_a).
+                val value =
+                    if (metaState and KeyEvent.META_SHIFT_ON != 0 &&
+                        keyEventCode in KeyEvent.KEYCODE_A..KeyEvent.KEYCODE_Z
+                    ) {
+                        'A'.code + (keyEventCode - KeyEvent.KEYCODE_A) // XK_A..XK_Z
+                    } else {
+                        val name = KeyCode.codeToKeyName(keyEventCode) ?: "VoidSymbol"
+                        RimeKeyEvent.getKeycodeByName(name)
+                    }
                 val m = if (keyEventCode in KeyEvent.KEYCODE_NUMPAD_0..KeyEvent.KEYCODE_NUMPAD_EQUALS) {
                     metaState or KeyEvent.META_NUM_LOCK_ON
                 } else {

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyCode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyCode.kt
@@ -91,6 +91,15 @@ object KeyCode {
             start = found + 1
         }
         val token = repr.substring(start)
+        // A single uppercase letter (e.g. 'A') is the letter key with Shift
+        // held, just like on a physical keyboard. Do not use the synthetic
+        // uppercase codes from RimeKeyMapping.upperNameToCode: they carry no
+        // shift modifier, so in ascii mode rime would reject the bare
+        // uppercase keysym and the fallback would commit the lowercase
+        // letter instead.
+        if (modifiers == 0 && token.length == 1 && token[0] in 'A'..'Z') {
+            return KeyEvent.KEYCODE_A + (token[0] - 'A') to KeyEvent.META_SHIFT_ON
+        }
         val keycode = nameToKeyCode(token)
         if (keycode == 0) {
             Timber.e("Unrecognized key '$token'")


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

Key actions like `{x: A}` were parsed as synthetic uppercase key codes (20000+) without a shift modifier, so rime received the bare uppercase keysym XK_A. While the `uppercase` recognizer pattern picks it up in Chinese mode, in ascii mode rime rejects the key and the fallback replays KEYCODE_A without shift, committing a lowercase letter instead.

Parse a single uppercase letter as the letter key with Shift held, like a physical keyboard, and pass the uppercase keysym (XK_A..XK_Z) to rime in the key path, so that both modes commit the same uppercase character.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

