### PR TITLE
feat: import the external tree before user-data sync

### DIFF
--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -147,6 +147,16 @@ class Rime :
     }
 
     override suspend fun syncUserData(): Boolean = RimeMaintenanceMutex.withLock {
+        // Keep the local user data dir a fresh copy of the external tree before
+        // syncing. The first sync also migrates the user databases (imported
+        // once, never synced afterwards, see UserDbMigration); every subsequent
+        // sync imports incrementally (SyncIndex) before the rime maintenance
+        // runs. The import progress notification is suppressed so syncing does
+        // not show a deploy notification.
+        if (RimeDataSync.usesExternalSync() && RimeDataSync.hasExternalAccess(appContext)) {
+            RimeDataSync.importToLocal(appContext, showProgress = false)
+                .onFailure { Timber.e(it, "Failed to import before user-data sync") }
+        }
         // RimeSyncUserData schedules maintenance asynchronously and returns once the
         // worker is started. Wait for DeployMessage so callers (e.g. export) only
         // proceed after sync/<installation_id>/ has been written.

--- a/app/src/main/java/com/osfans/trime/data/sync/RimeDataSync.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/RimeDataSync.kt
@@ -111,11 +111,12 @@ object RimeDataSync {
     suspend fun importToLocal(
         context: Context = appContext,
         keepNotificationUntilDeploySuccess: Boolean = false,
+        showProgress: Boolean = true,
     ): Result<SyncStats> {
         if (!usesExternalSync(context)) {
             return Result.success(SyncStats())
         }
-        DeployNotification.showProgress()
+        if (showProgress) DeployNotification.showProgress()
         return withContext(Dispatchers.IO) {
             runCatching {
                 val treeUri = treeUri() ?: error("No data path selected")


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #2096

#### Feature
Describe features of this pull request

The first sync also migrates the user databases: they are imported once and never synced afterwards, as rime keeps reading and writing them inside the private user data dir. Every subsequent sync imports incrementally (SyncIndex) before the rime maintenance runs, so the local user data dir stays a fresh copy of the external tree. The import progress notification is now optional so syncing does not show a deploy notification.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

