### PR TITLE
fix: avoid oversized navigation bar inset

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import splitties.dimensions.dp
 import splitties.views.dsl.core.withTheme
+import kotlin.math.max
 
 abstract class BaseInputView(
     val service: TrimeInputMethodService,
@@ -113,13 +114,18 @@ abstract class BaseInputView(
             return 0
         }
         val insets = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
-        var mask = WindowInsetsCompat.Type.navigationBars()
-        if (!ignoreSystemGestureInsets) {
-            mask = mask or WindowInsetsCompat.Type.mandatorySystemGestures() or
-                WindowInsetsCompat.Type.systemGestures()
+        val navBars = WindowInsetsCompat.Type.navigationBars()
+        val gestures = WindowInsetsCompat.Type.systemGestures() or
+            WindowInsetsCompat.Type.mandatorySystemGestures()
+        return if (ignoreSystemGestureInsets) {
+            // check gestures insets and ignore them when it greater than zero
+            val gesturesBottom = insets.getInsets(gestures).bottom
+            val navBarsBottom = insets.getInsets(navBars).bottom
+            if (gesturesBottom > 0) 0 else navBarsBottom
+        } else {
+            val insetsBottom = insets.getInsets(navBars or gestures).bottom
+            if (insetsBottom > 0) max(insetsBottom, navBarFrameHeight) else insetsBottom
         }
-        val insetsBottom = insets.getInsets(mask).bottom
-        return if (insetsBottom > 0) insetsBottom else navBarFrameHeight
     }
 
     override fun onAttachedToWindow() {
@@ -137,6 +143,6 @@ abstract class BaseInputView(
     }
 
     companion object {
-        private const val FALLBACK_NAVBAR_HEIGHT = 48
+        private const val FALLBACK_NAVBAR_HEIGHT = 16
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import splitties.dimensions.dp
 import splitties.views.dsl.core.withTheme
-import kotlin.math.max
 
 abstract class BaseInputView(
     val service: TrimeInputMethodService,
@@ -120,7 +119,7 @@ abstract class BaseInputView(
                 WindowInsetsCompat.Type.systemGestures()
         }
         val insetsBottom = insets.getInsets(mask).bottom
-        return if (insetsBottom > 0) max(insetsBottom, navBarFrameHeight) else insetsBottom
+        return if (insetsBottom > 0) insetsBottom else navBarFrameHeight
     }
 
     override fun onAttachedToWindow() {


### PR DESCRIPTION
#### Issue tracker

Fixes #2088

#### Bug fix

Use the bottom inset reported by Android when it is available, and use `navigation_bar_frame_height` only as a fallback when Android reports no inset.

Commit `00e13c51` made the frame height a minimum for every positive inset. On some devices the frame resource is substantially larger than the real navigation or gesture inset. It also made the "Ignore system gesture insets" setting ineffective.

Tested on a Samsung SM-S926B:

- Navigation bar inset: 39 px
- Mandatory gesture inset: 84 px
- `navigation_bar_frame_height`: 126 px
- Current nightly IME height: 703 px
- Patched default IME height: 661 px
- Patched height with "Ignore system gesture insets": 616 px

Before:

<img width="450" alt="before-padding" src="https://github.com/user-attachments/assets/20295073-be97-4331-88ae-37f14ea38fb6" />

After:

<img width="450" alt="after-ignore-gesture" src="https://github.com/user-attachments/assets/bd150a17-ef81-4d53-9c71-22df18cfd128" />


#### Code of conduct

- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style

- [ ] `make style-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass

- [x] `make debug`

#### Manually test

- [x] Done

#### Code Review

1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build

Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

- `make debug` passed for armeabi-v7a, arm64-v8a, x86, and x86_64.
- Kotlin Spotless passed.
- The native half of `make style-lint` reports formatting differences in unchanged JNI headers with local clang-format 22.1.8.
