### PR TITLE
Update runner image to ubuntu-26-04

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -49,6 +49,11 @@ jobs:
         run: |
           sdkmanager --install "cmake;3.31.6"
 
+      - name: Check code style
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          make style-lint
+
       - name: Calculate JNI cache hash
         id: cache-hash
         run: |
@@ -65,11 +70,6 @@ jobs:
         if: ${{ !steps.jni-cache.outputs.cache-hit }}
         run: |
           git submodule update --init --recursive
-        
-      - name: Check code style
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: |
-          make style-lint
 
       - name: Build debug Trime
         run: |

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-24.04
+          - ubuntu-26.04
           - macos-26
           - macos-26-intel
           - windows-2025

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     if: ${{ github.repository == 'osfans/trime' && github.ref == 'refs/heads/develop' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -56,6 +56,11 @@ jobs:
         run: |
           sdkmanager --install "cmake;3.31.6"
 
+      - name: Check code style
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          make style-lint
+
       - name: Calculate JNI cache hash
         id: cache-hash
         run: |
@@ -72,11 +77,6 @@ jobs:
         if: ${{ !steps.jni-cache.outputs.cache-hit }}
         run: |
           git submodule update --init --recursive
-
-      - name: Check code style
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: |
-          make style-lint
 
       - name: Build debug Trime
         run: |

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-24.04
+          - ubuntu-26.04
           - macos-26
           - macos-26-intel
           - windows-2025

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -12,7 +12,7 @@ env:
   CI_NAME: Release CI
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ spotlessApply:
 cmake-format:
 	cmake-format -i app/src/main/jni/cmake/*.cmake app/src/main/jni/CMakeLists.txt
 
+# Currently we are using clang-format version 22.1.8
 clang-format-lint:
 	./script/clang-format.sh -n
 

--- a/app/src/main/jni/librime_jni/jni-utils.h
+++ b/app/src/main/jni/librime_jni/jni-utils.h
@@ -9,7 +9,7 @@
 
 #include <string>
 
-static inline void throwJavaException(JNIEnv *env, const char *msg) {
+static inline void throwJavaException(JNIEnv* env, const char* msg) {
   jclass c = env->FindClass("java/lang/Exception");
   env->ThrowNew(c, msg);
   env->DeleteLocalRef(c);
@@ -17,31 +17,31 @@ static inline void throwJavaException(JNIEnv *env, const char *msg) {
 
 class CString {
  private:
-  JNIEnv *env_;
+  JNIEnv* env_;
   jstring str_;
-  const char *chr_;
+  const char* chr_;
 
  public:
-  CString(JNIEnv *env, jstring str)
+  CString(JNIEnv* env, jstring str)
       : env_(env), str_(str), chr_(env->GetStringUTFChars(str, nullptr)) {}
 
   ~CString() { env_->ReleaseStringUTFChars(str_, chr_); }
 
   operator std::string() { return chr_; }
 
-  operator const char *() { return chr_; }
+  operator const char*() { return chr_; }
 
-  const char *operator*() { return chr_; }
+  const char* operator*() { return chr_; }
 };
 
 template <typename T = jobject>
 class JRef {
  private:
-  JNIEnv *env_;
+  JNIEnv* env_;
   T ref_;
 
  public:
-  JRef(JNIEnv *env, jobject ref) : env_(env), ref_(reinterpret_cast<T>(ref)) {}
+  JRef(JNIEnv* env, jobject ref) : env_(env), ref_(reinterpret_cast<T>(ref)) {}
 
   ~JRef() { env_->DeleteLocalRef(ref_); }
 
@@ -52,14 +52,14 @@ class JRef {
 
 class JString {
  private:
-  JNIEnv *env_;
+  JNIEnv* env_;
   jstring jstring_;
 
  public:
-  JString(JNIEnv *env, const char *chars)
+  JString(JNIEnv* env, const char* chars)
       : env_(env), jstring_(env->NewStringUTF(chars)) {}
 
-  JString(JNIEnv *env, const std::string &string)
+  JString(JNIEnv* env, const std::string& string)
       : JString(env, string.c_str()) {}
 
   ~JString() { env_->DeleteLocalRef(jstring_); }
@@ -71,24 +71,24 @@ class JString {
 
 class JEnv {
  private:
-  JNIEnv *env = nullptr;
+  JNIEnv* env = nullptr;
 
  public:
-  explicit JEnv(JavaVM *jvm) {
-    if (jvm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) ==
+  explicit JEnv(JavaVM* jvm) {
+    if (jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) ==
         JNI_EDETACHED) {
       jvm->AttachCurrentThread(&env, nullptr);
     }
   }
 
-  operator JNIEnv *() { return env; }
+  operator JNIEnv*() { return env; }
 
-  JNIEnv *operator->() { return env; }
+  JNIEnv* operator->() { return env; }
 };
 
 class GlobalRefSingleton {
  public:
-  JavaVM *jvm;
+  JavaVM* jvm;
 
   jclass Object;
 
@@ -133,8 +133,8 @@ class GlobalRefSingleton {
   jclass KeyEvent;
   jmethodID KeyEventInit;
 
-  explicit GlobalRefSingleton(JavaVM *jvm_) : jvm(jvm_) {
-    JNIEnv *env;
+  explicit GlobalRefSingleton(JavaVM* jvm_) : jvm(jvm_) {
+    JNIEnv* env;
     jvm->AttachCurrentThread(&env, nullptr);
 
     Object = reinterpret_cast<jclass>(
@@ -220,4 +220,4 @@ class GlobalRefSingleton {
   [[nodiscard]] JEnv AttachEnv() const { return JEnv(jvm); }
 };
 
-extern GlobalRefSingleton *GlobalRef;
+extern GlobalRefSingleton* GlobalRef;

--- a/app/src/main/jni/librime_jni/key.cc
+++ b/app/src/main/jni/librime_jni/key.cc
@@ -7,7 +7,7 @@
 #include "jni-utils.h"
 
 extern "C" JNIEXPORT jobject JNICALL
-Java_com_osfans_trime_core_RimeKeyEvent_parse(JNIEnv *env, jclass clazz,
+Java_com_osfans_trime_core_RimeKeyEvent_parse(JNIEnv* env, jclass clazz,
                                               jstring repr) {
   rime::KeyEvent ke;
   ke.Parse(*CString(env, repr));
@@ -16,14 +16,14 @@ Java_com_osfans_trime_core_RimeKeyEvent_parse(JNIEnv *env, jclass clazz,
 }
 
 extern "C" JNIEXPORT jint JNICALL
-Java_com_osfans_trime_core_RimeKeyEvent_getModifierByName(JNIEnv *env,
+Java_com_osfans_trime_core_RimeKeyEvent_getModifierByName(JNIEnv* env,
                                                           jclass /* thiz */,
                                                           jstring name) {
   return RimeGetModifierByName(CString(env, name));
 }
 
 extern "C" JNIEXPORT jint JNICALL
-Java_com_osfans_trime_core_RimeKeyEvent_getKeycodeByName(JNIEnv *env,
+Java_com_osfans_trime_core_RimeKeyEvent_getKeycodeByName(JNIEnv* env,
                                                          jclass /* thiz */,
                                                          jstring name) {
   return RimeGetKeycodeByName(CString(env, name));

--- a/app/src/main/jni/librime_jni/levers.cc
+++ b/app/src/main/jni/librime_jni/levers.cc
@@ -7,8 +7,8 @@
 #include "jni-utils.h"
 #include "objconv.h"
 
-static RimeLeversApi *rime_get_levers_api() {
-  return (RimeLeversApi *)rime_get_api()->find_module("levers")->get_api();
+static RimeLeversApi* rime_get_levers_api() {
+  return (RimeLeversApi*)rime_get_api()->find_module("levers")->get_api();
 }
 
 class SwitcherSettings {
@@ -16,11 +16,11 @@ class SwitcherSettings {
   SwitcherSettings()
       : levers(rime_get_levers_api()),
         switcher(rime_get_levers_api()->switcher_settings_init()) {
-    levers->load_settings((RimeCustomSettings *)switcher);
+    levers->load_settings((RimeCustomSettings*)switcher);
   }
   ~SwitcherSettings() {
     if (switcher)
-      levers->custom_settings_destroy((RimeCustomSettings *)switcher);
+      levers->custom_settings_destroy((RimeCustomSettings*)switcher);
   }
 
   std::vector<SchemaItem> availableSchemas() {
@@ -43,17 +43,17 @@ class SwitcherSettings {
     return std::move(result);
   }
 
-  bool selectSchemas(const std::vector<std::string> &schemas) {
+  bool selectSchemas(const std::vector<std::string>& schemas) {
     auto length = schemas.size();
-    const char **input = new const char *[length];
+    const char** input = new const char*[length];
     int i = 0;
-    for (const auto &id : schemas) {
+    for (const auto& id : schemas) {
       input[i++] = id.c_str();
     }
     bool result =
         levers->select_schemas(switcher, input, static_cast<int>(length));
     if (result) {
-      levers->save_settings((RimeCustomSettings *)switcher);
+      levers->save_settings((RimeCustomSettings*)switcher);
     }
     delete[] input;
     return result;
@@ -90,26 +90,26 @@ class SwitcherSettings {
   }
 
  private:
-  RimeLeversApi *levers;
-  RimeSwitcherSettings *switcher;
+  RimeLeversApi* levers;
+  RimeSwitcherSettings* switcher;
 };
 
 extern "C" JNIEXPORT jobjectArray JNICALL
-Java_com_osfans_trime_core_Rime_getAvailableRimeSchemaList(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_getAvailableRimeSchemaList(JNIEnv* env,
                                                            jclass /* thiz */) {
   SwitcherSettings switcher;
   return rimeSchemaListToJObjectArray(env, switcher.availableSchemas());
 }
 
 extern "C" JNIEXPORT jobjectArray JNICALL
-Java_com_osfans_trime_core_Rime_getSelectedRimeSchemaList(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_getSelectedRimeSchemaList(JNIEnv* env,
                                                           jclass /* thiz */) {
   SwitcherSettings switcher;
   return rimeSchemaListToJObjectArray(env, switcher.selectedSchemas());
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_selectRimeSchemas(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_selectRimeSchemas(JNIEnv* env,
                                                   jclass /* thiz */,
                                                   jobjectArray array) {
   SwitcherSettings switcher;
@@ -118,28 +118,28 @@ Java_com_osfans_trime_core_Rime_selectRimeSchemas(JNIEnv *env,
 
 extern "C" JNIEXPORT jobjectArray JNICALL
 Java_com_osfans_trime_data_userdict_UserDictManager_getUserDictList(
-    JNIEnv *env, jclass clazz) {
+    JNIEnv* env, jclass clazz) {
   SwitcherSettings switcher;
   return stringVectorToJStringArray(env, switcher.userDictList());
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_osfans_trime_data_userdict_UserDictManager_backupUserDict(
-    JNIEnv *env, jclass clazz, jstring dict_name) {
+    JNIEnv* env, jclass clazz, jstring dict_name) {
   SwitcherSettings switcher;
   return switcher.backupUserDict(*CString(env, dict_name));
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_osfans_trime_data_userdict_UserDictManager_restoreUserDict(
-    JNIEnv *env, jclass clazz, jstring snapshot_file) {
+    JNIEnv* env, jclass clazz, jstring snapshot_file) {
   SwitcherSettings switcher;
   return switcher.restoreUserDict(*CString(env, snapshot_file));
 }
 
 extern "C" JNIEXPORT jint JNICALL
 Java_com_osfans_trime_data_userdict_UserDictManager_exportUserDict(
-    JNIEnv *env, jclass clazz, jstring dict_name, jstring text_file) {
+    JNIEnv* env, jclass clazz, jstring dict_name, jstring text_file) {
   SwitcherSettings switcher;
   return switcher.exportUserDict(*CString(env, dict_name),
                                  *CString(env, text_file));
@@ -147,7 +147,7 @@ Java_com_osfans_trime_data_userdict_UserDictManager_exportUserDict(
 
 extern "C" JNIEXPORT jint JNICALL
 Java_com_osfans_trime_data_userdict_UserDictManager_importUserDict(
-    JNIEnv *env, jclass clazz, jstring dict_name, jstring text_file) {
+    JNIEnv* env, jclass clazz, jstring dict_name, jstring text_file) {
   SwitcherSettings switcher;
   return switcher.importUserDict(*CString(env, dict_name),
                                  *CString(env, text_file));

--- a/app/src/main/jni/librime_jni/opencc.cc
+++ b/app/src/main/jni/librime_jni/opencc.cc
@@ -14,11 +14,11 @@
 
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_osfans_trime_data_opencc_OpenCCDictManager_openCCLineConv(
-    JNIEnv *env, jclass clazz, jstring input, jstring config_file_name) {
+    JNIEnv* env, jclass clazz, jstring input, jstring config_file_name) {
   try {
     opencc::SimpleConverter converter(CString(env, config_file_name));
     return env->NewStringUTF(converter.Convert(*CString(env, input)).data());
-  } catch (const opencc::Exception &e) {
+  } catch (const opencc::Exception& e) {
     throwJavaException(env, e.what());
     return env->NewStringUTF("");
   }
@@ -26,7 +26,7 @@ Java_com_osfans_trime_data_opencc_OpenCCDictManager_openCCLineConv(
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_osfans_trime_data_opencc_OpenCCDictManager_openCCDictConv(
-    JNIEnv *env, jclass clazz, jstring src, jstring dest, jboolean mode) {
+    JNIEnv* env, jclass clazz, jstring src, jstring dest, jboolean mode) {
   auto src_file = CString(env, src);
   auto dest_file = CString(env, dest);
   try {
@@ -35,7 +35,7 @@ Java_com_osfans_trime_data_opencc_OpenCCDictManager_openCCDictConv(
     } else {
       opencc::ConvertDictionary(src_file, dest_file, "text", "ocd2");
     }
-  } catch (const opencc::Exception &e) {
+  } catch (const opencc::Exception& e) {
     throwJavaException(env, e.what());
   }
 }

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -28,20 +28,20 @@ static void declare_librime_module_dependencies() {
 class Rime {
  public:
   Rime() : rime(rime_get_api()) {}
-  Rime(Rime const &) = delete;
-  void operator=(Rime const &) = delete;
+  Rime(Rime const&) = delete;
+  void operator=(Rime const&) = delete;
 
-  static Rime &Instance() {
+  static Rime& Instance() {
     static Rime instance;
     return instance;
   }
 
   void startup(bool fullCheck,
-               const RimeNotificationHandler &notificationHandler) {
+               const RimeNotificationHandler& notificationHandler) {
     if (!rime) return;
-    const char *userDir = getenv("RIME_USER_DATA_DIR");
-    const char *sharedDir = getenv("RIME_SHARED_DATA_DIR");
-    const char *versionName = getenv("RIME_DISTRIBUTION_VERSION");
+    const char* userDir = getenv("RIME_USER_DATA_DIR");
+    const char* sharedDir = getenv("RIME_SHARED_DATA_DIR");
+    const char* versionName = getenv("RIME_DISTRIBUTION_VERSION");
 
     RIME_STRUCT(RimeTraits, trime_traits)
     trime_traits.shared_data_dir = sharedDir;
@@ -71,7 +71,7 @@ class Rime {
     return rime->process_key(session(), keycode, mask);
   }
 
-  bool simulateKeySequence(const std::string &sequence) {
+  bool simulateKeySequence(const std::string& sequence) {
     return rime->simulate_key_sequence(session(), sequence.data());
   }
 
@@ -209,7 +209,7 @@ class Rime {
   }
 
  private:
-  RimeApi *rime;
+  RimeApi* rime;
   std::shared_ptr<SessionHolder> session_;
 
   RimeSessionId session(bool requestNewSession = true) {
@@ -228,16 +228,16 @@ class Rime {
   }
 };
 
-GlobalRefSingleton *GlobalRef;
+GlobalRefSingleton* GlobalRef;
 
-JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* jvm, void* reserved) {
   GlobalRef = new GlobalRefSingleton(jvm);
   declare_librime_module_dependencies();
   return JNI_VERSION_1_6;
 }
 
 extern "C" JNIEXPORT void JNICALL Java_com_osfans_trime_core_Rime_startupRime(
-    JNIEnv *env, jclass clazz, jstring shared_dir, jstring user_dir,
+    JNIEnv* env, jclass clazz, jstring shared_dir, jstring user_dir,
     jstring version_name, jboolean full_check) {
   // for rime shared data dir
   setenv("RIME_SHARED_DATA_DIR", CString(env, shared_dir), 1);
@@ -245,9 +245,9 @@ extern "C" JNIEXPORT void JNICALL Java_com_osfans_trime_core_Rime_startupRime(
   setenv("RIME_USER_DATA_DIR", CString(env, user_dir), 1);
   setenv("RIME_DISTRIBUTION_VERSION", CString(env, version_name), 1);
 
-  auto notificationHandler = [](void *context_object, RimeSessionId session_id,
-                                const char *message_type,
-                                const char *message_value) {
+  auto notificationHandler = [](void* context_object, RimeSessionId session_id,
+                                const char* message_type,
+                                const char* message_value) {
     auto env = GlobalRef->AttachEnv();
     int type = 0;  // unknown
     if (strcmp(message_type, "schema") == 0) {
@@ -268,20 +268,20 @@ extern "C" JNIEXPORT void JNICALL Java_com_osfans_trime_core_Rime_startupRime(
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_osfans_trime_core_Rime_exitRime(JNIEnv *env, jclass /* thiz */) {
+Java_com_osfans_trime_core_Rime_exitRime(JNIEnv* env, jclass /* thiz */) {
   Rime::Instance().exit();
 }
 
 // deployment
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_deployRimeSchemaFile(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_deployRimeSchemaFile(JNIEnv* env,
                                                      jclass /* thiz */,
                                                      jstring schema_file) {
   return Rime::Instance().deploySchema(*CString(env, schema_file));
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_deployRimeConfigFile(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_deployRimeConfigFile(JNIEnv* env,
                                                      jclass /* thiz */,
                                                      jstring file_name,
                                                      jstring version_key) {
@@ -290,107 +290,107 @@ Java_com_osfans_trime_core_Rime_deployRimeConfigFile(JNIEnv *env,
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_syncRimeUserData(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_syncRimeUserData(JNIEnv* env,
                                                  jclass /* thiz */) {
   return Rime::Instance().sync();
 }
 
 // input
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_processRimeKey(JNIEnv *env, jclass /* thiz */,
+Java_com_osfans_trime_core_Rime_processRimeKey(JNIEnv* env, jclass /* thiz */,
                                                jint keycode, jint mask) {
   return Rime::Instance().processKey(keycode, mask);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_commitRimeComposition(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_commitRimeComposition(JNIEnv* env,
                                                       jclass /* thiz */) {
   return Rime::Instance().commitComposition();
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_osfans_trime_core_Rime_clearRimeComposition(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_clearRimeComposition(JNIEnv* env,
                                                      jclass /* thiz */) {
   Rime::Instance().clearComposition();
 }
 
 // output
 extern "C" JNIEXPORT jobject JNICALL
-Java_com_osfans_trime_core_Rime_getRimeCommit(JNIEnv *env, jclass /* thiz */) {
+Java_com_osfans_trime_core_Rime_getRimeCommit(JNIEnv* env, jclass /* thiz */) {
   auto commit = Rime::Instance().commit();
   return rimeCommitToJObject(env, *commit);
 }
 
 extern "C" JNIEXPORT jobject JNICALL
-Java_com_osfans_trime_core_Rime_getRimeContext(JNIEnv *env, jclass /* thiz */) {
+Java_com_osfans_trime_core_Rime_getRimeContext(JNIEnv* env, jclass /* thiz */) {
   auto context = Rime::Instance().context();
   return rimeContextToJObject(env, *context);
 }
 
 extern "C" JNIEXPORT jobject JNICALL
-Java_com_osfans_trime_core_Rime_getRimeStatus(JNIEnv *env, jclass /* thiz */) {
+Java_com_osfans_trime_core_Rime_getRimeStatus(JNIEnv* env, jclass /* thiz */) {
   auto status = Rime::Instance().status();
   return rimeStatusToJObject(env, *status);
 }
 
 // runtime options
 extern "C" JNIEXPORT void JNICALL Java_com_osfans_trime_core_Rime_setRimeOption(
-    JNIEnv *env, jclass /* thiz */, jstring option, jboolean value) {
+    JNIEnv* env, jclass /* thiz */, jstring option, jboolean value) {
   Rime::Instance().setOption(*CString(env, option), value);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_getRimeOption(JNIEnv *env, jclass /* thiz */,
+Java_com_osfans_trime_core_Rime_getRimeOption(JNIEnv* env, jclass /* thiz */,
                                               jstring option) {
   return Rime::Instance().getOption(*CString(env, option));
 }
 
 extern "C" JNIEXPORT jobjectArray JNICALL
-Java_com_osfans_trime_core_Rime_getRimeSchemaList(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_getRimeSchemaList(JNIEnv* env,
                                                   jclass /* thiz */) {
   return rimeSchemaListToJObjectArray(env, Rime::Instance().schemaList());
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_com_osfans_trime_core_Rime_getCurrentRimeSchema(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_getCurrentRimeSchema(JNIEnv* env,
                                                      jclass /* thiz */) {
   return env->NewStringUTF(Rime::Instance().currentSchemaId().c_str());
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_selectRimeSchema(JNIEnv *env, jclass /* thiz */,
+Java_com_osfans_trime_core_Rime_selectRimeSchema(JNIEnv* env, jclass /* thiz */,
                                                  jstring schema_id) {
   return Rime::Instance().selectSchema(*CString(env, schema_id));
 }
 
 // testing
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_simulateRimeKeySequence(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_simulateRimeKeySequence(JNIEnv* env,
                                                         jclass /* thiz */,
                                                         jstring key_sequence) {
   return Rime::Instance().simulateKeySequence(CString(env, key_sequence));
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_com_osfans_trime_core_Rime_getRimeRawInput(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_getRimeRawInput(JNIEnv* env,
                                                 jclass /* thiz */) {
   return env->NewStringUTF(Rime::Instance().rawInput().data());
 }
 
 extern "C" JNIEXPORT jint JNICALL
-Java_com_osfans_trime_core_Rime_getRimeCaretPos(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_getRimeCaretPos(JNIEnv* env,
                                                 jclass /* thiz */) {
   return static_cast<jint>(Rime::Instance().caretPosition());
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_osfans_trime_core_Rime_setRimeCaretPos(JNIEnv *env, jclass /* thiz */,
+Java_com_osfans_trime_core_Rime_setRimeCaretPos(JNIEnv* env, jclass /* thiz */,
                                                 jint caret_pos) {
   Rime::Instance().setCaretPosition(caret_pos);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_selectRimeCandidate(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_selectRimeCandidate(JNIEnv* env,
                                                     jclass /* thiz */,
                                                     jint index,
                                                     jboolean global) {
@@ -398,7 +398,7 @@ Java_com_osfans_trime_core_Rime_selectRimeCandidate(JNIEnv *env,
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_deleteRimeCandidate(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_deleteRimeCandidate(JNIEnv* env,
                                                     jclass /* thiz */,
                                                     jint index,
                                                     jboolean global) {
@@ -406,14 +406,14 @@ Java_com_osfans_trime_core_Rime_deleteRimeCandidate(JNIEnv *env,
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_osfans_trime_core_Rime_changeRimeCandidatePage(JNIEnv *env,
+Java_com_osfans_trime_core_Rime_changeRimeCandidatePage(JNIEnv* env,
                                                         jclass clazz,
                                                         jboolean backward) {
   return Rime::Instance().changePage(backward);
 }
 
 extern "C" JNIEXPORT jobjectArray JNICALL
-Java_com_osfans_trime_core_Rime_getRimeCandidates(JNIEnv *env, jclass clazz,
+Java_com_osfans_trime_core_Rime_getRimeCandidates(JNIEnv* env, jclass clazz,
                                                   jint start_index,
                                                   jint limit) {
   return rimeCandidateListToJObjectArray(
@@ -421,7 +421,7 @@ Java_com_osfans_trime_core_Rime_getRimeCandidates(JNIEnv *env, jclass clazz,
 }
 
 extern "C" JNIEXPORT jobject JNICALL
-Java_com_osfans_trime_core_Rime_getRimeResponse(JNIEnv *env, jclass clazz,
+Java_com_osfans_trime_core_Rime_getRimeResponse(JNIEnv* env, jclass clazz,
                                                 jboolean paging_mode) {
   auto commit = Rime::Instance().commit();
   // the menu is only needed in paging mode, otherwise its candidates would be
@@ -437,7 +437,7 @@ Java_com_osfans_trime_core_Rime_getRimeResponse(JNIEnv *env, jclass clazz,
   if (paging_mode) {
     // the candidate layout is queried right where the page is built, so the
     // consumer does not need a separate rime option round-trip per key
-    auto &rime = Rime::Instance();
+    auto& rime = Rime::Instance();
     bool is_horizontal_layout =
         rime.getOption("_linear") || rime.getOption("_horizontal");
     jCandidates =

--- a/app/src/main/jni/librime_jni/session.h
+++ b/app/src/main/jni/librime_jni/session.h
@@ -7,7 +7,7 @@
 class SessionHolder {
  public:
   SessionHolder() {
-    auto *api = rime_get_api();
+    auto* api = rime_get_api();
     id_ = api->create_session();
 
     if (!id_) {
@@ -15,7 +15,7 @@ class SessionHolder {
     }
   }
 
-  SessionHolder(SessionHolder &&) = delete;
+  SessionHolder(SessionHolder&&) = delete;
 
   ~SessionHolder() {
     if (id_) {

--- a/script/clang-format.sh
+++ b/script/clang-format.sh
@@ -7,6 +7,9 @@
 # clang format options
 method="-i"
 
+# echo clang-format version for developer
+clang-format --version
+
 while getopts "in" option; do
 	case "${option}" in
 	i) # format code


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

We should adopt the new clang-format(21) in Ubuntu 26.04 in https://github.com/actions/runner-images/issues/14226

**Default Clang 14 is obsoleted in Ubuntu 24.04.**

Software difference between Ubuntu 24 and Ubuntu 26

| Tool name | Ubuntu 24.04 | Ubuntu 26.04 | Notes |
|-----------|--------------|--------------|-------|
| Clang | <ul><li>13.* </li><li>14.* (default)</li><li>15.* </li></ul> | <ul><li>20.* </li><li>21.*  (default)</li><li>22.* </li></ul> | The most recent versions are installed |
| GCC / GNU C++ / GNU Fortran | <ul><li>12.* </li><li>13.* </li><li>14.* </li></ul> | <ul><li>13.* </li><li>14.* </li><li>15.* </li></ul> | The most recent versions are installed |

- **ci: upgrade runner image to ubuntu-26.04**
- **chore: format with clang-format**
- **chore: echo clang-format version**
- **ci: move up code style lint step**

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

