### PR TITLE
Fix import & export of `sync`

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/sync/OrphanCleaner.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/OrphanCleaner.kt
@@ -18,6 +18,7 @@ object OrphanCleaner {
         root: File,
         externalPaths: Set<String>,
         ownId: String? = null,
+        syncDir: String = SyncPathPolicy.DEFAULT_SYNC_DIR,
     ): Result {
         if (!root.exists()) return Result()
         var deleted = 0
@@ -37,7 +38,7 @@ object OrphanCleaner {
                         return@forEach
                     }
                 when {
-                    file.isFile && SyncPathPolicy.shouldPreserveLocal(relative, ownId) -> Unit
+                    file.isFile && SyncPathPolicy.shouldPreserveLocal(relative, ownId, syncDir) -> Unit
                     file.isFile && relative !in externalPaths -> {
                         val deleteResult = FileUtils.delete(file)
                         if (deleteResult.isSuccess) {

--- a/app/src/main/java/com/osfans/trime/data/sync/OrphanCleaner.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/OrphanCleaner.kt
@@ -4,14 +4,11 @@
 
 package com.osfans.trime.data.sync
 
-import com.osfans.trime.data.base.DataManager
 import com.osfans.trime.util.FileUtils
 import timber.log.Timber
 import java.io.File
 
 object OrphanCleaner {
-    private val preservedFiles = setOf(DataManager.INSTALLATION_FILE_NAME)
-
     data class Result(
         val deleted: Int = 0,
         val failed: Int = 0,
@@ -20,6 +17,7 @@ object OrphanCleaner {
     fun removeLocalOrphans(
         root: File,
         externalPaths: Set<String>,
+        ownId: String? = null,
     ): Result {
         if (!root.exists()) return Result()
         var deleted = 0
@@ -39,7 +37,7 @@ object OrphanCleaner {
                         return@forEach
                     }
                 when {
-                    file.isFile && relative in preservedFiles -> Unit
+                    file.isFile && SyncPathPolicy.shouldPreserveLocal(relative, ownId) -> Unit
                     file.isFile && relative !in externalPaths -> {
                         val deleteResult = FileUtils.delete(file)
                         if (deleteResult.isSuccess) {

--- a/app/src/main/java/com/osfans/trime/data/sync/RimeDataSync.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/RimeDataSync.kt
@@ -284,8 +284,8 @@ object RimeDataSync {
             val userDataDir = DataManager.userDataDir
             val syncDir = SyncPathPolicy.treeRelativeSyncDir(syncDirRaw, userDataDir)
             val exportPrefix =
-                runCatching { SyncPathPolicy.ownSyncPrefix(ownId, syncDir) }.getOrElse {
-                    Timber.w("Export skipped: installation_id unreadable")
+                runCatching { SyncPathPolicy.ownSyncPrefix(ownId, syncDir) }.getOrElse { e ->
+                    Timber.w(e, "Export skipped: invalid installation_id or sync_dir")
                     return@runCatching SyncStats()
                 }
             val srcRoot = SyncPathPolicy.localOwnSyncDir(ownId, syncDirRaw, userDataDir)

--- a/app/src/main/java/com/osfans/trime/data/sync/RimeDataSync.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/RimeDataSync.kt
@@ -126,11 +126,24 @@ object RimeDataSync {
                 val destRoot = DataManager.userDataDir
                 val index = SyncIndex.load()
                 val skipUserDb = !UserDbMigration.shouldImportUserDb()
-                val files = SafTreeWalker.listFiles(cr, treeUri, rootId, skipUserDb = skipUserDb)
+                val ownId = SyncPathPolicy.readOwnInstallationId()
+                val skipPrefix =
+                    ownId?.takeIf { it.isNotEmpty() }?.let {
+                        runCatching { SyncPathPolicy.ownSyncPrefix(it) }.getOrNull()
+                    }
+                val files =
+                    SafTreeWalker.listFiles(
+                        cr,
+                        treeUri,
+                        rootId,
+                        skipUserDb = skipUserDb,
+                        skipPrefix = skipPrefix,
+                    )
                 val externalPaths = files.map { it.relativePath }.toSet()
+                val toCopy = files.filter { SyncPathPolicy.shouldImport(it.relativePath, ownId) }
                 val createdDirs = LocalDirectoryGate()
                 val copyResults =
-                    BoundedCopyPool.mapParallel(files, parallelism) { entry ->
+                    BoundedCopyPool.mapParallel(toCopy, parallelism) { entry ->
                         copySafToLocal(
                             context,
                             treeUri,
@@ -141,7 +154,7 @@ object RimeDataSync {
                             createdDirs,
                         )
                     }
-                val removeResult = OrphanCleaner.removeLocalOrphans(destRoot, externalPaths)
+                val removeResult = OrphanCleaner.removeLocalOrphans(destRoot, externalPaths, ownId)
                 SyncIndex.save(SyncIndex.withCurrentTree(mergeIndexEntries(index.entries, copyResults)))
                 val importStats = mergeStats(copyResults.map { it.result })
                 if (UserDbMigration.shouldImportUserDb() && importStats.failed == 0) {
@@ -173,8 +186,11 @@ object RimeDataSync {
             val rootId = DocumentsContract.getTreeDocumentId(treeUri)
             val srcRoot = DataManager.userDataDir
             val index = SyncIndex.load()
-            val listing = SafTreeWalker.listTree(cr, treeUri, rootId)
-            val cache = SafPathCache(listing, rootId)
+            val cache =
+                SafPathCache(
+                    SafTreeListing(emptyList(), mapOf("" to rootId)),
+                    rootId,
+                )
             val copyResults =
                 DataManager.POST_SCHEMA_DEPLOY_EXPORT_FILES.map { fileName ->
                     val sourceFile = srcRoot.resolve(fileName)
@@ -254,32 +270,55 @@ object RimeDataSync {
             check(hasExternalAccess(context)) { "No access to data path" }
             val cr = context.contentResolver
             val rootId = DocumentsContract.getTreeDocumentId(treeUri)
-            val srcRoot = DataManager.userDataDir.resolve("sync")
-            if (!srcRoot.exists()) {
+            val ownId = SyncPathPolicy.readOwnInstallationId()
+            if (ownId.isNullOrEmpty()) {
+                Timber.w("Export skipped: installation_id unreadable")
+                return@runCatching SyncStats()
+            }
+            val exportPrefix =
+                runCatching { SyncPathPolicy.ownSyncPrefix(ownId) }.getOrElse {
+                    Timber.w("Export skipped: installation_id unreadable")
+                    return@runCatching SyncStats()
+                }
+            val srcRoot = DataManager.userDataDir.resolve(exportPrefix)
+            if (!srcRoot.isDirectory) {
                 return@runCatching SyncStats()
             }
             val index = SyncIndex.load()
             val localFiles = listLocalFiles(srcRoot)
-            val listing = SafTreeWalker.listTree(cr, treeUri, rootId)
+            if (localFiles.isEmpty()) {
+                return@runCatching SyncStats()
+            }
+            val listing = SafTreeWalker.listTree(cr, treeUri, rootId, limitToPrefix = exportPrefix)
             val cache = SafPathCache(listing, rootId)
             val indexData = SyncIndex.withCurrentTree(index.entries)
             val parentDirsToEnsure =
                 localFiles
-                    .filter { file ->
-                        val relativePath = file.relativeTo(srcRoot).path.replace('\\', '/')
-                        SyncIndex.shouldCopy(
-                            relativePath,
-                            file.length(),
-                            file.lastModified(),
-                            indexData,
-                        )
-                    }.map { file ->
-                        file.relativeTo(srcRoot).path.replace('\\', '/').substringBeforeLast('/', "")
+                    .mapNotNull { file ->
+                        val relativePath =
+                            runCatching {
+                                val localRel =
+                                    SyncRelativePath.normalize(
+                                        file.relativeTo(srcRoot).path.replace('\\', '/'),
+                                    )
+                                SyncRelativePath.normalize("$exportPrefix/$localRel")
+                            }.getOrNull() ?: return@mapNotNull null
+                        if (!SyncIndex.shouldCopy(
+                                relativePath,
+                                file.length(),
+                                file.lastModified(),
+                                indexData,
+                            )
+                        ) {
+                            return@mapNotNull null
+                        }
+                        relativePath.substringBeforeLast('/', "")
                     }.distinct()
                     .sortedBy { it.count { c -> c == '/' } }
             for (parentDir in parentDirsToEnsure) {
-                val externalDir = if (parentDir.isEmpty()) "sync" else "sync/$parentDir"
-                cache.ensureDirectory(cr, treeUri, externalDir)
+                if (parentDir.isNotEmpty()) {
+                    cache.ensureDirectory(cr, treeUri, parentDir)
+                }
             }
             val copyResults =
                 BoundedCopyPool.mapParallel(localFiles, parallelism) { file ->
@@ -290,7 +329,7 @@ object RimeDataSync {
                         srcRoot,
                         index.entries,
                         cache,
-                        exportPathPrefix = "sync",
+                        exportPathPrefix = exportPrefix,
                     )
                 }
             SyncIndex.save(SyncIndex.withCurrentTree(mergeIndexEntries(index.entries, copyResults)))

--- a/app/src/main/java/com/osfans/trime/data/sync/RimeDataSync.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/RimeDataSync.kt
@@ -127,9 +127,14 @@ object RimeDataSync {
                 val index = SyncIndex.load()
                 val skipUserDb = !UserDbMigration.shouldImportUserDb()
                 val ownId = SyncPathPolicy.readOwnInstallationId()
+                val syncDir =
+                    SyncPathPolicy.treeRelativeSyncDir(
+                        SyncPathPolicy.readOwnSyncDir(),
+                        destRoot,
+                    )
                 val skipPrefix =
                     ownId?.takeIf { it.isNotEmpty() }?.let {
-                        runCatching { SyncPathPolicy.ownSyncPrefix(it) }.getOrNull()
+                        runCatching { SyncPathPolicy.ownSyncPrefix(it, syncDir) }.getOrNull()
                     }
                 val files =
                     SafTreeWalker.listFiles(
@@ -140,7 +145,7 @@ object RimeDataSync {
                         skipPrefix = skipPrefix,
                     )
                 val externalPaths = files.map { it.relativePath }.toSet()
-                val toCopy = files.filter { SyncPathPolicy.shouldImport(it.relativePath, ownId) }
+                val toCopy = files.filter { SyncPathPolicy.shouldImport(it.relativePath, ownId, syncDir) }
                 val createdDirs = LocalDirectoryGate()
                 val copyResults =
                     BoundedCopyPool.mapParallel(toCopy, parallelism) { entry ->
@@ -154,7 +159,7 @@ object RimeDataSync {
                             createdDirs,
                         )
                     }
-                val removeResult = OrphanCleaner.removeLocalOrphans(destRoot, externalPaths, ownId)
+                val removeResult = OrphanCleaner.removeLocalOrphans(destRoot, externalPaths, ownId, syncDir)
                 SyncIndex.save(SyncIndex.withCurrentTree(mergeIndexEntries(index.entries, copyResults)))
                 val importStats = mergeStats(copyResults.map { it.result })
                 if (UserDbMigration.shouldImportUserDb() && importStats.failed == 0) {
@@ -275,13 +280,17 @@ object RimeDataSync {
                 Timber.w("Export skipped: installation_id unreadable")
                 return@runCatching SyncStats()
             }
+            val syncDirRaw = SyncPathPolicy.readOwnSyncDir()
+            val userDataDir = DataManager.userDataDir
+            val syncDir = SyncPathPolicy.treeRelativeSyncDir(syncDirRaw, userDataDir)
             val exportPrefix =
-                runCatching { SyncPathPolicy.ownSyncPrefix(ownId) }.getOrElse {
+                runCatching { SyncPathPolicy.ownSyncPrefix(ownId, syncDir) }.getOrElse {
                     Timber.w("Export skipped: installation_id unreadable")
                     return@runCatching SyncStats()
                 }
-            val srcRoot = DataManager.userDataDir.resolve(exportPrefix)
+            val srcRoot = SyncPathPolicy.localOwnSyncDir(ownId, syncDirRaw, userDataDir)
             if (!srcRoot.isDirectory) {
+                Timber.w("Export skipped: local sync dir does not exist: ${srcRoot.path}")
                 return@runCatching SyncStats()
             }
             val index = SyncIndex.load()

--- a/app/src/main/java/com/osfans/trime/data/sync/SafTreeWalker.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/SafTreeWalker.kt
@@ -50,18 +50,54 @@ object SafTreeWalker {
         return dirSegments.any { it.contains(SKIP_DIR_SUBSTRING) }
     }
 
+    /**
+     * Whether [relativePath] should be listed. [skipPrefix] drops that path and its
+     * descendants. [limitToPrefix] keeps only ancestors of the prefix, the prefix
+     * itself, and descendants. Applied before enqueue so skipped directories are
+     * never queried.
+     */
+    fun shouldVisit(
+        relativePath: String,
+        skipPrefix: String? = null,
+        limitToPrefix: String? = null,
+    ): Boolean {
+        if (!skipPrefix.isNullOrEmpty() &&
+            (relativePath == skipPrefix || relativePath.startsWith("$skipPrefix/"))
+        ) {
+            return false
+        }
+        if (!limitToPrefix.isNullOrEmpty()) {
+            val selfOrDescendant =
+                relativePath == limitToPrefix || relativePath.startsWith("$limitToPrefix/")
+            val ancestor = limitToPrefix.startsWith("$relativePath/")
+            if (!selfOrDescendant && !ancestor) return false
+        }
+        return true
+    }
+
     fun listFiles(
         contentResolver: ContentResolver,
         treeUri: Uri,
         rootDocumentId: String,
         skipUserDb: Boolean = true,
-    ): List<SafFileEntry> = listTree(contentResolver, treeUri, rootDocumentId, skipUserDb).files
+        skipPrefix: String? = null,
+        limitToPrefix: String? = null,
+    ): List<SafFileEntry> = listTree(
+        contentResolver,
+        treeUri,
+        rootDocumentId,
+        skipUserDb,
+        skipPrefix,
+        limitToPrefix,
+    ).files
 
     fun listTree(
         contentResolver: ContentResolver,
         treeUri: Uri,
         rootDocumentId: String,
         skipUserDb: Boolean = true,
+        skipPrefix: String? = null,
+        limitToPrefix: String? = null,
     ): SafTreeListing {
         val result = mutableListOf<SafFileEntry>()
         val directoryIds = mutableMapOf("" to rootDocumentId)
@@ -92,6 +128,7 @@ object SafTreeWalker {
                         }
                     val isDirectory = DocumentsContract.Document.MIME_TYPE_DIR == mimeType
                     if (shouldSkip(childPath, isDirectory, skipUserDb)) continue
+                    if (!shouldVisit(childPath, skipPrefix, limitToPrefix)) continue
                     if (isDirectory) {
                         directoryIds[childPath] = documentId
                         queue.add(childPath to documentId)

--- a/app/src/main/java/com/osfans/trime/data/sync/SyncPathPolicy.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/SyncPathPolicy.kt
@@ -13,10 +13,14 @@ import java.io.File
 
 /**
  * Copy rules for EXTERNAL_SYNC: never import [DataManager.INSTALLATION_FILE_NAME],
- * import peer `sync/<id>/` folders only, and export this device's `sync/<id>/` only.
+ * import peer `<syncDir>/<id>/` folders only, and export this device's `<syncDir>/<id>/` only.
  */
 object SyncPathPolicy {
+    const val DEFAULT_SYNC_DIR = "sync"
+
     fun readOwnInstallationId(): String? = readInstallationId(localInstallationFile())
+
+    fun readOwnSyncDir(): String = readSyncDir(localInstallationFile())
 
     fun readInstallationId(text: String): String? {
         val node = Yaml.parseToYamlNode(text)
@@ -24,34 +28,89 @@ object SyncPathPolicy {
         return id.takeIf { it.isNotEmpty() }
     }
 
-    fun ownSyncPrefix(ownId: String): String = SyncRelativePath.normalize("sync/$ownId")
+    fun readSyncDir(text: String): String {
+        val node = Yaml.parseToYamlNode(text)
+        val dir = node.mapping?.get("sync_dir")?.string?.trim().orEmpty()
+        return cleanSyncDir(dir)
+    }
+
+    /**
+     * Filesystem directory librime writes dumps into (`sync_dir`, or
+     * `[userDataDir]/sync` when unset). Absolute [syncDir] is used as-is.
+     */
+    fun localSyncRoot(
+        syncDir: String,
+        userDataDir: File,
+    ): File {
+        val cleaned = cleanSyncDir(syncDir)
+        val file = File(cleaned)
+        return if (file.isAbsolute) file else File(userDataDir, cleaned)
+    }
+
+    fun localOwnSyncDir(
+        ownId: String,
+        syncDir: String,
+        userDataDir: File,
+    ): File = File(localSyncRoot(syncDir, userDataDir), ownId)
+
+    /**
+     * Tree-relative parent of installation folders on the mirrored user-data
+     * tree. Absolute [syncDir] under [userDataDir] is relativized; otherwise the
+     * last path segment is used.
+     */
+    fun treeRelativeSyncDir(
+        syncDir: String,
+        userDataDir: File? = null,
+    ): String {
+        val cleaned = cleanSyncDir(syncDir)
+        val file = File(cleaned)
+        if (file.isAbsolute) {
+            if (userDataDir != null) {
+                relativizeIfContained(userDataDir, file)?.let { rel ->
+                    return runCatching { SyncRelativePath.normalize(rel) }.getOrDefault(DEFAULT_SYNC_DIR)
+                }
+            }
+            val name = file.name.ifEmpty { DEFAULT_SYNC_DIR }
+            return runCatching { SyncRelativePath.normalize(name) }.getOrDefault(DEFAULT_SYNC_DIR)
+        }
+        return runCatching { SyncRelativePath.normalize(cleaned) }.getOrDefault(DEFAULT_SYNC_DIR)
+    }
+
+    fun ownSyncPrefix(
+        ownId: String,
+        syncDir: String = DEFAULT_SYNC_DIR,
+        userDataDir: File? = null,
+    ): String = SyncRelativePath.normalize("${treeRelativeSyncDir(syncDir, userDataDir)}/$ownId")
 
     /**
      * @param relativePath path relative to the external / user-data root
      *   (e.g. `installation.yaml`, `sync/peer-id/foo.userdb.txt`)
      * @param ownId this device's installation_id, or null if unknown
+     * @param syncDir tree-relative parent of installation sync folders
      */
     fun shouldImport(
         relativePath: String,
         ownId: String?,
+        syncDir: String = DEFAULT_SYNC_DIR,
     ): Boolean {
         val normalized =
             runCatching { SyncRelativePath.normalize(relativePath) }.getOrElse { return false }
-        return !shouldPreserveLocal(normalized, ownId)
+        return !shouldPreserveLocal(normalized, ownId, syncDir)
     }
 
     /**
      * Whether a local file must survive orphan cleanup. [relativePath] is already
      * normalized. True for [DataManager.INSTALLATION_FILE_NAME] and this device's
-     * `sync/<ownId>/` tree when [ownId] is known.
+     * `<syncDir>/<ownId>/` tree when [ownId] is known.
      */
     fun shouldPreserveLocal(
         relativePath: String,
         ownId: String?,
+        syncDir: String = DEFAULT_SYNC_DIR,
     ): Boolean {
         if (relativePath == DataManager.INSTALLATION_FILE_NAME) return true
         if (ownId.isNullOrEmpty()) return false
-        return isOwnSyncPath(relativePath, ownId)
+        return isOwnSyncPath(relativePath, ownId, syncDir)
     }
 
     private fun localInstallationFile(): File = File(DataManager.userDataDir, DataManager.INSTALLATION_FILE_NAME)
@@ -63,11 +122,32 @@ object SyncPathPolicy {
             .getOrNull()
     }
 
+    private fun readSyncDir(file: File): String {
+        if (!file.isFile) return DEFAULT_SYNC_DIR
+        return runCatching { readSyncDir(file.readText()) }
+            .onFailure { Timber.w(it, "Failed to read sync_dir from ${file.path}") }
+            .getOrDefault(DEFAULT_SYNC_DIR)
+    }
+
+    private fun cleanSyncDir(syncDir: String): String {
+        val cleaned = syncDir.trim().replace('\\', '/').trimEnd('/')
+        return cleaned.ifEmpty { DEFAULT_SYNC_DIR }
+    }
+
+    private fun relativizeIfContained(
+        root: File,
+        path: File,
+    ): String? = runCatching {
+        val rel = path.canonicalFile.relativeTo(root.canonicalFile).path.replace('\\', '/')
+        rel.takeIf { it.isNotEmpty() && !it.startsWith("../") && it != ".." }
+    }.getOrNull()
+
     private fun isOwnSyncPath(
         normalizedRelativePath: String,
         ownId: String,
+        syncDir: String,
     ): Boolean {
-        val prefix = runCatching { ownSyncPrefix(ownId) }.getOrElse { return false }
+        val prefix = runCatching { ownSyncPrefix(ownId, syncDir) }.getOrElse { return false }
         return normalizedRelativePath == prefix || normalizedRelativePath.startsWith("$prefix/")
     }
 }

--- a/app/src/main/java/com/osfans/trime/data/sync/SyncPathPolicy.kt
+++ b/app/src/main/java/com/osfans/trime/data/sync/SyncPathPolicy.kt
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2015 - 2026 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.data.sync
+
+import com.osfans.trime.data.base.DataManager
+import com.osfans.trime.util.yaml.Yaml
+import com.osfans.trime.util.yaml.mapping
+import com.osfans.trime.util.yaml.string
+import timber.log.Timber
+import java.io.File
+
+/**
+ * Copy rules for EXTERNAL_SYNC: never import [DataManager.INSTALLATION_FILE_NAME],
+ * import peer `sync/<id>/` folders only, and export this device's `sync/<id>/` only.
+ */
+object SyncPathPolicy {
+    fun readOwnInstallationId(): String? = readInstallationId(localInstallationFile())
+
+    fun readInstallationId(text: String): String? {
+        val node = Yaml.parseToYamlNode(text)
+        val id = node.mapping?.get("installation_id")?.string?.trim().orEmpty()
+        return id.takeIf { it.isNotEmpty() }
+    }
+
+    fun ownSyncPrefix(ownId: String): String = SyncRelativePath.normalize("sync/$ownId")
+
+    /**
+     * @param relativePath path relative to the external / user-data root
+     *   (e.g. `installation.yaml`, `sync/peer-id/foo.userdb.txt`)
+     * @param ownId this device's installation_id, or null if unknown
+     */
+    fun shouldImport(
+        relativePath: String,
+        ownId: String?,
+    ): Boolean {
+        val normalized =
+            runCatching { SyncRelativePath.normalize(relativePath) }.getOrElse { return false }
+        return !shouldPreserveLocal(normalized, ownId)
+    }
+
+    /**
+     * Whether a local file must survive orphan cleanup. [relativePath] is already
+     * normalized. True for [DataManager.INSTALLATION_FILE_NAME] and this device's
+     * `sync/<ownId>/` tree when [ownId] is known.
+     */
+    fun shouldPreserveLocal(
+        relativePath: String,
+        ownId: String?,
+    ): Boolean {
+        if (relativePath == DataManager.INSTALLATION_FILE_NAME) return true
+        if (ownId.isNullOrEmpty()) return false
+        return isOwnSyncPath(relativePath, ownId)
+    }
+
+    private fun localInstallationFile(): File = File(DataManager.userDataDir, DataManager.INSTALLATION_FILE_NAME)
+
+    private fun readInstallationId(file: File): String? {
+        if (!file.isFile) return null
+        return runCatching { readInstallationId(file.readText()) }
+            .onFailure { Timber.w(it, "Failed to read installation_id from ${file.path}") }
+            .getOrNull()
+    }
+
+    private fun isOwnSyncPath(
+        normalizedRelativePath: String,
+        ownId: String,
+    ): Boolean {
+        val prefix = runCatching { ownSyncPrefix(ownId) }.getOrElse { return false }
+        return normalizedRelativePath == prefix || normalizedRelativePath.startsWith("$prefix/")
+    }
+}

--- a/app/src/test/java/com/osfans/trime/data/sync/OrphanCleanerTest.kt
+++ b/app/src/test/java/com/osfans/trime/data/sync/OrphanCleanerTest.kt
@@ -30,4 +30,26 @@ class OrphanCleanerTest :
                 root.deleteRecursively()
             }
         }
+        "preserves own sync dumps even when missing from external listing" {
+            val root = createTempDirectory().toFile()
+            try {
+                val ownDump = File(root, "sync/phone-a/luna.userdb.txt")
+                ownDump.parentFile?.mkdirs()
+                ownDump.writeText("dump")
+                File(root, "orphan.yaml").writeText("orphan")
+
+                val result =
+                    OrphanCleaner.removeLocalOrphans(
+                        root,
+                        externalPaths = emptySet(),
+                        ownId = "phone-a",
+                    )
+
+                ownDump.exists() shouldBe true
+                File(root, "orphan.yaml").exists() shouldBe false
+                result.deleted shouldBe 1
+            } finally {
+                root.deleteRecursively()
+            }
+        }
     })

--- a/app/src/test/java/com/osfans/trime/data/sync/SafTreeWalkerTest.kt
+++ b/app/src/test/java/com/osfans/trime/data/sync/SafTreeWalkerTest.kt
@@ -20,4 +20,26 @@ class SafTreeWalkerTest :
             SafTreeWalker.shouldSkip("foo/luna_pinyin.userdb/user.kct") shouldBe true
             SafTreeWalker.shouldSkip("luna_pinyin.userdb.yaml") shouldBe false
         }
+        "skipPrefix drops that path and descendants but not sibling prefixes" {
+            val skip = "sync/phone-a"
+            SafTreeWalker.shouldVisit("sync/phone-a", skipPrefix = skip) shouldBe false
+            SafTreeWalker.shouldVisit("sync/phone-a/luna.userdb.txt", skipPrefix = skip) shouldBe false
+            SafTreeWalker.shouldVisit("sync/phone-abc/luna.userdb.txt", skipPrefix = skip) shouldBe true
+            SafTreeWalker.shouldVisit("sync/phone-b/luna.userdb.txt", skipPrefix = skip) shouldBe true
+            SafTreeWalker.shouldVisit("default.custom.yaml", skipPrefix = skip) shouldBe true
+        }
+        "limitToPrefix keeps ancestors, the prefix, and descendants" {
+            val limit = "sync/phone-a"
+            SafTreeWalker.shouldVisit("sync", limitToPrefix = limit) shouldBe true
+            SafTreeWalker.shouldVisit("sync/phone-a", limitToPrefix = limit) shouldBe true
+            SafTreeWalker.shouldVisit("sync/phone-a/luna.userdb.txt", limitToPrefix = limit) shouldBe true
+            SafTreeWalker.shouldVisit("sync/phone-b", limitToPrefix = limit) shouldBe false
+            SafTreeWalker.shouldVisit("sync/phone-b/luna.userdb.txt", limitToPrefix = limit) shouldBe false
+            SafTreeWalker.shouldVisit("default.custom.yaml", limitToPrefix = limit) shouldBe false
+        }
+        "blank prefixes do not filter" {
+            SafTreeWalker.shouldVisit("sync/phone-a/foo.txt") shouldBe true
+            SafTreeWalker.shouldVisit("sync/phone-a/foo.txt", skipPrefix = "") shouldBe true
+            SafTreeWalker.shouldVisit("default.custom.yaml", limitToPrefix = "") shouldBe true
+        }
     })

--- a/app/src/test/java/com/osfans/trime/data/sync/SyncPathPolicyTest.kt
+++ b/app/src/test/java/com/osfans/trime/data/sync/SyncPathPolicyTest.kt
@@ -6,6 +6,8 @@ package com.osfans.trime.data.sync
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import java.io.File
+import kotlin.io.path.createTempDirectory
 
 class SyncPathPolicyTest :
     StringSpec({
@@ -24,6 +26,9 @@ class SyncPathPolicyTest :
         }
         "ownSyncPrefix is sync/<id>" {
             SyncPathPolicy.ownSyncPrefix("phone-a") shouldBe "sync/phone-a"
+        }
+        "ownSyncPrefix uses custom syncDir" {
+            SyncPathPolicy.ownSyncPrefix("phone-a", "backups") shouldBe "backups/phone-a"
         }
         "preserve installation.yaml always" {
             SyncPathPolicy.shouldPreserveLocal("installation.yaml", "phone-a") shouldBe true
@@ -44,5 +49,62 @@ class SyncPathPolicyTest :
                 """.trimIndent(),
             ) shouldBe "abc-123"
             SyncPathPolicy.readInstallationId("distribution_code_name: trime") shouldBe null
+        }
+        "readSyncDir uses sync_dir or defaults to sync" {
+            SyncPathPolicy.readSyncDir("sync_dir: backups") shouldBe "backups"
+            SyncPathPolicy.readSyncDir("sync_dir: \"backups\"") shouldBe "backups"
+            SyncPathPolicy.readSyncDir("installation_id: phone-a") shouldBe "sync"
+            SyncPathPolicy.readSyncDir("sync_dir: \"\"") shouldBe "sync"
+            SyncPathPolicy.readSyncDir("sync_dir: \"  \"") shouldBe "sync"
+            SyncPathPolicy.readSyncDir("sync_dir: backups/") shouldBe "backups"
+            SyncPathPolicy.readSyncDir("sync_dir: /sdcard/rime-sync") shouldBe "/sdcard/rime-sync"
+            SyncPathPolicy.readSyncDir("sync_dir: /sdcard/rime-sync/") shouldBe "/sdcard/rime-sync"
+        }
+        "import skips own folder under custom syncDir" {
+            SyncPathPolicy.shouldImport("backups/phone-a/luna.userdb.txt", "phone-a", "backups") shouldBe false
+            SyncPathPolicy.shouldImport("backups/phone-a", "phone-a", "backups") shouldBe false
+            SyncPathPolicy.shouldImport("backups/phone-b/luna.userdb.txt", "phone-a", "backups") shouldBe true
+            SyncPathPolicy.shouldImport("sync/phone-a/luna.userdb.txt", "phone-a", "backups") shouldBe true
+        }
+        "preserve own folder under custom syncDir" {
+            SyncPathPolicy.shouldPreserveLocal("backups/phone-a/luna.userdb.txt", "phone-a", "backups") shouldBe true
+            SyncPathPolicy.shouldPreserveLocal("backups/phone-a", "phone-a", "backups") shouldBe true
+            SyncPathPolicy.shouldPreserveLocal("backups/phone-b/luna.userdb.txt", "phone-a", "backups") shouldBe false
+            SyncPathPolicy.shouldPreserveLocal("sync/phone-a/luna.userdb.txt", "phone-a", "backups") shouldBe false
+        }
+        "localSyncRoot joins relative dirs and keeps absolute dirs" {
+            val userDataDir = createTempDirectory().toFile()
+            try {
+                SyncPathPolicy.localSyncRoot("backups", userDataDir).canonicalFile shouldBe
+                    File(userDataDir, "backups").canonicalFile
+                SyncPathPolicy.localSyncRoot("sync", userDataDir).canonicalFile shouldBe
+                    File(userDataDir, "sync").canonicalFile
+                val absolute = File(userDataDir, "outside-abs").apply { mkdirs() }
+                SyncPathPolicy.localSyncRoot(absolute.path, userDataDir).canonicalFile shouldBe
+                    absolute.canonicalFile
+                SyncPathPolicy.localOwnSyncDir("phone-a", "backups", userDataDir).canonicalFile shouldBe
+                    File(userDataDir, "backups/phone-a").canonicalFile
+            } finally {
+                userDataDir.deleteRecursively()
+            }
+        }
+        "treeRelativeSyncDir relativizes paths under userDataDir" {
+            val userDataDir = createTempDirectory().toFile()
+            try {
+                SyncPathPolicy.treeRelativeSyncDir("backups", userDataDir) shouldBe "backups"
+                val nested = File(userDataDir, "mysync").apply { mkdirs() }
+                SyncPathPolicy.treeRelativeSyncDir(nested.path, userDataDir) shouldBe "mysync"
+                SyncPathPolicy.ownSyncPrefix("phone-a", nested.path, userDataDir) shouldBe "mysync/phone-a"
+                val outside = createTempDirectory().toFile()
+                try {
+                    SyncPathPolicy.treeRelativeSyncDir(outside.path, userDataDir) shouldBe outside.name
+                    SyncPathPolicy.ownSyncPrefix("phone-a", outside.path, userDataDir) shouldBe
+                        "${outside.name}/phone-a"
+                } finally {
+                    outside.deleteRecursively()
+                }
+            } finally {
+                userDataDir.deleteRecursively()
+            }
         }
     })

--- a/app/src/test/java/com/osfans/trime/data/sync/SyncPathPolicyTest.kt
+++ b/app/src/test/java/com/osfans/trime/data/sync/SyncPathPolicyTest.kt
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2015 - 2026 Rime community
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.osfans.trime.data.sync
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SyncPathPolicyTest :
+    StringSpec({
+        "import skips installation.yaml" {
+            SyncPathPolicy.shouldImport("installation.yaml", "phone-a") shouldBe false
+            SyncPathPolicy.shouldImport("installation.yaml", null) shouldBe false
+        }
+        "import skips own sync folder" {
+            SyncPathPolicy.shouldImport("sync/phone-a/luna.userdb.txt", "phone-a") shouldBe false
+            SyncPathPolicy.shouldImport("sync/phone-a", "phone-a") shouldBe false
+        }
+        "import allows peer sync folder and other files" {
+            SyncPathPolicy.shouldImport("sync/phone-b/luna.userdb.txt", "phone-a") shouldBe true
+            SyncPathPolicy.shouldImport("default.custom.yaml", "phone-a") shouldBe true
+            SyncPathPolicy.shouldImport("sync/phone-b/luna.userdb.txt", null) shouldBe true
+        }
+        "ownSyncPrefix is sync/<id>" {
+            SyncPathPolicy.ownSyncPrefix("phone-a") shouldBe "sync/phone-a"
+        }
+        "preserve installation.yaml always" {
+            SyncPathPolicy.shouldPreserveLocal("installation.yaml", "phone-a") shouldBe true
+            SyncPathPolicy.shouldPreserveLocal("installation.yaml", null) shouldBe true
+            SyncPathPolicy.shouldPreserveLocal("default.custom.yaml", "phone-a") shouldBe false
+        }
+        "preserve own sync folder when ownId is known" {
+            SyncPathPolicy.shouldPreserveLocal("sync/phone-a/luna.userdb.txt", "phone-a") shouldBe true
+            SyncPathPolicy.shouldPreserveLocal("sync/phone-a", "phone-a") shouldBe true
+            SyncPathPolicy.shouldPreserveLocal("sync/phone-b/luna.userdb.txt", "phone-a") shouldBe false
+            SyncPathPolicy.shouldPreserveLocal("sync/phone-a/luna.userdb.txt", null) shouldBe false
+        }
+        "readInstallationId parses yaml text" {
+            SyncPathPolicy.readInstallationId(
+                """
+                installation_id: "abc-123"
+                distribution_code_name: trime
+                """.trimIndent(),
+            ) shouldBe "abc-123"
+            SyncPathPolicy.readInstallationId("distribution_code_name: trime") shouldBe null
+        }
+    })


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #2096

#### Feature

- Read `sync_dir` from `installation.yaml`, use `sync` if not found.
- Do not copy `installation.yaml` from external directory
- Importing: Do not import "own-id" under `sync_dir`
- Exporting: Only export `own-id` folder under `sync_dir`

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

